### PR TITLE
feat(auth): no-auth mode for CLI and SDK (#54)

### DIFF
--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -42,6 +42,17 @@ for chunk in kweaver.chat("Generate a risk report", stream=True):
     print(chunk.delta, end="", flush=True)
 ```
 
+### No-auth servers
+
+If the platform has no API authentication, use `configure(..., auth=False)` or pass `NoAuth()` to `KWeaverClient`. This matches the TypeScript CLI `kweaver auth <url> --no-auth` token stored in `~/.kweaver/` (`ConfigAuth` then sends no `Authorization` header when the saved token is the `__NO_AUTH__` sentinel).
+
+```python
+from kweaver import KWeaverClient, NoAuth
+
+client = KWeaverClient(base_url="http://localhost:8080", auth=NoAuth())
+# or: kweaver.configure("http://localhost:8080", auth=False)
+```
+
 ### Client API (full control)
 
 ```python

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kweaver-sdk"
-version = "0.5.2"
+version = "0.6.0"
 description = "KWeaver Python SDK — client library for knowledge network construction and querying"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/python/src/kweaver/__init__.py
+++ b/packages/python/src/kweaver/__init__.py
@@ -141,14 +141,20 @@ def configure(
             effective_url = url or os.environ.get("KWEAVER_BASE_URL")
             if not effective_url:
                 raise ValueError("Provide url=, config=True, or set KWEAVER_BASE_URL")
-            auth = TokenAuth(token)
-            _default_client = KWeaverClient(base_url=effective_url, auth=auth, business_domain=effective_domain)
+            auth_provider = TokenAuth(token)
+            _default_client = KWeaverClient(
+                base_url=effective_url, auth=auth_provider, business_domain=effective_domain
+            )
         elif username and password:
             effective_url = url or os.environ.get("KWEAVER_BASE_URL")
             if not effective_url:
                 raise ValueError("Provide url=, config=True, or set KWEAVER_BASE_URL")
-            auth = PasswordAuth(base_url=effective_url, username=username, password=password)
-            _default_client = KWeaverClient(base_url=effective_url, auth=auth, business_domain=effective_domain)
+            auth_provider = PasswordAuth(
+                base_url=effective_url, username=username, password=password
+            )
+            _default_client = KWeaverClient(
+                base_url=effective_url, auth=auth_provider, business_domain=effective_domain
+            )
         elif os.environ.get("KWEAVER_NO_AUTH", "").lower() in ("1", "true", "yes") and not os.environ.get(
             "KWEAVER_TOKEN", ""
         ).strip():

--- a/packages/python/src/kweaver/__init__.py
+++ b/packages/python/src/kweaver/__init__.py
@@ -79,7 +79,8 @@ def configure(
 ) -> None:
     """Initialize the default KWeaver client.
 
-    Auth priority: config > auth=False (NoAuth) > token > username+password.
+    Auth priority: config > auth=False (NoAuth) > token > username+password >
+    KWEAVER_NO_AUTH env (when KWEAVER_TOKEN is unset).
 
     Args:
         url: KWeaver base URL, e.g. "https://kweaver.example.com".
@@ -89,6 +90,8 @@ def configure(
         password: Password for PasswordAuth (requires username).
         auth: If False, use NoAuth (no Authorization headers). Requires ``url`` or
             ``KWEAVER_BASE_URL``. Incompatible with ``token``, ``username``/``password``, and ``config``.
+            Alternatively set env ``KWEAVER_NO_AUTH=1`` (or ``true``/``yes``) with ``url`` or
+            ``KWEAVER_BASE_URL`` when ``KWEAVER_TOKEN`` is not set (matches TS CLI behavior).
         config: If True, use credentials from the local config file (~/.kweaver/).
             When config=True, url is ignored — the base URL comes from the saved
             platform config, preventing accidental cross-environment credential leaks.
@@ -146,8 +149,21 @@ def configure(
                 raise ValueError("Provide url=, config=True, or set KWEAVER_BASE_URL")
             auth = PasswordAuth(base_url=effective_url, username=username, password=password)
             _default_client = KWeaverClient(base_url=effective_url, auth=auth, business_domain=effective_domain)
+        elif os.environ.get("KWEAVER_NO_AUTH", "").lower() in ("1", "true", "yes") and not os.environ.get(
+            "KWEAVER_TOKEN", ""
+        ).strip():
+            effective_url = url or os.environ.get("KWEAVER_BASE_URL")
+            if not effective_url:
+                raise ValueError(
+                    "Provide url= or set KWEAVER_BASE_URL when KWEAVER_NO_AUTH is set"
+                )
+            _default_client = KWeaverClient(
+                base_url=effective_url, auth=NoAuth(), business_domain=effective_domain
+            )
         else:
-            raise ValueError("Provide token=, username+password=, or config=True")
+            raise ValueError(
+                "Provide token=, username+password=, config=True, or KWEAVER_NO_AUTH with url/KWEAVER_BASE_URL"
+            )
         _default_bkn_id = bkn_id
         _default_agent_id = agent_id
 

--- a/packages/python/src/kweaver/__init__.py
+++ b/packages/python/src/kweaver/__init__.py
@@ -6,7 +6,7 @@ import os
 import threading
 from typing import Iterator
 
-from kweaver._auth import ConfigAuth, OAuth2Auth, OAuth2BrowserAuth, PasswordAuth, TokenAuth
+from kweaver._auth import ConfigAuth, NoAuth, OAuth2Auth, OAuth2BrowserAuth, PasswordAuth, TokenAuth
 from kweaver._client import KWeaverClient
 from kweaver._errors import (
     KWeaverError,
@@ -32,6 +32,7 @@ __all__ = [
     "KWeaverClient",
     # Auth
     "TokenAuth",
+    "NoAuth",
     "PasswordAuth",
     "OAuth2Auth",
     "ConfigAuth",
@@ -71,13 +72,14 @@ def configure(
     username: str | None = None,
     password: str | None = None,
     config: bool = False,
+    auth: bool | None = None,
     bkn_id: str | None = None,
     agent_id: str | None = None,
     business_domain: str | None = None,
 ) -> None:
     """Initialize the default KWeaver client.
 
-    Auth priority: config > token > username+password.
+    Auth priority: config > auth=False (NoAuth) > token > username+password.
 
     Args:
         url: KWeaver base URL, e.g. "https://kweaver.example.com".
@@ -85,6 +87,8 @@ def configure(
         token: Bearer token for TokenAuth.
         username: Username for PasswordAuth (requires password).
         password: Password for PasswordAuth (requires username).
+        auth: If False, use NoAuth (no Authorization headers). Requires ``url`` or
+            ``KWEAVER_BASE_URL``. Incompatible with ``token``, ``username``/``password``, and ``config``.
         config: If True, use credentials from the local config file (~/.kweaver/).
             When config=True, url is ignored — the base URL comes from the saved
             platform config, preventing accidental cross-environment credential leaks.
@@ -113,11 +117,23 @@ def configure(
 
         effective_domain = business_domain or os.environ.get("KWEAVER_BUSINESS_DOMAIN")
 
+        if config and auth is False:
+            raise ValueError("Cannot use config=True with auth=False")
+        if auth is False and (token or (username and password)):
+            raise ValueError("Cannot combine auth=False with token= or username/password")
+
         if config:
             # ConfigAuth carries its own base_url from ~/.kweaver/ — do not pass url
             # to avoid sending credentials to the wrong environment.
-            auth = ConfigAuth()
-            _default_client = KWeaverClient(auth=auth, business_domain=effective_domain)
+            auth_provider = ConfigAuth()
+            _default_client = KWeaverClient(auth=auth_provider, business_domain=effective_domain)
+        elif auth is False:
+            effective_url = url or os.environ.get("KWEAVER_BASE_URL")
+            if not effective_url:
+                raise ValueError("Provide url= or set KWEAVER_BASE_URL when auth=False")
+            _default_client = KWeaverClient(
+                base_url=effective_url, auth=NoAuth(), business_domain=effective_domain
+            )
         elif token:
             effective_url = url or os.environ.get("KWEAVER_BASE_URL")
             if not effective_url:

--- a/packages/python/src/kweaver/_auth.py
+++ b/packages/python/src/kweaver/_auth.py
@@ -39,6 +39,16 @@ class AuthProvider(Protocol):
     def auth_headers(self) -> dict[str, str]: ...
 
 
+class NoAuth:
+    """Send no credentials (platforms without API authentication)."""
+
+    def auth_headers(self) -> dict[str, str]:
+        return {}
+
+    def __repr__(self) -> str:
+        return "NoAuth()"
+
+
 class TokenAuth:
     """Static bearer-token authentication."""
 
@@ -220,6 +230,12 @@ class ConfigAuth:
                 raise RuntimeError(
                     f"No token found for {url}. Run 'kweaver auth login' first."
                 )
+
+            from kweaver.config.no_auth import is_no_auth
+
+            access_token = token_data.get("accessToken", "")
+            if is_no_auth(access_token):
+                return {}
 
             # Check expiration
             expires_at = token_data.get("expiresAt")

--- a/packages/python/src/kweaver/config/no_auth.py
+++ b/packages/python/src/kweaver/config/no_auth.py
@@ -1,0 +1,9 @@
+"""No-auth sentinel shared with the TypeScript CLI (~/.kweaver/ token.json)."""
+
+from __future__ import annotations
+
+NO_AUTH_TOKEN = "__NO_AUTH__"
+
+
+def is_no_auth(access_token: str) -> bool:
+    return access_token == NO_AUTH_TOKEN

--- a/packages/python/src/kweaver/config/store.py
+++ b/packages/python/src/kweaver/config/store.py
@@ -471,7 +471,7 @@ class PlatformStore:
         if not os.environ.get("KWEAVER_USER"):
             self.set_active_user(url, uid)
 
-    def save_no_auth_platform(self, url: str) -> dict[str, Any]:
+    def save_no_auth_platform(self, url: str, *, tls_insecure: bool = False) -> dict[str, Any]:
         """Persist a no-auth session (compatible with TS CLI ``saveNoAuthPlatform``)."""
         from datetime import datetime, timezone
 
@@ -485,6 +485,8 @@ class PlatformStore:
             "scope": "",
             "obtainedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         }
+        if tls_insecure:
+            data["tlsInsecure"] = True
         self.save_token(base, data)
         self.use(base)
         return data

--- a/packages/python/src/kweaver/config/store.py
+++ b/packages/python/src/kweaver/config/store.py
@@ -471,6 +471,24 @@ class PlatformStore:
         if not os.environ.get("KWEAVER_USER"):
             self.set_active_user(url, uid)
 
+    def save_no_auth_platform(self, url: str) -> dict[str, Any]:
+        """Persist a no-auth session (compatible with TS CLI ``saveNoAuthPlatform``)."""
+        from datetime import datetime, timezone
+
+        from kweaver.config.no_auth import NO_AUTH_TOKEN
+
+        base = url.rstrip("/")
+        data: dict[str, Any] = {
+            "baseUrl": base,
+            "accessToken": NO_AUTH_TOKEN,
+            "tokenType": "none",
+            "scope": "",
+            "obtainedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        }
+        self.save_token(base, data)
+        self.use(base)
+        return data
+
     # ------------------------------------------------------------------
     # Platform config — businessDomain etc. (user-scoped)
     # ------------------------------------------------------------------

--- a/packages/python/tests/unit/test_auth.py
+++ b/packages/python/tests/unit/test_auth.py
@@ -11,7 +11,18 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from kweaver._auth import ConfigAuth, OAuth2Auth, OAuth2BrowserAuth, PasswordAuth, TokenAuth
+from kweaver._auth import ConfigAuth, NoAuth, OAuth2Auth, OAuth2BrowserAuth, PasswordAuth, TokenAuth
+
+
+# ── NoAuth ───────────────────────────────────────────────────────────────────
+
+
+def test_no_auth_headers_empty():
+    assert NoAuth().auth_headers() == {}
+
+
+def test_no_auth_repr():
+    assert repr(NoAuth()) == "NoAuth()"
 
 
 # ── TokenAuth ────────────────────────────────────────────────────────────────

--- a/packages/python/tests/unit/test_config_auth.py
+++ b/packages/python/tests/unit/test_config_auth.py
@@ -42,6 +42,16 @@ def test_config_auth_reads_stored_token(tmp_path: Path, monkeypatch):
     assert headers["Authorization"] == "Bearer my_access_token_123"
 
 
+def test_save_no_auth_platform_tls_insecure(tmp_path: Path):
+    url = "https://tls-noauth.dev"
+    store = PlatformStore(root=tmp_path)
+    data = store.save_no_auth_platform(url, tls_insecure=True)
+    assert data.get("tlsInsecure") is True
+    tok = store.load_token(url)
+    assert tok is not None
+    assert tok.get("tlsInsecure") is True
+
+
 def test_config_auth_no_auth_returns_empty_headers(tmp_path: Path):
     """Stored __NO_AUTH__ token must not send Authorization (matches TS CLI)."""
     url = "https://local.dev"

--- a/packages/python/tests/unit/test_config_auth.py
+++ b/packages/python/tests/unit/test_config_auth.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from kweaver._auth import ConfigAuth
+from kweaver.config.no_auth import NO_AUTH_TOKEN
 from kweaver.config.store import PlatformStore
 
 
@@ -39,6 +40,25 @@ def test_config_auth_reads_stored_token(tmp_path: Path, monkeypatch):
 
     headers = auth.auth_headers()
     assert headers["Authorization"] == "Bearer my_access_token_123"
+
+
+def test_config_auth_no_auth_returns_empty_headers(tmp_path: Path):
+    """Stored __NO_AUTH__ token must not send Authorization (matches TS CLI)."""
+    url = "https://local.dev"
+    store = PlatformStore(root=tmp_path)
+    store.save_no_auth_platform(url)
+
+    import threading
+
+    auth = ConfigAuth.__new__(ConfigAuth)
+    auth._store = store
+    auth._platform = None
+    auth._lock = threading.Lock()
+
+    assert auth.auth_headers() == {}
+    tok = store.load_token(url)
+    assert tok is not None
+    assert tok["accessToken"] == NO_AUTH_TOKEN
 
 
 def test_config_auth_raises_when_no_platform(tmp_path: Path, monkeypatch):

--- a/packages/python/tests/unit/test_http.py
+++ b/packages/python/tests/unit/test_http.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 from kweaver._http import HttpClient
-from kweaver._auth import TokenAuth
+from kweaver._auth import NoAuth, TokenAuth
 from kweaver._errors import NetworkError, ServerError
 
 
@@ -84,6 +84,24 @@ def test_custom_headers_injected():
     client = _make_client(handler)
     client.get("/api/test", headers={"X-Custom": "value"})
     assert captured["headers"].get("x-custom") == "value"
+
+
+def test_no_auth_omits_authorization():
+    """NoAuth provider must not add Authorization header."""
+    captured = {}
+
+    def handler(req):
+        captured["headers"] = dict(req.headers)
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(handler)
+    client = HttpClient(
+        base_url="https://mock",
+        auth=NoAuth(),
+        transport=transport,
+    )
+    client.get("/api/test")
+    assert "authorization" not in {k.lower() for k in captured["headers"]}
 
 
 def test_post_multipart_returns_status_and_bytes():

--- a/packages/python/tests/unit/test_top_level_api.py
+++ b/packages/python/tests/unit/test_top_level_api.py
@@ -71,6 +71,26 @@ class TestConfigure:
         with pytest.raises(ValueError, match="config=True with auth=False"):
             kweaver.configure(config=True, auth=False)
 
+    def test_configure_kweaver_no_auth_env(self, monkeypatch):
+        monkeypatch.setenv("KWEAVER_NO_AUTH", "1")
+        monkeypatch.delenv("KWEAVER_TOKEN", raising=False)
+        kweaver.configure("https://noauth.example.com")
+        assert kweaver._default_client is not None
+
+    def test_configure_kweaver_no_auth_env_requires_url(self, monkeypatch):
+        monkeypatch.setenv("KWEAVER_NO_AUTH", "true")
+        monkeypatch.delenv("KWEAVER_TOKEN", raising=False)
+        monkeypatch.delenv("KWEAVER_BASE_URL", raising=False)
+        with pytest.raises(ValueError, match="KWEAVER_BASE_URL when KWEAVER_NO_AUTH"):
+            kweaver.configure()
+
+    def test_configure_kweaver_no_auth_skipped_when_kweaver_token_set(self, monkeypatch):
+        monkeypatch.setenv("KWEAVER_NO_AUTH", "1")
+        monkeypatch.setenv("KWEAVER_TOKEN", "some-token")
+        monkeypatch.delenv("KWEAVER_BASE_URL", raising=False)
+        with pytest.raises(ValueError):
+            kweaver.configure("https://example.com")
+
     def test_failed_reconfigure_clears_previous_client(self):
         """A failed configure() must not leave the old client active."""
         kweaver.configure("https://example.com", token="tok1", bkn_id="kn-old")

--- a/packages/python/tests/unit/test_top_level_api.py
+++ b/packages/python/tests/unit/test_top_level_api.py
@@ -58,6 +58,19 @@ class TestConfigure:
         with pytest.raises(ValueError, match="Provide token="):
             kweaver.configure("https://example.com")
 
+    def test_configure_auth_false(self):
+        kweaver.configure("https://example.com", auth=False)
+        assert kweaver._default_client is not None
+
+    def test_configure_auth_false_requires_url(self, monkeypatch):
+        monkeypatch.delenv("KWEAVER_BASE_URL", raising=False)
+        with pytest.raises(ValueError, match="KWEAVER_BASE_URL"):
+            kweaver.configure(auth=False)
+
+    def test_configure_auth_false_with_config_raises(self):
+        with pytest.raises(ValueError, match="config=True with auth=False"):
+            kweaver.configure(config=True, auth=False)
+
     def test_failed_reconfigure_clears_previous_client(self):
         """A failed configure() must not leave the old client active."""
         kweaver.configure("https://example.com", token="tok1", bkn_id="kn-old")

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "kweaver-sdk"
-version = "0.5.2"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -142,7 +142,7 @@ const skillMd = await client.skills.fetchContent("skill-id");
 ## CLI Reference
 
 ```
-kweaver auth login <url> [--alias name] [-u user] [-p pass] [--playwright] [--insecure|-k]
+kweaver auth login <url> [--alias name] [--no-auth] [-u user] [-p pass] [--playwright] [--insecure|-k]
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (headless login)
 kweaver auth export [url|alias] [--json]   (export command to run on a headless host)
 kweaver auth status/list/use/delete/logout
@@ -184,6 +184,8 @@ kweaver dataflow logs <dagId> <instanceId> --detail
 
 `kweaver dataflow runs --since` filters one local natural day. If the value cannot be parsed by `new Date(...)`, the CLI falls back to the most recent 20 runs. `kweaver dataflow logs` defaults to summary output; add `--detail` to print indented `input` and `output` payloads.
 
+**No-auth platforms:** If OAuth is not enabled, use `kweaver auth <url> --no-auth` (or run a normal `auth login`; a **404** on `POST /oauth2/clients` switches to no-auth automatically). Credentials are still saved under `~/.kweaver/` and work with `auth use` / `auth list`. Optional: `KWEAVER_NO_AUTH=1` with `KWEAVER_BASE_URL` when no token env is set. SDK: `new KWeaverClient({ baseUrl, auth: false })` or `kweaver.configure({ baseUrl, auth: false })`.
+
 ## Environment Variables
 
 | Variable | Description |
@@ -191,6 +193,7 @@ kweaver dataflow logs <dagId> <instanceId> --detail
 | `KWEAVER_BASE_URL` | KWeaver instance URL |
 | `KWEAVER_BUSINESS_DOMAIN` | Business domain identifier |
 | `KWEAVER_TOKEN` | Access token |
+| `KWEAVER_NO_AUTH` | Set to `1`/`true`/`yes` to use no-auth sentinel when `KWEAVER_TOKEN` is unset (with `KWEAVER_BASE_URL` or active platform) |
 | `KWEAVER_TLS_INSECURE` | Set to `1` or `true` to skip TLS certificate verification for all HTTPS in the process (dev only; prefer `kweaver auth … --insecure` which saves per platform) |
 | `NODE_TLS_REJECT_UNAUTHORIZED` | Node.js built-in TLS switch: set to `0` to skip certificate verification for HTTPS in this process. The `kweaver` CLI sets this when `KWEAVER_TLS_INSECURE` is set or the saved token has insecure TLS (same scope as above; dev only). |
 

--- a/packages/typescript/README.zh.md
+++ b/packages/typescript/README.zh.md
@@ -131,7 +131,7 @@ const skillMd = await client.skills.fetchContent("skill-id");
 ## 命令速查
 
 ```
-kweaver auth login <url> [--alias name] [-u user] [-p pass] [--playwright] [--insecure|-k]
+kweaver auth login <url> [--alias name] [--no-auth] [-u user] [-p pass] [--playwright] [--insecure|-k]
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (无浏览器登录)
 kweaver auth export [url|alias] [--json]   (导出在无浏览器机器上运行的命令)
 kweaver auth status/list/use/delete/logout
@@ -168,6 +168,8 @@ kweaver dataflow logs <dagId> <instanceId> --detail
 
 `kweaver dataflow runs --since` 会按本地自然日过滤；如果参数无法被 `new Date(...)` 解析，CLI 会回退到最近 20 条运行记录。`kweaver dataflow logs` 默认输出摘要；加上 `--detail` 会打印带缩进的 `input` 和 `output` 载荷。
 
+**无 OAuth 的平台：** 使用 `kweaver auth <url> --no-auth`，或照常 `auth login`；若 `POST /oauth2/clients` 返回 **404**，CLI 会提示并自动保存为 no-auth。凭据仍在 `~/.kweaver/`，可用 `auth use` / `auth list` 切换。可选环境变量 `KWEAVER_NO_AUTH=1`（未设置 `KWEAVER_TOKEN` 时）配合 `KWEAVER_BASE_URL`。SDK：`new KWeaverClient({ baseUrl, auth: false })` 或 `kweaver.configure({ baseUrl, auth: false })`。
+
 ## 环境变量
 
 | 变量 | 说明 |
@@ -175,6 +177,7 @@ kweaver dataflow logs <dagId> <instanceId> --detail
 | `KWEAVER_BASE_URL` | KWeaver 实例地址 |
 | `KWEAVER_BUSINESS_DOMAIN` | 业务域标识 |
 | `KWEAVER_TOKEN` | 访问令牌 |
+| `KWEAVER_NO_AUTH` | 设为 `1`/`true`/`yes` 且未设置 `KWEAVER_TOKEN` 时使用 no-auth 占位（需 `KWEAVER_BASE_URL` 或已选平台） |
 | `KWEAVER_TLS_INSECURE` | 设为 `1` 或 `true` 时跳过 TLS 证书校验（仅开发；更推荐 `kweaver auth … --insecure` 以按平台持久化） |
 | `NODE_TLS_REJECT_UNAUTHORIZED` | Node.js 内置 TLS 开关：设为 `0` 时在本进程内跳过 HTTPS 证书校验。`kweaver` 在 `KWEAVER_TLS_INSECURE` 生效或已保存 token 为不安全 TLS 时会设置此项（范围同上；仅开发）。 |
 

--- a/packages/typescript/package-lock.json
+++ b/packages/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kweaver-ai/kweaver-sdk",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kweaver-ai/kweaver-sdk",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@kweaver-ai/bkn": "^0.1.0",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kweaver-ai/kweaver-sdk",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "KWeaver TypeScript SDK — CLI tool and programmatic API for knowledge networks and Decision Agents.",
   "type": "module",
   "main": "./dist/index.js",
@@ -28,6 +28,8 @@
     "start": "node ./dist/cli.js",
     "lint": "tsc --noEmit -p tsconfig.json",
     "test": "node --import tsx --test test/*.test.ts",
+    "test:e2e": "node --import tsx --test test/e2e/*.test.ts",
+    "test:e2e:live": "KWEAVER_BASE_URL=${KWEAVER_BASE_URL:-https://43.129.210.161} KWEAVER_NO_AUTH=1 KWEAVER_TLS_INSECURE=1 node --import tsx --test test/e2e/*.test.ts",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/packages/typescript/src/api/agent-chat.ts
+++ b/packages/typescript/src/api/agent-chat.ts
@@ -1,3 +1,4 @@
+import { isNoAuth } from "../config/no-auth.js";
 import { fetchTextOrThrow, fetchWithRetry, HttpError } from "../utils/http.js";
 import { normalizeDisplayText } from "../utils/display-text.js";
 
@@ -80,16 +81,19 @@ export async function fetchAgentInfo(options: {
 }): Promise<AgentInfo> {
   const { baseUrl, accessToken, agentId, version, businessDomain = "bd_public" } = options;
   const url = buildAgentInfoUrl(baseUrl, agentId, version);
+  const agentHeaders: Record<string, string> = {
+    accept: "application/json, text/plain, */*",
+    "x-business-domain": businessDomain,
+    "x-language": "zh-CN",
+    "x-requested-with": "XMLHttpRequest",
+  };
+  if (!isNoAuth(accessToken)) {
+    agentHeaders.Authorization = `Bearer ${accessToken}`;
+    agentHeaders.token = accessToken;
+  }
   const { body } = await fetchTextOrThrow(url, {
     method: "GET",
-    headers: {
-      accept: "application/json, text/plain, */*",
-      Authorization: `Bearer ${accessToken}`,
-      token: accessToken,
-      "x-business-domain": businessDomain,
-      "x-language": "zh-CN",
-      "x-requested-with": "XMLHttpRequest",
-    },
+    headers: agentHeaders,
   });
 
   const data = JSON.parse(body) as Partial<AgentInfo>;
@@ -400,11 +404,13 @@ export async function sendChatRequest(options: SendChatRequestOptions): Promise<
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     accept: stream ? "text/event-stream" : "application/json",
-    Authorization: `Bearer ${accessToken}`,
     "Accept-Language": "zh-CN",
     "x-Language": "zh-CN",
     "x-business-domain": businessDomain,
   };
+  if (!isNoAuth(accessToken)) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
 
   if (verbose) {
     console.error(`POST ${url}`);
@@ -497,11 +503,13 @@ export async function sendChatRequestStream(
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     accept: "text/event-stream",
-    Authorization: `Bearer ${accessToken}`,
     "Accept-Language": "zh-CN",
     "x-Language": "zh-CN",
     "x-business-domain": businessDomain,
   };
+  if (!isNoAuth(accessToken)) {
+    headers.Authorization = `Bearer ${accessToken}`;
+  }
 
   if (verbose) {
     console.error(`POST ${url}`);

--- a/packages/typescript/src/api/business-domains.ts
+++ b/packages/typescript/src/api/business-domains.ts
@@ -1,3 +1,4 @@
+import { isNoAuth } from "../config/no-auth.js";
 import { HttpError } from "../utils/http.js";
 
 /** One business domain entry from GET /api/business-system/v1/business-domain */
@@ -46,13 +47,16 @@ export async function listBusinessDomains(
   const url = `${base}/api/business-system/v1/business-domain`;
 
   return withTlsInsecure(tlsInsecure, async () => {
+    const headers: Record<string, string> = {
+      accept: "application/json, text/plain, */*",
+    };
+    if (!isNoAuth(accessToken)) {
+      headers.authorization = `Bearer ${accessToken}`;
+      headers.token = accessToken;
+    }
     const response = await fetch(url, {
       method: "GET",
-      headers: {
-        accept: "application/json, text/plain, */*",
-        authorization: `Bearer ${accessToken}`,
-        token: accessToken,
-      },
+      headers,
     });
     const body = await response.text();
     if (!response.ok) {

--- a/packages/typescript/src/api/context-loader.ts
+++ b/packages/typescript/src/api/context-loader.ts
@@ -1,3 +1,4 @@
+import { isNoAuth } from "../config/no-auth.js";
 import { fetchTextOrThrow } from "../utils/http.js";
 
 /** Per-call options for context-loader MCP. */
@@ -20,10 +21,12 @@ function buildHeaders(options: ContextLoaderCallOptions, sessionId?: string): Re
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     Accept: "application/json, text/event-stream",
-    Authorization: `Bearer ${options.accessToken}`,
     "X-Kn-ID": options.knId,
     "MCP-Protocol-Version": MCP_PROTOCOL_VERSION,
   };
+  if (!isNoAuth(options.accessToken)) {
+    headers.Authorization = `Bearer ${options.accessToken}`;
+  }
   if (sessionId) {
     headers["MCP-Session-Id"] = sessionId;
   }

--- a/packages/typescript/src/api/conversations.ts
+++ b/packages/typescript/src/api/conversations.ts
@@ -1,3 +1,5 @@
+import { buildHeaders } from "./headers.js";
+
 export interface ListConversationsOptions {
   baseUrl: string;
   accessToken: string;
@@ -47,9 +49,7 @@ export async function listConversations(opts: ListConversationsOptions): Promise
     method: "GET",
     headers: {
       accept: "application/json",
-      authorization: `Bearer ${accessToken}`,
-      token: accessToken,
-      "x-business-domain": businessDomain,
+      ...buildHeaders(accessToken, businessDomain),
     },
   });
 
@@ -75,9 +75,7 @@ export async function getTracesByConversation(opts: GetTracesOptions): Promise<s
     headers: {
       "Content-Type": "application/json",
       accept: "application/json",
-      authorization: `Bearer ${accessToken}`,
-      token: accessToken,
-      "x-business-domain": businessDomain,
+      ...buildHeaders(accessToken, businessDomain),
     },
     body: JSON.stringify({
       agent_id: agentId,
@@ -108,9 +106,7 @@ export async function listMessages(opts: ListMessagesOptions): Promise<string> {
     method: "GET",
     headers: {
       accept: "application/json",
-      authorization: `Bearer ${accessToken}`,
-      token: accessToken,
-      "x-business-domain": businessDomain,
+      ...buildHeaders(accessToken, businessDomain),
     },
   });
 

--- a/packages/typescript/src/api/headers.ts
+++ b/packages/typescript/src/api/headers.ts
@@ -1,3 +1,5 @@
+import { isNoAuth } from "../config/no-auth.js";
+
 /**
  * Shared HTTP header builder for all KWeaver API calls.
  *
@@ -5,16 +7,20 @@
  * environment variables KWEAVER_ACCOUNT_ID and KWEAVER_ACCOUNT_TYPE.
  * These are required by older platform versions (e.g. dip-poc.aishu.cn)
  * that do not infer account info from the token automatically.
+ *
+ * When accessToken is the no-auth sentinel, `authorization` and `token` are omitted.
  */
 export function buildHeaders(accessToken: string, businessDomain: string): Record<string, string> {
   const headers: Record<string, string> = {
     accept: "application/json, text/plain, */*",
     "accept-language": "zh-cn",
-    authorization: `Bearer ${accessToken}`,
-    token: accessToken,
     "x-business-domain": businessDomain,
     "x-language": "zh-cn",
   };
+  if (!isNoAuth(accessToken)) {
+    headers.authorization = `Bearer ${accessToken}`;
+    headers.token = accessToken;
+  }
 
   const accountId = process.env.KWEAVER_ACCOUNT_ID;
   const accountType = process.env.KWEAVER_ACCOUNT_TYPE;

--- a/packages/typescript/src/api/skills.ts
+++ b/packages/typescript/src/api/skills.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { Buffer } from "node:buffer";
 import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
+import { buildHeaders as buildPlatformHeaders } from "./headers.js";
 import { HttpError, fetchTextOrThrow } from "../utils/http.js";
 
 const SKILL_API_PREFIX = "/api/agent-operator-integration/v1";
@@ -153,18 +154,8 @@ export interface InstallSkillArchiveOptions {
   force?: boolean;
 }
 
-function buildHeaders(accessToken: string, businessDomain: string): Record<string, string> {
-  return {
-    accept: "application/json, text/plain, */*",
-    authorization: `Bearer ${accessToken}`,
-    token: accessToken,
-    "x-business-domain": businessDomain,
-    "x-language": "zh-cn",
-  };
-}
-
 function baseHeaders(opts: SkillApiBaseOptions): Record<string, string> {
-  return buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public");
+  return buildPlatformHeaders(opts.accessToken, opts.businessDomain ?? "bd_public");
 }
 
 function buildUrl(baseUrl: string, path: string): string {

--- a/packages/typescript/src/auth/oauth.ts
+++ b/packages/typescript/src/auth/oauth.ts
@@ -358,7 +358,7 @@ export async function oauth2Login(
       process.stderr.write(
         "OAuth2 endpoint not found (404). Saving platform in no-auth mode.\n",
       );
-      return saveNoAuthPlatform(base);
+      return saveNoAuthPlatform(base, { tlsInsecure: options?.tlsInsecure });
     }
     throw e;
   }
@@ -663,7 +663,7 @@ export async function playwrightLogin(
       process.stderr.write(
         "OAuth2 endpoint not found (404). Saving platform in no-auth mode.\n",
       );
-      return saveNoAuthPlatform(base);
+      return saveNoAuthPlatform(base, { tlsInsecure: options?.tlsInsecure });
     }
     throw e;
   }

--- a/packages/typescript/src/auth/oauth.ts
+++ b/packages/typescript/src/auth/oauth.ts
@@ -1011,6 +1011,20 @@ export async function ensureValidToken(opts?: { forceRefresh?: boolean }): Promi
     };
   }
 
+  if (!opts?.forceRefresh && envToken && !envBaseUrl) {
+    const currentPlatformForEnv = getCurrentPlatform();
+    if (currentPlatformForEnv) {
+      const rawToken = envToken.replace(/^Bearer\s+/i, "");
+      return {
+        baseUrl: normalizeBaseUrl(currentPlatformForEnv),
+        accessToken: rawToken,
+        tokenType: isNoAuth(rawToken) ? "none" : "bearer",
+        scope: "",
+        obtainedAt: new Date().toISOString(),
+      };
+    }
+  }
+
   const currentPlatform = getCurrentPlatform();
   if (!currentPlatform) {
     throw new Error("No active platform selected. Run `kweaver auth login <platform-url>` first.");

--- a/packages/typescript/src/auth/oauth.ts
+++ b/packages/typescript/src/auth/oauth.ts
@@ -1,4 +1,5 @@
 import type { Server } from "node:http";
+import { isNoAuth } from "../config/no-auth.js";
 import {
   type ClientConfig,
   type TokenConfig,
@@ -9,6 +10,7 @@ import {
   loadUserTokenConfig,
   resolveUserId,
   saveClientConfig,
+  saveNoAuthPlatform,
   saveTokenConfig,
   setCurrentPlatform,
 } from "../config/store.js";
@@ -348,7 +350,18 @@ export async function oauth2Login(
   const callbackPathname = parsedRedirect?.pathname ?? "/callback";
 
   // Step 1: Determine client — use provided client ID or fall back to dynamic registration
-  let client = await resolveOrRegisterClient(base, redirectUri, scope, options);
+  let client: ClientConfig;
+  try {
+    client = await resolveOrRegisterClient(base, redirectUri, scope, options);
+  } catch (e) {
+    if (e instanceof HttpError && e.status === 404) {
+      process.stderr.write(
+        "OAuth2 endpoint not found (404). Saving platform in no-auth mode.\n",
+      );
+      return saveNoAuthPlatform(base);
+    }
+    throw e;
+  }
 
   // Use PKCE when no client secret is available (public client / platform client).
   const usePkce = !client.clientSecret;
@@ -642,7 +655,18 @@ export async function playwrightLogin(
   const hasCredentials = !!(options?.username && options?.password);
 
   // Step 1: Ensure registered OAuth2 client (with stale-client auto-recovery)
-  let client = await resolveOrRegisterClient(base, redirectUri, scope);
+  let client: ClientConfig;
+  try {
+    client = await resolveOrRegisterClient(base, redirectUri, scope);
+  } catch (e) {
+    if (e instanceof HttpError && e.status === 404) {
+      process.stderr.write(
+        "OAuth2 endpoint not found (404). Saving platform in no-auth mode.\n",
+      );
+      return saveNoAuthPlatform(base);
+    }
+    throw e;
+  }
 
   // Step 2: Generate CSRF state
   const state = randomBytes(12).toString("hex");
@@ -847,6 +871,9 @@ export async function refreshTokenLogin(
 }
 
 function tokenNeedsRefresh(token: TokenConfig): boolean {
+  if (isNoAuth(token.accessToken)) {
+    return false;
+  }
   if (!token.expiresAt) {
     return false;
   }
@@ -864,6 +891,9 @@ function tokenNeedsRefresh(token: TokenConfig): boolean {
  */
 export async function refreshAccessToken(token: TokenConfig): Promise<TokenConfig> {
   const baseUrl = normalizeBaseUrl(token.baseUrl);
+  if (isNoAuth(token.accessToken)) {
+    throw new Error(`Cannot refresh no-auth session for ${baseUrl}.`);
+  }
   const refreshToken = token.refreshToken?.trim();
   if (!refreshToken) {
     throw new Error(
@@ -975,7 +1005,7 @@ export async function ensureValidToken(opts?: { forceRefresh?: boolean }): Promi
     return {
       baseUrl: normalizeBaseUrl(envBaseUrl),
       accessToken: rawToken,
-      tokenType: "bearer",
+      tokenType: isNoAuth(rawToken) ? "none" : "bearer",
       scope: "",
       obtainedAt: new Date().toISOString(),
     };
@@ -1006,6 +1036,10 @@ export async function ensureValidToken(opts?: { forceRefresh?: boolean }): Promi
     throw new Error(
       `No saved token for ${currentPlatform}. Run \`kweaver auth login ${currentPlatform}\` first.`,
     );
+  }
+
+  if (isNoAuth(token.accessToken)) {
+    return token;
   }
 
   if (opts?.forceRefresh) {
@@ -1053,6 +1087,9 @@ export async function with401RefreshRetry<T>(fn: () => Promise<T>): Promise<T> {
       if (!latest) {
         throw error;
       }
+      if (isNoAuth(latest.accessToken)) {
+        throw error;
+      }
       try {
         await refreshAccessToken(latest);
       } catch (retryErr) {
@@ -1081,6 +1118,9 @@ export async function withTokenRetry<T>(
     return await fn(token);
   } catch (error) {
     if (error instanceof HttpError && error.status === 401) {
+      if (isNoAuth(token.accessToken)) {
+        throw error;
+      }
       const platformUrl = normalizeBaseUrl(token.baseUrl);
       const envUser = process.env.KWEAVER_USER;
       let latest: TokenConfig | null;

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -1,3 +1,4 @@
+import { NO_AUTH_TOKEN } from "./config/no-auth.js";
 import { applyTlsEnvFromSavedTokens } from "./config/tls-env.js";
 import { runAgentCommand } from "./commands/agent.js";
 import { runAuthCommand } from "./commands/auth.js";
@@ -21,7 +22,7 @@ Usage:
   kweaver --version | -V
   kweaver --help | -h
 
-  kweaver auth <platform-url> [--alias name] [-u user] [-p pass] [--playwright] [--insecure|-k]
+  kweaver auth <platform-url> [--alias name] [--no-auth] [-u user] [-p pass] [--playwright] [--insecure|-k]
   kweaver auth login <platform-url>          (alias for auth <url>)
   kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (run on host without browser)
   kweaver auth whoami [platform-url|alias] [--json]
@@ -135,6 +136,14 @@ Commands:
 
 export async function run(argv: string[]): Promise<number> {
   applyTlsEnvFromSavedTokens();
+
+  const noAuthEnv = process.env.KWEAVER_NO_AUTH;
+  if (
+    (noAuthEnv === "1" || noAuthEnv === "true" || noAuthEnv === "yes") &&
+    !process.env.KWEAVER_TOKEN
+  ) {
+    process.env.KWEAVER_TOKEN = NO_AUTH_TOKEN;
+  }
 
   // Global --user flag: override active user for this invocation
   const userIdx = argv.indexOf("--user");

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -266,7 +266,13 @@ export class KWeaverClient implements ClientContext {
             "Access token revoked. Run `kweaver auth login` to re-authenticate."
           );
         }
-      } catch {
+      } catch (e) {
+        if (
+          e instanceof Error &&
+          e.message.startsWith("Access token revoked")
+        ) {
+          throw e;
+        }
         // Network error — return client as-is, let the caller deal with it
       }
     }

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -53,12 +53,16 @@ export interface KWeaverClientOptions {
    * When true, read credentials exclusively from ~/.kweaver/ (saved by
    * `kweaver auth login`), ignoring KWEAVER_BASE_URL / KWEAVER_TOKEN env vars.
    * Useful when env vars hold stale tokens or are intended for other tooling.
+   * Incompatible with `auth: false` — the constructor throws if both are set.
    */
   config?: boolean;
 
   /**
    * When false, use no-auth mode: API requests omit Authorization / token headers.
-   * Requires `baseUrl` (explicit, env, or active platform when `config` is true).
+   * Requires a resolvable base URL: `baseUrl`, `KWEAVER_BASE_URL`, or the active
+   * platform from `kweaver auth login`. Incompatible with `config: true` — use
+   * saved `~/.kweaver/` credentials (including `__NO_AUTH__`) via `config: true`
+   * alone instead of passing `auth: false`.
    */
   auth?: boolean;
 }
@@ -128,17 +132,17 @@ export class KWeaverClient implements ClientContext {
   constructor(opts: KWeaverClientOptions = {}) {
     const envDomain = process.env.KWEAVER_BUSINESS_DOMAIN;
 
+    if (opts.auth === false && opts.config) {
+      throw new Error(
+        "KWeaverClient: auth: false is incompatible with config: true.",
+      );
+    }
+
     let baseUrl: string | undefined;
     let accessToken: string | undefined;
 
     if (opts.auth === false) {
-      if (opts.config) {
-        const platform = getCurrentPlatform();
-        if (!platform) {
-          throw new Error("No active platform. Run `kweaver auth login` first.");
-        }
-        baseUrl = opts.baseUrl ?? platform;
-      } else {
+      {
         const envUrl = process.env.KWEAVER_BASE_URL;
         baseUrl = opts.baseUrl ?? envUrl;
         if (!baseUrl) {

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -1,5 +1,5 @@
 import { applyTlsEnvFromSavedTokens } from "./config/tls-env.js";
-import { NO_AUTH_TOKEN } from "./config/no-auth.js";
+import { NO_AUTH_TOKEN, isNoAuth } from "./config/no-auth.js";
 import {
   getCurrentPlatform,
   loadTokenConfig,
@@ -253,20 +253,22 @@ export class KWeaverClient implements ClientContext {
       ...opts,
     });
 
-    // Quick probe — if the token was revoked server-side, force refresh
-    try {
-      const bd = client.base().businessDomain;
-      const probe = await fetch(
-        `${token.baseUrl.replace(/\/+$/, "")}/api/ontology-manager/v1/knowledge-networks?limit=1`,
-        { headers: buildHeaders(token.accessToken, bd) },
-      );
-      if (probe.status === 401) {
-        throw new Error(
-          "Access token revoked. Run `kweaver auth login` to re-authenticate."
+    if (!isNoAuth(token.accessToken)) {
+      // Quick probe — if the token was revoked server-side, force refresh
+      try {
+        const bd = client.base().businessDomain;
+        const probe = await fetch(
+          `${token.baseUrl.replace(/\/+$/, "")}/api/ontology-manager/v1/knowledge-networks?limit=1`,
+          { headers: buildHeaders(token.accessToken, bd) },
         );
+        if (probe.status === 401) {
+          throw new Error(
+            "Access token revoked. Run `kweaver auth login` to re-authenticate."
+          );
+        }
+      } catch {
+        // Network error — return client as-is, let the caller deal with it
       }
-    } catch {
-      // Network error — return client as-is, let the caller deal with it
     }
     return client;
   }

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -1,8 +1,10 @@
 import { applyTlsEnvFromSavedTokens } from "./config/tls-env.js";
+import { NO_AUTH_TOKEN } from "./config/no-auth.js";
 import {
   getCurrentPlatform,
   loadTokenConfig,
 } from "./config/store.js";
+import { buildHeaders } from "./api/headers.js";
 import { ensureValidToken } from "./auth/oauth.js";
 import { AgentsResource } from "./resources/agents.js";
 import { ConversationsResource } from "./resources/conversations.js";
@@ -53,6 +55,12 @@ export interface KWeaverClientOptions {
    * Useful when env vars hold stale tokens or are intended for other tooling.
    */
   config?: boolean;
+
+  /**
+   * When false, use no-auth mode: API requests omit Authorization / token headers.
+   * Requires `baseUrl` (explicit, env, or active platform when `config` is true).
+   */
+  auth?: boolean;
 }
 
 // ── KWeaverClient ─────────────────────────────────────────────────────────────
@@ -122,6 +130,42 @@ export class KWeaverClient implements ClientContext {
 
     let baseUrl: string | undefined;
     let accessToken: string | undefined;
+
+    if (opts.auth === false) {
+      if (opts.config) {
+        const platform = getCurrentPlatform();
+        if (!platform) {
+          throw new Error("No active platform. Run `kweaver auth login` first.");
+        }
+        baseUrl = opts.baseUrl ?? platform;
+      } else {
+        const envUrl = process.env.KWEAVER_BASE_URL;
+        baseUrl = opts.baseUrl ?? envUrl;
+        if (!baseUrl) {
+          const platform = getCurrentPlatform();
+          if (platform) baseUrl = platform;
+        }
+      }
+      if (!baseUrl) {
+        throw new Error(
+          "KWeaverClient: baseUrl is required when auth is false. " +
+            "Pass it explicitly, set KWEAVER_BASE_URL, or run `kweaver auth login`.",
+        );
+      }
+      this._baseUrl = baseUrl.replace(/\/+$/, "");
+      this._accessToken = NO_AUTH_TOKEN;
+      this._businessDomain = opts.businessDomain ?? envDomain ?? "bd_public";
+      this.knowledgeNetworks = new KnowledgeNetworksResource(this);
+      this.agents = new AgentsResource(this);
+      this.bkn = new BknResource(this);
+      this.conversations = new ConversationsResource(this);
+      this.dataflows = new DataflowsResource(this);
+      this.datasources = new DataSourcesResource(this);
+      this.dataviews = new DataViewsResource(this);
+      this.vega = new VegaResource(this);
+      this.skills = new SkillsResource(this);
+      return;
+    }
 
     if (opts.config) {
       // config: true — read exclusively from ~/.kweaver/, ignore env vars
@@ -207,9 +251,10 @@ export class KWeaverClient implements ClientContext {
 
     // Quick probe — if the token was revoked server-side, force refresh
     try {
+      const bd = client.base().businessDomain;
       const probe = await fetch(
         `${token.baseUrl.replace(/\/+$/, "")}/api/ontology-manager/v1/knowledge-networks?limit=1`,
-        { headers: { authorization: `Bearer ${token.accessToken}`, token: token.accessToken } },
+        { headers: buildHeaders(token.accessToken, bd) },
       );
       if (probe.status === 401) {
         throw new Error(

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -155,7 +155,7 @@ Login options:
       let token;
 
       if (noAuth) {
-        token = saveNoAuthPlatform(normalizedTarget);
+        token = saveNoAuthPlatform(normalizedTarget, { tlsInsecure });
       } else if (refreshToken) {
         if (!clientId || !clientSecret) {
           console.error("--refresh-token requires --client-id and --client-secret.\n");

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -1,3 +1,4 @@
+import { isNoAuth } from "../config/no-auth.js";
 import {
   autoSelectBusinessDomain,
   clearPlatformSession,
@@ -13,8 +14,10 @@ import {
   listUsers,
   loadClientConfig,
   loadTokenConfig,
+  resolveBusinessDomain,
   resolvePlatformIdentifier,
   resolveUserId,
+  saveNoAuthPlatform,
   setActiveUser,
   setCurrentPlatform,
   setPlatformAlias,
@@ -62,14 +65,15 @@ Login options:
   -u, --username         Username (with -p triggers Playwright headless login)
   -p, --password         Password
   --playwright           Force Playwright browser login even without -u/-p
-  --insecure, -k         Skip TLS certificate verification (self-signed / dev HTTPS only)`);
+  --insecure, -k         Skip TLS certificate verification (self-signed / dev HTTPS only)
+  --no-auth              Save platform without OAuth (servers with no authentication). Same as detecting OAuth 404 during login.`);
 
     return 0;
   }
 
   if (target === "login") {
     if (rest[0] === "--help" || rest[0] === "-h") {
-      console.log(`kweaver auth login <platform-url> [--alias <name>] [-u user] [-p pass] [--playwright] [--refresh-token T --client-id ID --client-secret S]`);
+      console.log(`kweaver auth login <platform-url> [--alias <name>] [--no-auth] [-u user] [-p pass] [--playwright] [--refresh-token T --client-id ID --client-secret S]`);
       return 0;
     }
     const url = rest[0];
@@ -113,11 +117,12 @@ Login options:
       const customPortStr = readOption(args, "--port");
       const customPort = customPortStr ? parseInt(customPortStr, 10) : undefined;
       const tlsInsecure = args.includes("--insecure") || args.includes("-k");
+      const noAuth = args.includes("--no-auth");
 
       const KNOWN_LOGIN_FLAGS = new Set([
         "--alias", "--client-id", "--client-secret", "--refresh-token",
         "--port", "--redirect-uri", "--username", "-u", "--password", "-p",
-        "--playwright", "--insecure", "-k",
+        "--playwright", "--insecure", "-k", "--no-auth",
       ]);
       const KNOWN_VALUE_FLAGS = new Set([
         "--alias", "--client-id", "--client-secret", "--refresh-token",
@@ -138,9 +143,20 @@ Login options:
         return 1;
       }
 
+      if (noAuth && refreshToken) {
+        console.error("--no-auth cannot be used with --refresh-token.");
+        return 1;
+      }
+      if (noAuth && (username || password || usePlaywright)) {
+        console.error("--no-auth cannot be used with Playwright login or -u/-p.");
+        return 1;
+      }
+
       let token;
 
-      if (refreshToken) {
+      if (noAuth) {
+        token = saveNoAuthPlatform(normalizedTarget);
+      } else if (refreshToken) {
         if (!clientId || !clientSecret) {
           console.error("--refresh-token requires --client-id and --client-secret.\n");
           console.error("Get these values from the callback page after a browser login or `kweaver auth export`.");
@@ -195,18 +211,24 @@ Login options:
         const userLabel = token.displayName ? `${token.displayName} (${activeUser})` : activeUser;
         console.log(`User: ${userLabel}`);
       }
-      console.log(`Access token saved: yes`);
-      if (token.refreshToken) {
-        console.log(`Refresh token: yes (auto-refresh enabled)`);
+      if (isNoAuth(token.accessToken)) {
+        console.log(`Authentication: none (no-auth mode)`);
       } else {
+        console.log(`Access token saved: yes`);
+      }
+      if (!isNoAuth(token.accessToken) && token.refreshToken) {
+        console.log(`Refresh token: yes (auto-refresh enabled)`);
+      } else if (!isNoAuth(token.accessToken)) {
         console.log(`Refresh token: no (token will expire in 1 hour)`);
       }
       if (token.expiresAt) {
         console.log(`Token expires at: ${token.expiresAt}`);
       }
-      const selectedBd = await autoSelectBusinessDomain(normalizedTarget, token.accessToken, {
-        tlsInsecure: token.tlsInsecure,
-      });
+      const selectedBd = isNoAuth(token.accessToken)
+        ? resolveBusinessDomain(normalizedTarget)
+        : await autoSelectBusinessDomain(normalizedTarget, token.accessToken, {
+            tlsInsecure: token.tlsInsecure,
+          });
       console.log(`Business domain: ${selectedBd}`);
       return 0;
     } catch (error) {
@@ -241,29 +263,34 @@ Login options:
       `Current platform: ${token.baseUrl === currentPlatform ? "yes" : "no"}`,
     ];
 
-    const statusActiveUser = getActiveUser(platform);
-    if (statusActiveUser) {
-      const statusDisplayName = token.displayName;
-      const userLabel = statusDisplayName ? `${statusDisplayName} (${statusActiveUser})` : statusActiveUser;
-      lines.push(`User: ${userLabel}`);
-    }
+    if (isNoAuth(token.accessToken)) {
+      lines.push(`Authentication: none (no-auth mode)`);
+      lines.push(`User: default (built-in profile for no-auth platforms)`);
+    } else {
+      const statusActiveUser = getActiveUser(platform);
+      if (statusActiveUser) {
+        const statusDisplayName = token.displayName;
+        const userLabel = statusDisplayName ? `${statusDisplayName} (${statusActiveUser})` : statusActiveUser;
+        lines.push(`User: ${userLabel}`);
+      }
 
-    lines.push(`Token present: yes`);
-    lines.push(`Refresh token: ${token.refreshToken ? "yes (auto-refresh enabled)" : "no"}`);
-    if (token.tlsInsecure) {
-      lines.push(`TLS: certificate verification disabled (saved; dev only)`);
-    }
+      lines.push(`Token present: yes`);
+      lines.push(`Refresh token: ${token.refreshToken ? "yes (auto-refresh enabled)" : "no"}`);
+      if (token.tlsInsecure) {
+        lines.push(`TLS: certificate verification disabled (saved; dev only)`);
+      }
 
-    if (token.expiresAt) {
-      const expiry = new Date(token.expiresAt);
-      const remainingMs = expiry.getTime() - Date.now();
-      if (remainingMs > 0) {
-        const remainingMin = Math.ceil(remainingMs / 60_000);
-        lines.push(`Token status: active (expires in ${remainingMin} min)`);
-      } else if (token.refreshToken) {
-        lines.push(`Token status: expired (will auto-refresh on next command)`);
-      } else {
-        lines.push(`Token status: expired (run \`kweaver auth login ${token.baseUrl}\` again)`);
+      if (token.expiresAt) {
+        const expiry = new Date(token.expiresAt);
+        const remainingMs = expiry.getTime() - Date.now();
+        if (remainingMs > 0) {
+          const remainingMin = Math.ceil(remainingMs / 60_000);
+          lines.push(`Token status: active (expires in ${remainingMin} min)`);
+        } else if (token.refreshToken) {
+          lines.push(`Token status: expired (will auto-refresh on next command)`);
+        } else {
+          lines.push(`Token status: expired (run \`kweaver auth login ${token.baseUrl}\` again)`);
+        }
       }
     }
 
@@ -285,7 +312,9 @@ Login options:
     for (const platform of platforms) {
       const marker = platform.baseUrl === currentPlatform ? "*" : "-";
       const aliasPart = platform.alias ? ` (${platform.alias})` : "";
-      console.log(`${marker} ${platform.baseUrl}${aliasPart}`);
+      const tok = loadTokenConfig(platform.baseUrl);
+      const noAuthPart = tok && isNoAuth(tok.accessToken) ? " (no-auth)" : "";
+      console.log(`${marker} ${platform.baseUrl}${aliasPart}${noAuthPart}`);
 
       const profiles = listUserProfiles(platform.baseUrl);
       const activeUser = getActiveUser(platform.baseUrl);

--- a/packages/typescript/src/commands/call.ts
+++ b/packages/typescript/src/commands/call.ts
@@ -1,4 +1,5 @@
 import { ensureValidToken, formatHttpError, with401RefreshRetry } from "../auth/oauth.js";
+import { isNoAuth } from "../config/no-auth.js";
 import { HttpError } from "../utils/http.js";
 import { resolveBusinessDomain } from "../config/store.js";
 
@@ -97,12 +98,14 @@ export function parseCallArgs(args: string[]): CallInvocation {
 }
 
 function injectAuthHeaders(headers: Headers, accessToken: string, businessDomain: string): void {
-  if (!headers.has("authorization")) {
-    headers.set("authorization", `Bearer ${accessToken}`);
-  }
+  if (!isNoAuth(accessToken)) {
+    if (!headers.has("authorization")) {
+      headers.set("authorization", `Bearer ${accessToken}`);
+    }
 
-  if (!headers.has("token")) {
-    headers.set("token", accessToken);
+    if (!headers.has("token")) {
+      headers.set("token", accessToken);
+    }
   }
 
   if (!headers.has("x-business-domain")) {

--- a/packages/typescript/src/config/no-auth.ts
+++ b/packages/typescript/src/config/no-auth.ts
@@ -1,0 +1,6 @@
+/** Sentinel access token for platforms with no OAuth / no API authentication. */
+export const NO_AUTH_TOKEN = "__NO_AUTH__";
+
+export function isNoAuth(accessToken: string): boolean {
+  return accessToken === NO_AUTH_TOKEN;
+}

--- a/packages/typescript/src/config/store.ts
+++ b/packages/typescript/src/config/store.ts
@@ -22,7 +22,7 @@ export { NO_AUTH_TOKEN, isNoAuth } from "./no-auth.js";
  * Persist a no-auth session for a platform (users/default/token.json) and set it as current.
  * Used by `kweaver auth <url> --no-auth` and when OAuth registration returns 404.
  */
-export function saveNoAuthPlatform(baseUrl: string): TokenConfig {
+export function saveNoAuthPlatform(baseUrl: string, opts?: { tlsInsecure?: boolean }): TokenConfig {
   const base = baseUrl.replace(/\/+$/, "");
   const token: TokenConfig = {
     baseUrl: base,
@@ -31,6 +31,9 @@ export function saveNoAuthPlatform(baseUrl: string): TokenConfig {
     scope: "",
     obtainedAt: new Date().toISOString(),
   };
+  if (opts?.tlsInsecure) {
+    token.tlsInsecure = true;
+  }
   saveTokenConfig(token);
   setCurrentPlatform(base);
   return token;

--- a/packages/typescript/src/config/store.ts
+++ b/packages/typescript/src/config/store.ts
@@ -13,7 +13,28 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 
 import { listBusinessDomains } from "../api/business-domains.js";
+import { NO_AUTH_TOKEN } from "./no-auth.js";
 import { decodeJwtPayload, extractUserIdFromJwt } from "./jwt.js";
+
+export { NO_AUTH_TOKEN, isNoAuth } from "./no-auth.js";
+
+/**
+ * Persist a no-auth session for a platform (users/default/token.json) and set it as current.
+ * Used by `kweaver auth <url> --no-auth` and when OAuth registration returns 404.
+ */
+export function saveNoAuthPlatform(baseUrl: string): TokenConfig {
+  const base = baseUrl.replace(/\/+$/, "");
+  const token: TokenConfig = {
+    baseUrl: base,
+    accessToken: NO_AUTH_TOKEN,
+    tokenType: "none",
+    scope: "",
+    obtainedAt: new Date().toISOString(),
+  };
+  saveTokenConfig(token);
+  setCurrentPlatform(base);
+  return token;
+}
 
 export interface TokenConfig {
   baseUrl: string;

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -244,6 +244,9 @@ export type {
 } from "./config/store.js";
 export type { UserProfile } from "./config/store.js";
 export {
+  NO_AUTH_TOKEN,
+  isNoAuth,
+  saveNoAuthPlatform,
   autoSelectBusinessDomain,
   getConfigDir,
   getCurrentPlatform,

--- a/packages/typescript/src/kweaver.ts
+++ b/packages/typescript/src/kweaver.ts
@@ -114,6 +114,24 @@ export function configure(opts: ConfigureOptions): void {
       accessToken: stored.accessToken,
       businessDomain,
     });
+  } else if (
+    !accessToken &&
+    !process.env.KWEAVER_TOKEN &&
+    ["1", "true", "yes"].includes(
+      (process.env.KWEAVER_NO_AUTH ?? "").toLowerCase(),
+    )
+  ) {
+    const resolvedBase = baseUrl ?? process.env.KWEAVER_BASE_URL;
+    if (!resolvedBase) {
+      throw new Error(
+        "Provide baseUrl= or set KWEAVER_BASE_URL when KWEAVER_NO_AUTH is set.",
+      );
+    }
+    _client = new KWeaverClient({
+      baseUrl: resolvedBase,
+      auth: false,
+      businessDomain,
+    });
   } else {
     if (!baseUrl && !process.env.KWEAVER_BASE_URL) {
       throw new Error("Provide baseUrl=, config=true, or set KWEAVER_BASE_URL.");

--- a/packages/typescript/src/kweaver.ts
+++ b/packages/typescript/src/kweaver.ts
@@ -85,6 +85,9 @@ export function configure(opts: ConfigureOptions): void {
   if (auth === false && config) {
     throw new Error("Cannot use auth: false with config: true.");
   }
+  if (auth === false && accessToken) {
+    throw new Error("Cannot use auth: false with accessToken.");
+  }
 
   if (auth === false) {
     const resolvedBase = baseUrl ?? process.env.KWEAVER_BASE_URL;

--- a/packages/typescript/src/kweaver.ts
+++ b/packages/typescript/src/kweaver.ts
@@ -51,6 +51,11 @@ export interface ConfigureOptions {
    * config, preventing accidental cross-environment credential leaks.
    */
   config?: boolean;
+  /**
+   * If false, use no-auth mode (no Authorization headers). Requires baseUrl or KWEAVER_BASE_URL.
+   * Incompatible with config=true.
+   */
+  auth?: boolean;
   /** Default BKN ID used by search() and weaver(). */
   bknId?: string;
   /** Default agent ID used by chat(). */
@@ -75,9 +80,23 @@ export function configure(opts: ConfigureOptions): void {
   _defaultBknId = null;
   _defaultAgentId = null;
 
-  const { bknId, agentId, businessDomain, config, baseUrl, accessToken } = opts;
+  const { bknId, agentId, businessDomain, config, baseUrl, accessToken, auth } = opts;
 
-  if (config) {
+  if (auth === false && config) {
+    throw new Error("Cannot use auth: false with config: true.");
+  }
+
+  if (auth === false) {
+    const resolvedBase = baseUrl ?? process.env.KWEAVER_BASE_URL;
+    if (!resolvedBase) {
+      throw new Error("Provide baseUrl= or set KWEAVER_BASE_URL when auth is false.");
+    }
+    _client = new KWeaverClient({
+      baseUrl: resolvedBase,
+      auth: false,
+      businessDomain,
+    });
+  } else if (config) {
     // Use saved credentials — do NOT pass baseUrl to avoid cross-env leaks
     const platform = getCurrentPlatform();
     if (!platform) {

--- a/packages/typescript/src/resources/bkn.ts
+++ b/packages/typescript/src/resources/bkn.ts
@@ -1,3 +1,4 @@
+import { buildHeaders } from "../api/headers.js";
 import {
   objectTypeQuery,
   objectTypeProperties,
@@ -50,9 +51,7 @@ export class BknResource {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: `Bearer ${accessToken}`,
-        token: accessToken,
-        "x-business-domain": businessDomain,
+        ...buildHeaders(accessToken, businessDomain),
       },
       body: JSON.stringify({
         kn_id: bknId,

--- a/packages/typescript/src/resources/knowledge-networks.ts
+++ b/packages/typescript/src/resources/knowledge-networks.ts
@@ -1,3 +1,4 @@
+import { buildHeaders } from "../api/headers.js";
 import {
   listKnowledgeNetworks,
   getKnowledgeNetwork,
@@ -91,9 +92,7 @@ export class KnowledgeNetworksResource {
     const { baseUrl, accessToken, businessDomain } = this.ctx.base();
     const headers = {
       "content-type": "application/json",
-      authorization: `Bearer ${accessToken}`,
-      token: accessToken,
-      "x-business-domain": businessDomain,
+      ...buildHeaders(accessToken, businessDomain),
     };
     await fetchTextOrThrow(
       `${baseUrl}/api/ontology-manager/v1/knowledge-networks/${encodeURIComponent(bknId)}/jobs`,
@@ -108,11 +107,7 @@ export class KnowledgeNetworksResource {
   /** Poll build status for a BKN. */
   async buildStatus(bknId: string): Promise<BuildStatus> {
     const { baseUrl, accessToken, businessDomain } = this.ctx.base();
-    const headers = {
-      authorization: `Bearer ${accessToken}`,
-      token: accessToken,
-      "x-business-domain": businessDomain,
-    };
+    const headers = buildHeaders(accessToken, businessDomain);
     const { body } = await fetchTextOrThrow(
       `${baseUrl}/api/ontology-manager/v1/knowledge-networks/${encodeURIComponent(bknId)}/jobs?limit=1&direction=desc`,
       { headers }

--- a/packages/typescript/test/cli.test.ts
+++ b/packages/typescript/test/cli.test.ts
@@ -472,6 +472,85 @@ test("run auth login with --refresh-token exchanges and saves access token", asy
   assert.equal(client?.clientSecret, "h-sec");
 });
 
+test("run auth login --no-auth saves no-auth platform and exits 0", async () => {
+  const configDir = createConfigDir();
+  const store = await importStoreModule(configDir);
+  const auth = await importAuthModule(configDir);
+
+  const base = "https://noauth.example.com";
+  const code = await auth.runAuthCommand([base, "--no-auth"]);
+  assert.equal(code, 0);
+
+  assert.equal(store.getCurrentPlatform(), base);
+  const tok = store.loadTokenConfig(base);
+  assert.ok(tok, "token should be saved");
+  assert.equal(tok?.accessToken, "__NO_AUTH__");
+});
+
+test("run auth login --no-auth with --insecure persists tlsInsecure", async () => {
+  const configDir = createConfigDir();
+  const store = await importStoreModule(configDir);
+  const auth = await importAuthModule(configDir);
+
+  const base = "https://self-signed.example.com";
+  const code = await auth.runAuthCommand([base, "--no-auth", "-k"]);
+  assert.equal(code, 0);
+
+  const tok = store.loadTokenConfig(base);
+  assert.equal(tok?.tlsInsecure, true);
+});
+
+test("run auth login --no-auth with --refresh-token is rejected", async () => {
+  const configDir = createConfigDir();
+  await importStoreModule(configDir);
+  const auth = await importAuthModule(configDir);
+
+  const errors: string[] = [];
+  const origError = console.error;
+  console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+  try {
+    const code = await auth.runAuthCommand([
+      "https://example.com", "--no-auth", "--refresh-token", "rt",
+      "--client-id", "cid", "--client-secret", "csec",
+    ]);
+    assert.equal(code, 1);
+    assert.ok(errors.some((e) => e.includes("--no-auth cannot be used with --refresh-token")));
+  } finally {
+    console.error = origError;
+  }
+});
+
+test("run auth login --no-auth with -u/-p is rejected", async () => {
+  const configDir = createConfigDir();
+  await importStoreModule(configDir);
+  const auth = await importAuthModule(configDir);
+
+  const errors: string[] = [];
+  const origError = console.error;
+  console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+  try {
+    const code = await auth.runAuthCommand([
+      "https://example.com", "--no-auth", "-u", "user", "-p", "pass",
+    ]);
+    assert.equal(code, 1);
+    assert.ok(errors.some((e) => e.includes("--no-auth cannot be used with Playwright")));
+  } finally {
+    console.error = origError;
+  }
+});
+
+test("run auth login --no-auth with alias saves alias", async () => {
+  const configDir = createConfigDir();
+  const store = await importStoreModule(configDir);
+  const auth = await importAuthModule(configDir);
+
+  const base = "https://noauth-alias.example.com";
+  const code = await auth.runAuthCommand([base, "--no-auth", "--alias", "na"]);
+  assert.equal(code, 0);
+
+  assert.equal(store.getPlatformAlias(base), "na");
+});
+
 test("run auth login rejects unknown flags", async () => {
   const configDir = createConfigDir();
   await importStoreModule(configDir);
@@ -510,6 +589,7 @@ test("run auth login accepts all known flags without unknown-flag error", async 
       "--redirect-uri", "http://127.0.0.1:9010/callback",
       "--port", "9010",
       "--insecure",
+      "--no-auth",
     ]);
     assert.ok(!errors.some((e) => e.includes("Unknown option")));
   } finally {

--- a/packages/typescript/test/client.test.ts
+++ b/packages/typescript/test/client.test.ts
@@ -21,6 +21,42 @@ test("KWeaverClient auth false uses no-auth sentinel", () => {
   assert.equal(client.base().baseUrl, BASE);
 });
 
+test("KWeaverClient auth false with config true throws", () => {
+  assert.throws(
+    () => new KWeaverClient({ baseUrl: BASE, auth: false, config: true }),
+    /incompatible with config: true/,
+  );
+});
+
+test("KWeaverClient auth false falls back to active platform for baseUrl", async () => {
+  const { mkdtempSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const origUrl = process.env.KWEAVER_BASE_URL;
+  const origDir = process.env.KWEAVERC_CONFIG_DIR;
+  delete process.env.KWEAVER_BASE_URL;
+
+  const configDir = mkdtempSync(join(tmpdir(), "kweaver-client-noauth-"));
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+
+  const t = `${Date.now()}-${Math.random()}`;
+  const store = await import(`../src/config/store.ts?t=${t}`);
+  store.setCurrentPlatform("https://saved-platform.example.com");
+
+  const clientMod = await import(`../src/client.ts?t=${t}`);
+  try {
+    const client = new clientMod.KWeaverClient({ auth: false });
+    assert.equal(client.base().baseUrl, "https://saved-platform.example.com");
+    assert.equal(client.base().accessToken, NO_AUTH_TOKEN);
+  } finally {
+    if (origUrl !== undefined) process.env.KWEAVER_BASE_URL = origUrl;
+    else delete process.env.KWEAVER_BASE_URL;
+    if (origDir !== undefined) process.env.KWEAVERC_CONFIG_DIR = origDir;
+    else delete process.env.KWEAVERC_CONFIG_DIR;
+  }
+});
+
 test("KWeaverClient auth false requires baseUrl when no env and no platform", () => {
   const origUrl = process.env.KWEAVER_BASE_URL;
   const origDir = process.env.KWEAVERC_CONFIG_DIR;

--- a/packages/typescript/test/client.test.ts
+++ b/packages/typescript/test/client.test.ts
@@ -57,6 +57,59 @@ test("KWeaverClient auth false falls back to active platform for baseUrl", async
   }
 });
 
+test("KWeaverClient.connect throws when probe returns 401 (revoked token)", async () => {
+  const { mkdtempSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+
+  const origDir = process.env.KWEAVERC_CONFIG_DIR;
+  const origTok = process.env.KWEAVER_TOKEN;
+  const origUrl = process.env.KWEAVER_BASE_URL;
+  delete process.env.KWEAVER_TOKEN;
+  delete process.env.KWEAVER_BASE_URL;
+
+  const configDir = mkdtempSync(join(tmpdir(), "kweaver-connect-probe-"));
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+
+  const t = `${Date.now()}-${Math.random()}`;
+  const store = await import(`../src/config/store.ts?t=${t}`);
+  const baseUrl = "https://probe-platform.example.com";
+  store.setCurrentPlatform(baseUrl);
+  store.saveTokenConfig({
+    baseUrl,
+    accessToken: "live-access-token",
+    tokenType: "Bearer",
+    scope: "",
+    obtainedAt: new Date().toISOString(),
+  });
+
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (input) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url.includes("/knowledge-networks") && url.includes("limit=1")) {
+      return new Response("unauthorized", { status: 401 });
+    }
+    return new Response("{}", { status: 200 });
+  };
+
+  const clientMod = await import(`../src/client.ts?t=${t}`);
+  try {
+    await assert.rejects(
+      () => clientMod.KWeaverClient.connect(),
+      (err: unknown) =>
+        err instanceof Error &&
+        err.message.startsWith("Access token revoked"),
+      "connect must surface revoked token from 401 probe",
+    );
+  } finally {
+    globalThis.fetch = origFetch;
+    if (origDir !== undefined) process.env.KWEAVERC_CONFIG_DIR = origDir;
+    else delete process.env.KWEAVERC_CONFIG_DIR;
+    if (origTok !== undefined) process.env.KWEAVER_TOKEN = origTok;
+    if (origUrl !== undefined) process.env.KWEAVER_BASE_URL = origUrl;
+  }
+});
+
 test("KWeaverClient auth false requires baseUrl when no env and no platform", () => {
   const origUrl = process.env.KWEAVER_BASE_URL;
   const origDir = process.env.KWEAVERC_CONFIG_DIR;

--- a/packages/typescript/test/client.test.ts
+++ b/packages/typescript/test/client.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
 
+import { NO_AUTH_TOKEN } from "../src/config/no-auth.js";
 import { KWeaverClient } from "../src/client.js";
 import { ContextLoaderResource } from "../src/resources/context-loader.js";
 
@@ -13,6 +14,30 @@ function makeClient(extra: Record<string, string> = {}): KWeaverClient {
 }
 
 // ── constructor ───────────────────────────────────────────────────────────────
+
+test("KWeaverClient auth false uses no-auth sentinel", () => {
+  const client = new KWeaverClient({ baseUrl: BASE, auth: false });
+  assert.equal(client.base().accessToken, NO_AUTH_TOKEN);
+  assert.equal(client.base().baseUrl, BASE);
+});
+
+test("KWeaverClient auth false requires baseUrl when no env and no platform", () => {
+  const origUrl = process.env.KWEAVER_BASE_URL;
+  const origDir = process.env.KWEAVERC_CONFIG_DIR;
+  delete process.env.KWEAVER_BASE_URL;
+  process.env.KWEAVERC_CONFIG_DIR = fileURLToPath(new URL("../../.tmp-test-cfg", import.meta.url));
+  try {
+    assert.throws(
+      () => new KWeaverClient({ auth: false }),
+      /baseUrl is required when auth is false/,
+    );
+  } finally {
+    if (origUrl !== undefined) process.env.KWEAVER_BASE_URL = origUrl;
+    else delete process.env.KWEAVER_BASE_URL;
+    if (origDir !== undefined) process.env.KWEAVERC_CONFIG_DIR = origDir;
+    else delete process.env.KWEAVERC_CONFIG_DIR;
+  }
+});
 
 test("KWeaverClient throws when accessToken missing and env var absent", () => {
   // Point config dir to an empty temp directory so no saved token is found

--- a/packages/typescript/test/config-store.test.ts
+++ b/packages/typescript/test/config-store.test.ts
@@ -4,9 +4,13 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  getCurrentPlatform,
+  isNoAuth,
   loadPlatformBusinessDomain,
-  savePlatformBusinessDomain,
+  loadTokenConfig,
   resolveBusinessDomain,
+  saveNoAuthPlatform,
+  savePlatformBusinessDomain,
 } from "../src/config/store.js";
 
 describe("platform config (businessDomain)", () => {
@@ -50,5 +54,16 @@ describe("platform config (businessDomain)", () => {
     assert.equal(resolveBusinessDomain("https://no-config.com"), "bd_public");
     savePlatformBusinessDomain("https://example.com", "uuid-bd");
     assert.equal(resolveBusinessDomain("https://example.com"), "uuid-bd");
+  });
+
+  it("saveNoAuthPlatform persists sentinel and sets current platform", () => {
+    const url = "https://no-oauth.example.com";
+    const tok = saveNoAuthPlatform(url);
+    assert.ok(isNoAuth(tok.accessToken));
+    assert.equal(getCurrentPlatform(), url.replace(/\/+$/, ""));
+    const loaded = loadTokenConfig(url);
+    assert.ok(loaded);
+    assert.ok(isNoAuth(loaded!.accessToken));
+    assert.equal(loaded!.tokenType, "none");
   });
 });

--- a/packages/typescript/test/e2e/no-auth-cli.test.ts
+++ b/packages/typescript/test/e2e/no-auth-cli.test.ts
@@ -1,0 +1,93 @@
+/**
+ * E2E smoke tests for no-auth platforms using the packaged CLI (`bin/kweaver.js` → `dist/cli.js`).
+ *
+ * Requires a running KWeaver instance for live tests:
+ *   export KWEAVER_BASE_URL=https://your-host
+ *   export KWEAVER_NO_AUTH=1   (optional; tests set it for subprocesses)
+ *
+ * Optional: KWEAVER_TLS_INSECURE=1 for self-signed HTTPS.
+ *
+ * Run from `packages/typescript`:
+ *   npm run build && npm run test:e2e
+ *
+ * Full live smoke (default URL + TLS insecure for self-signed HTTPS):
+ *   npm run build && npm run test:e2e:live
+ * Override base URL: `KWEAVER_BASE_URL=https://other.host npm run test:e2e:live`
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const kweaverBin = join(__dirname, "../../bin/kweaver.js");
+
+function runKweaver(
+  args: string[],
+  extraEnv: Record<string, string | undefined>,
+): { status: number | null; stdout: string; stderr: string } {
+  const env = { ...process.env, ...extraEnv };
+  delete env.KWEAVER_TOKEN;
+  const r = spawnSync(process.execPath, [kweaverBin, ...args], {
+    encoding: "utf8",
+    env,
+  });
+  return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+function hasLiveBaseUrl(): boolean {
+  return Boolean(process.env.KWEAVER_BASE_URL?.trim());
+}
+
+test("e2e no-auth: bin/kweaver.js --version exits 0", () => {
+  const r = runKweaver(["--version"], {});
+  assert.equal(r.status, 0, r.stderr || r.stdout);
+  assert.match(r.stdout + r.stderr, /\d+\.\d+\.\d+/, "expected semver in output");
+});
+
+test("e2e no-auth: bin/kweaver.js -V matches --version", () => {
+  const a = runKweaver(["--version"], {});
+  const b = runKweaver(["-V"], {});
+  assert.equal(a.status, 0);
+  assert.equal(b.status, 0);
+  assert.equal(a.stdout.trim(), b.stdout.trim());
+});
+
+test(
+  "e2e no-auth: call GET knowledge-networks (live)",
+  { skip: !hasLiveBaseUrl() },
+  () => {
+    const base = process.env.KWEAVER_BASE_URL!.replace(/\/+$/, "");
+    const r = runKweaver(
+      ["call", `${base}/api/ontology-manager/v1/knowledge-networks?limit=1`, "-X", "GET"],
+      {
+        KWEAVER_NO_AUTH: "1",
+        KWEAVER_BASE_URL: base,
+      },
+    );
+    assert.equal(
+      r.status,
+      0,
+      `call failed (status ${r.status}). stderr:\n${r.stderr}\nstdout:\n${r.stdout}`,
+    );
+  },
+);
+
+test(
+  "e2e no-auth: ds list --limit 1 (live)",
+  { skip: !hasLiveBaseUrl() },
+  () => {
+    const base = process.env.KWEAVER_BASE_URL!.replace(/\/+$/, "");
+    const r = runKweaver(["ds", "list", "--limit", "1"], {
+      KWEAVER_NO_AUTH: "1",
+      KWEAVER_BASE_URL: base,
+    });
+    assert.equal(
+      r.status,
+      0,
+      `ds list failed (status ${r.status}). stderr:\n${r.stderr}\nstdout:\n${r.stdout}`,
+    );
+  },
+);

--- a/packages/typescript/test/headers.test.ts
+++ b/packages/typescript/test/headers.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildHeaders } from "../src/api/headers.js";
+import { NO_AUTH_TOKEN } from "../src/config/no-auth.js";
+
+test("buildHeaders omits authorization and token for no-auth sentinel", () => {
+  const h = buildHeaders(NO_AUTH_TOKEN, "bd_public");
+  assert.equal(h["authorization"], undefined);
+  assert.equal(h.token, undefined);
+  assert.equal(h["x-business-domain"], "bd_public");
+  assert.ok(h.accept);
+});
+
+test("buildHeaders sets authorization and token for normal token", () => {
+  const h = buildHeaders("real-token", "bd_x");
+  assert.equal(h.authorization, "Bearer real-token");
+  assert.equal(h.token, "real-token");
+});

--- a/packages/typescript/test/kweaver.test.ts
+++ b/packages/typescript/test/kweaver.test.ts
@@ -9,6 +9,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { NO_AUTH_TOKEN } from "../src/config/no-auth.js";
+
 const BASE = "https://mock.kweaver.test";
 const TOKEN = "test-token-xyz";
 
@@ -84,6 +86,26 @@ test("configure reads accessToken from env", () => {
     );
   } finally {
     delete process.env.KWEAVER_TOKEN;
+  }
+});
+
+test("configure uses KWEAVER_NO_AUTH env with KWEAVER_BASE_URL", () => {
+  const origNoAuth = process.env.KWEAVER_NO_AUTH;
+  const origTok = process.env.KWEAVER_TOKEN;
+  const origBase = process.env.KWEAVER_BASE_URL;
+  process.env.KWEAVER_NO_AUTH = "1";
+  delete process.env.KWEAVER_TOKEN;
+  process.env.KWEAVER_BASE_URL = BASE;
+  try {
+    assert.doesNotThrow(() => kweaver.configure({}));
+    assert.equal(kweaver.getClient().base().accessToken, NO_AUTH_TOKEN);
+    assert.equal(kweaver.getClient().base().baseUrl, BASE);
+  } finally {
+    if (origNoAuth !== undefined) process.env.KWEAVER_NO_AUTH = origNoAuth;
+    else delete process.env.KWEAVER_NO_AUTH;
+    if (origTok !== undefined) process.env.KWEAVER_TOKEN = origTok;
+    if (origBase !== undefined) process.env.KWEAVER_BASE_URL = origBase;
+    else delete process.env.KWEAVER_BASE_URL;
   }
 });
 

--- a/packages/typescript/test/kweaver.test.ts
+++ b/packages/typescript/test/kweaver.test.ts
@@ -87,6 +87,18 @@ test("configure reads accessToken from env", () => {
   }
 });
 
+test("configure rejects auth false with accessToken", () => {
+  assert.throws(
+    () =>
+      kweaver.configure({
+        baseUrl: BASE,
+        accessToken: TOKEN,
+        auth: false,
+      }),
+    /auth: false with accessToken/,
+  );
+});
+
 test("getClient throws before configure", () => {
   // Force unconfigured state by importing fresh module state
   // We achieve this by calling a private-state-resetting trick: configure sets state.

--- a/packages/typescript/test/oauth-auth.test.ts
+++ b/packages/typescript/test/oauth-auth.test.ts
@@ -272,6 +272,30 @@ test("ensureValidToken: no-auth token returns without calling fetch", async () =
   }
 });
 
+test("ensureValidToken: KWEAVER_TOKEN without KWEAVER_BASE_URL honors env over saved token", async () => {
+  const configDir = createConfigDir();
+  const { store, oauth } = await importOauthAndStore(configDir);
+  const baseUrl = "https://env-override.example.com";
+  store.setCurrentPlatform(baseUrl);
+  store.saveTokenConfig({
+    baseUrl,
+    accessToken: "saved-real-token",
+    tokenType: "Bearer",
+    scope: "",
+    obtainedAt: new Date().toISOString(),
+  });
+
+  const { NO_AUTH_TOKEN } = await import("../src/config/no-auth.js");
+  process.env.KWEAVER_TOKEN = NO_AUTH_TOKEN;
+  try {
+    const t = await oauth.ensureValidToken();
+    assert.equal(t.accessToken, NO_AUTH_TOKEN);
+    assert.equal(t.baseUrl.replace(/\/+$/, ""), baseUrl.replace(/\/+$/, ""));
+  } finally {
+    delete process.env.KWEAVER_TOKEN;
+  }
+});
+
 // ---------------------------------------------------------------------------
 // KWEAVER_USER env var: load a specific user's token
 // ---------------------------------------------------------------------------

--- a/packages/typescript/test/oauth-auth.test.ts
+++ b/packages/typescript/test/oauth-auth.test.ts
@@ -254,6 +254,24 @@ test("ensureValidToken: forceRefresh calls token endpoint", async () => {
   }
 });
 
+test("ensureValidToken: no-auth token returns without calling fetch", async () => {
+  const configDir = createConfigDir();
+  const { store, oauth } = await importOauthAndStore(configDir);
+  const baseUrl = "https://plain.example.com";
+  store.saveNoAuthPlatform(baseUrl);
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error("fetch should not be called for no-auth ensureValidToken");
+  };
+  try {
+    const t = await oauth.ensureValidToken();
+    assert.ok(store.isNoAuth(t.accessToken));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 // ---------------------------------------------------------------------------
 // KWEAVER_USER env var: load a specific user's token
 // ---------------------------------------------------------------------------
@@ -365,6 +383,29 @@ test("withTokenRetry: returns on first success", async () => {
   });
   assert.equal(r, 42);
   assert.equal(n, 1);
+});
+
+test("withTokenRetry: no-auth session does not attempt refresh on 401", async () => {
+  const configDir = createConfigDir();
+  const { store, oauth } = await importOauthAndStore(configDir);
+  const baseUrl = "https://plain.example.com";
+  store.saveNoAuthPlatform(baseUrl);
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new Error("fetch should not be called");
+  };
+  try {
+    await assert.rejects(
+      () =>
+        oauth.withTokenRetry(async () => {
+          throw new HttpError(401, "Unauthorized", "{}");
+        }),
+      HttpError,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test("withTokenRetry: retries once after 401 when refresh succeeds", async () => {

--- a/skills/kweaver-core/references/auth.md
+++ b/skills/kweaver-core/references/auth.md
@@ -13,7 +13,7 @@ npm install playwright && npx playwright install chromium
 ## 命令
 
 ```bash
-kweaver auth login <url> [--alias <name>] [-u user] [-p pass] [--playwright]
+kweaver auth login <url> [--alias <name>] [--no-auth] [-u user] [-p pass] [--playwright]
                          [--port <n>] [--redirect-uri <uri>] [--insecure|-k]
 kweaver auth <url> [--alias <name>] ...              # 同上（简写）
 kweaver auth whoami [url|alias] [--json]              # 显示当前用户身份
@@ -26,6 +26,14 @@ kweaver auth switch [url|alias] --user <id|username>  # 切换活跃用户
 kweaver auth logout [url|alias] [--user <id|username>]
 kweaver auth delete <url|alias> [--user <id|username>]
 ```
+
+## 无认证平台（no-auth）
+
+部分环境未启用 OAuth（例如内网开发机）。可显式保存为 no-auth 平台，或与正常登录一样执行 `kweaver auth login <url>`：若 `POST /oauth2/clients` 返回 **404**，CLI 会提示并自动保存为 no-auth 模式。
+
+- **`--no-auth`**：`kweaver auth <url> --no-auth` 与 `kweaver auth login <url> --no-auth` 等价，跳过浏览器/OAuth。
+- **环境变量**：`KWEAVER_NO_AUTH=1` 且未设置 `KWEAVER_TOKEN` 时，CLI 使用与磁盘 no-auth 相同的 sentinel（需配合 `KWEAVER_BASE_URL` 或已选平台）。
+- 凭据仍写入 `~/.kweaver/`，可用 `auth use` / `auth list` 切换；内置 **default** 用户目录（与 TS/Python SDK 一致）。
 
 ## 多账号支持
 


### PR DESCRIPTION
## Summary

- Add `--no-auth` flag to `kweaver auth login` and `auth: false` option to `KWeaverClient` / `kweaver.configure()` for platforms without OAuth/API authentication
- When OAuth2 client registration returns 404, automatically save the platform in no-auth mode (graceful fallback)
- Strip `Authorization` / `token` headers from all API calls when using the `__NO_AUTH__` sentinel token
- Support `KWEAVER_NO_AUTH=1` environment variable in both CLI and programmatic SDK usage (TS + Python parity)
- Fix `connect()` 401 probe that was silently swallowed by its own `catch {}` block — revoked tokens are now surfaced to the caller
- Fix `ensureValidToken()` ignoring `KWEAVER_TOKEN` env when `KWEAVER_BASE_URL` is not set
- Propagate `tlsInsecure` to `saveNoAuthPlatform` in both TS and Python
- Reject conflicting options (`auth:false + config:true`, `auth:false + accessToken`)
- Reject unknown CLI flags in `kweaver auth login` with actionable error messages
- Add unit tests for all new behavior (TS: 582 pass, Python: 325 pass)

## Test plan

- [x] `make -C packages/typescript test` — 582 tests pass, 0 failures
- [x] `make -C packages/python test` — 325 tests pass
- [x] `make -C packages/typescript lint` — tsc --noEmit passes
- [x] Manual: `kweaver auth login <no-auth-platform> --no-auth` saves and `kweaver auth status` shows no-auth mode
- [x] Manual: `KWEAVER_NO_AUTH=1 KWEAVER_BASE_URL=<url> node -e "import kweaver from 'kweaver-sdk/kweaver'; kweaver.configure({})"` works
- [x] E2E: `npm run test:e2e -w packages/typescript` against a no-auth platform


Made with [Cursor](https://cursor.com)