### PR TITLE
Fix agent false-positive on token expiry in auth status

### DIFF
--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -13,6 +13,7 @@ import {
 import type { CallbackSession, ClientConfig, TokenConfig } from "../config/store.js";
 import {
   callLogoutEndpoint,
+  ensureValidToken,
   formatHttpError,
   getStoredAuthSummary,
   login,
@@ -48,7 +49,15 @@ export function formatAuthStatusSummary(input: {
   }
 
   if (input.token?.expiresAt) {
-    lines.push(`Token expires at: ${input.token.expiresAt}`);
+    const expiry = new Date(input.token.expiresAt);
+    const now = new Date();
+    const remainingMs = expiry.getTime() - now.getTime();
+    if (remainingMs > 0) {
+      const remainingMin = Math.ceil(remainingMs / 60_000);
+      lines.push(`Token status: active (expires in ${remainingMin} min, auto-refresh enabled)`);
+    } else {
+      lines.push(`Token status: expired (will auto-refresh on next command)`);
+    }
   }
 
   if (input.callback?.receivedAt) {
@@ -142,6 +151,14 @@ kweaver auth delete <url>    Delete saved credentials`);
     const resolvedTarget = args[1] ? resolvePlatformIdentifier(args[1]) : undefined;
     const statusTarget =
       resolvedTarget && /^https?:\/\//.test(resolvedTarget) ? normalizeBaseUrl(resolvedTarget) : resolvedTarget ?? undefined;
+
+    // Try to refresh token before displaying status, so agent never sees stale expiry
+    try {
+      await ensureValidToken();
+    } catch {
+      // Refresh may fail (no token, network error) — continue to show whatever we have
+    }
+
     const { client, token, callback } = getStoredAuthSummary(statusTarget);
 
     if (!client) {

--- a/skills/kweaver/SKILL.md
+++ b/skills/kweaver/SKILL.md
@@ -72,5 +72,6 @@ kweaver <command> [subcommand] [options]
 
 - **不要自行猜测 business_domain 值**。首次使用时运行 `kweaver config show` 确认当前 business domain。如果返回 `bd_public (default)` 但命令结果为空，可能需要用 `kweaver config set-bd <uuid>` 设置正确的值（从平台 UI 的请求头中获取 `X-Business-Domain`）
 - Action 执行有副作用，执行前向用户确认
+- **禁止运行 `kweaver auth status` 做预检**。直接执行目标命令，CLI 会自动处理认证和 token 刷新
 - Token 1 小时过期，CLI 自动刷新；遇到 401 会自动重试一次，无需手动干预
 - 仅当 refresh token 也失效（自动重试仍报 401）时，才提示用户 `kweaver auth login`


### PR DESCRIPTION
## Summary

- `kweaver auth status` now auto-refreshes token before displaying, so agents never see stale expiry timestamps
- Replaced raw ISO expiry output with agent-friendly status: `active (expires in X min, auto-refresh enabled)` or `expired (will auto-refresh on next command)`
- Added SKILL.md directive forbidding `auth status` as a pre-check

Fixes an issue where agents (especially non-Claude models) would run `auth status`, see a past expiry time, report "token expired" to the user, then successfully execute the actual command which auto-refreshes silently.

## Test plan

- [x] 245 unit tests pass
- [ ] Run `kweaver auth status` — verify output shows `Token status: active (expires in X min, auto-refresh enabled)`
- [ ] Wait for token to expire, run `auth status` — verify it auto-refreshes and shows active status
- [ ] Test with OpenClaw agent: give a kweaver command, verify agent does not falsely report token expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)