### PR TITLE
feat(vega): add SQL / DSL query support (TS + Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ kweaver bkn action-execution get
 kweaver bkn action-log list/get/cancel
 kweaver agent list/get/create/update/delete/chat/sessions/history/publish/unpublish
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
-kweaver vega health/stats/inspect/catalog/resource/connector-type
+kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
 kweaver context-loader config set/use/list/show
 kweaver context-loader kn-search/query-object-instance/...
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-bd domain]

--- a/README.zh.md
+++ b/README.zh.md
@@ -256,7 +256,7 @@ kweaver bkn action-execution get
 kweaver bkn action-log list/get/cancel
 kweaver agent list/get/get-by-key/create/update/delete/chat/sessions/history/publish/unpublish
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
-kweaver vega health/stats/inspect/catalog/resource/connector-type
+kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
 kweaver context-loader config set/use/list/show
 kweaver context-loader kn-search/query-object-instance/...
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-bd domain]

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -82,6 +82,9 @@ models = client.vega.metric_models.list()
 # Vega — Query
 result = client.vega.query.dsl(body={"query": {"match_all": {}}, "size": 10})
 result = client.vega.query.execute(tables=[...], output_fields=["*"], limit=20)
+# Direct SQL or OpenSearch DSL — POST /api/vega-backend/v1/resources/query
+# Use {{resource_id}} placeholders so vega-backend routes to the correct catalog connector.
+rows = client.vega.query.sql_query({"query": "SELECT * FROM {{<resource-id>}} LIMIT 5", "resource_type": "mysql"})
 
 # Vega — Diagnostics
 info = client.vega.health()
@@ -133,7 +136,7 @@ client = KWeaverClient(auth=ConfigAuth(), dry_run=True)
 | Data Views | `client.vega.data_views` | `list`, `get` |
 | Data Dicts | `client.vega.data_dicts` | `list`, `get` |
 | Objective Models | `client.vega.objective_models` | `list`, `get` |
-| Query | `client.vega.query` | `execute`, `dsl`, `dsl_count`, `promql`, `promql_instant`, `events` |
+| Query | `client.vega.query` | `execute`, `sql_query`, `dsl`, `dsl_count`, `promql`, `promql_instant`, `events` |
 | Tasks | `client.vega.tasks` | `list_discover`, `get_discover`, `wait_discover`, `get_metric` |
 | Namespace | `client.vega` | `health`, `stats`, `inspect` |
 

--- a/packages/python/README.zh.md
+++ b/packages/python/README.zh.md
@@ -71,6 +71,9 @@ models = client.vega.metric_models.list()
 # Vega — 查询
 result = client.vega.query.dsl(body={"query": {"match_all": {}}, "size": 10})
 result = client.vega.query.execute(tables=[...], output_fields=["*"], limit=20)
+# 直连 SQL 或 OpenSearch DSL — POST /api/vega-backend/v1/resources/query
+# 使用 {{resource_id}} 占位符以路由到正确的 catalog connector
+rows = client.vega.query.sql_query({"query": "SELECT * FROM {{<resource-id>}} LIMIT 5", "resource_type": "mysql"})
 
 # Vega — 诊断
 info = client.vega.health()
@@ -122,7 +125,7 @@ client = KWeaverClient(auth=ConfigAuth(), dry_run=True)
 | 数据视图 | `client.vega.data_views` | `list`, `get` |
 | 数据字典 | `client.vega.data_dicts` | `list`, `get` |
 | 目标模型 | `client.vega.objective_models` | `list`, `get` |
-| 查询 | `client.vega.query` | `execute`, `dsl`, `dsl_count`, `promql`, `promql_instant`, `events` |
+| 查询 | `client.vega.query` | `execute`, `sql_query`, `dsl`, `dsl_count`, `promql`, `promql_instant`, `events` |
 | 任务 | `client.vega.tasks` | `list_discover`, `get_discover`, `wait_discover`, `get_metric` |
 | 命名空间 | `client.vega` | `health`, `stats`, `inspect` |
 

--- a/packages/python/src/kweaver/resources/vega/query.py
+++ b/packages/python/src/kweaver/resources/vega/query.py
@@ -53,8 +53,14 @@ class VegaQueryResource:
         return VegaQueryResult(**data) if data else VegaQueryResult()
 
     def sql_query(self, body: dict[str, Any]) -> dict[str, Any]:
-        """POST /api/vega-backend/v1/resources/query — direct SQL or OpenSearch DSL."""
+        """POST /api/vega-backend/v1/resources/query — direct SQL or OpenSearch DSL.
+
+        Use ``{{<resource_id>}}`` placeholders in ``query`` so vega-backend
+        routes to the correct catalog connector.
+        """
         data = self._http.post("/api/vega-backend/v1/resources/query", json=body)
+        if data is None:
+            raise ValueError("sql_query returned no data — check request body and connectivity")
         return data if isinstance(data, dict) else {}
 
     def dsl(self, *, index: str | None = None, body: dict) -> VegaDslResult:

--- a/packages/python/src/kweaver/resources/vega/query.py
+++ b/packages/python/src/kweaver/resources/vega/query.py
@@ -16,26 +16,46 @@ class VegaQueryResource:
     def execute(
         self,
         *,
-        tables: list[str] | None = None,
+        tables: list[str] | list[dict[str, Any]] | None = None,
         filter_condition: Any = None,
         output_fields: list[str] | None = None,
         sort: list[dict[str, Any]] | None = None,
         offset: int = 0,
         limit: int = 20,
+        joins: list[dict[str, Any]] | None = None,
+        need_total: bool | None = None,
+        query_id: str | None = None,
     ) -> VegaQueryResult:
         body: dict[str, Any] = {}
         if tables:
-            body["tables"] = tables
+            normalized: list[dict[str, Any]] = []
+            for t in tables:
+                if isinstance(t, str):
+                    normalized.append({"resource_id": t})
+                else:
+                    normalized.append(t)
+            body["tables"] = normalized
         if filter_condition:
             body["filter_condition"] = filter_condition
         if output_fields:
             body["output_fields"] = output_fields
         if sort:
             body["sort"] = sort
+        if joins:
+            body["joins"] = joins
+        if need_total is not None:
+            body["need_total"] = need_total
+        if query_id:
+            body["query_id"] = query_id
         body["offset"] = offset
         body["limit"] = limit
         data = self._http.post("/api/vega-backend/v1/query/execute", json=body)
         return VegaQueryResult(**data) if data else VegaQueryResult()
+
+    def sql_query(self, body: dict[str, Any]) -> dict[str, Any]:
+        """POST /api/vega-backend/v1/resources/query — direct SQL or OpenSearch DSL."""
+        data = self._http.post("/api/vega-backend/v1/resources/query", json=body)
+        return data if isinstance(data, dict) else {}
 
     def dsl(self, *, index: str | None = None, body: dict) -> VegaDslResult:
         path = (

--- a/packages/python/src/kweaver/resources/vega/query.py
+++ b/packages/python/src/kweaver/resources/vega/query.py
@@ -16,7 +16,7 @@ class VegaQueryResource:
     def execute(
         self,
         *,
-        tables: list[str] | list[dict[str, Any]] | None = None,
+        tables: list[str | dict[str, Any]] | None = None,
         filter_condition: Any = None,
         output_fields: list[str] | None = None,
         sort: list[dict[str, Any]] | None = None,

--- a/packages/python/tests/unit/test_vega.py
+++ b/packages/python/tests/unit/test_vega.py
@@ -105,6 +105,35 @@ def test_query_execute_empty_response():
     assert result.total_count == 0
 
 
+def test_query_sql_query():
+    """sql_query() posts to /resources/query and returns dict."""
+    def handler(req):
+        assert req.url.path == "/api/vega-backend/v1/resources/query"
+        body = req.content
+        import json as _json
+        parsed = _json.loads(body)
+        assert parsed["resource_type"] == "mysql"
+        return httpx.Response(200, json={"columns": [{"name": "x"}], "entries": [{"x": 1}], "total_count": 1})
+
+    from kweaver.resources.vega import VegaNamespace
+    ns = VegaNamespace(_make_vega_http(handler))
+    result = ns.query.sql_query({"query": "SELECT 1 AS x", "resource_type": "mysql"})
+    assert isinstance(result, dict)
+    assert result["total_count"] == 1
+    assert result["entries"] == [{"x": 1}]
+
+
+def test_query_sql_query_none_raises():
+    """sql_query() raises ValueError when backend returns no content."""
+    def handler(req):
+        return httpx.Response(204)
+
+    from kweaver.resources.vega import VegaNamespace
+    ns = VegaNamespace(_make_vega_http(handler))
+    with pytest.raises(ValueError, match="sql_query returned no data"):
+        ns.query.sql_query({"query": "SELECT 1", "resource_type": "mysql"})
+
+
 def test_query_dsl_with_index():
     """dsl() posts to index-specific endpoint when index is provided."""
     def handler(req):

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "kweaver-sdk"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -126,9 +126,18 @@ const result = await client.dataflows.execute({
   steps: [{ id: "s1", title: "load", operator: "csv_import", parameters: {} }],
 });
 
-// Vega observability
+// Vega — observability and query
 const catalogs = await client.vega.listCatalogs();
 const health   = await client.vega.health();
+// Structured query — POST /api/vega-backend/v1/query/execute (JSON string body)
+const structured = await client.vega.executeQuery(
+  JSON.stringify({ tables: [{ resource_id: "res-1" }], output_fields: ["*"], limit: 20 }),
+);
+// Direct SQL or OpenSearch DSL — POST /api/vega-backend/v1/resources/query
+// Use {{resource_id}} placeholders so vega-backend routes to the correct catalog connector.
+const rows = await client.vega.sqlQuery(
+  JSON.stringify({ query: "SELECT * FROM {{res-1}} LIMIT 5", resource_type: "mysql" }),
+);
 
 // Context Loader (semantic search over a BKN via MCP)
 const cl      = client.contextLoader(mcpUrl, "bkn-id");
@@ -164,7 +173,7 @@ kweaver bkn action-execution get
 kweaver bkn action-log list/get/cancel
 kweaver agent list/get/create/update/delete/chat/sessions/history/publish/unpublish
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
-kweaver vega health/stats/inspect/catalog/resource/connector-type
+kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
 kweaver context-loader config set/use/list/show
 kweaver context-loader kn-search/query-object-instance/...
 kweaver call <path> [-X METHOD] [-d BODY] [-H header]

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -193,6 +193,20 @@ kweaver dataflow logs <dagId> <instanceId> --detail
 
 `kweaver dataflow runs --since` filters one local natural day. If the value cannot be parsed by `new Date(...)`, the CLI falls back to the most recent 20 runs. `kweaver dataflow logs` defaults to summary output; add `--detail` to print indented `input` and `output` payloads.
 
+### Vega `sql` CLI examples
+
+Direct SQL against catalog-backed resources (`POST /api/vega-backend/v1/resources/query`). In SQL, use **`{{<resource_id>}}`** or **`{{.<resource_id>}}`** (Vega resource id from `vega resource list` / `get`) so the backend resolves the physical table and connector. `--resource-type` accepts the connector type of the target data source (run `kweaver vega connector-type list` to see available types). In simple mode, **quote the entire `--query` value** so the shell does not treat `{` / `}` specially.
+
+```bash
+# Simple mode (recommended): avoid JSON-escaping the query string
+kweaver vega sql --resource-type mysql --query "SELECT * FROM {{res-1}} LIMIT 5"
+
+# Advanced mode: full JSON body (optional fields like query_timeout, stream_size, OpenSearch DSL object)
+kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT * FROM {{res-1}} LIMIT 5"}'
+```
+
+If both `-d` and `--query` / `--resource-type` are present, **only `-d` is used**.
+
 **No-auth platforms:** If OAuth is not enabled, use `kweaver auth <url> --no-auth` (or run a normal `auth login`; a **404** on `POST /oauth2/clients` switches to no-auth automatically). Credentials are still saved under `~/.kweaver/` and work with `auth use` / `auth list`. Optional: `KWEAVER_NO_AUTH=1` with `KWEAVER_BASE_URL` when no token env is set. SDK: `new KWeaverClient({ baseUrl, auth: false })` or `kweaver.configure({ baseUrl, auth: false })`.
 
 ## Environment Variables

--- a/packages/typescript/README.zh.md
+++ b/packages/typescript/README.zh.md
@@ -182,6 +182,20 @@ kweaver dataflow logs <dagId> <instanceId> --detail
 
 `kweaver dataflow runs --since` 会按本地自然日过滤；如果参数无法被 `new Date(...)` 解析，CLI 会回退到最近 20 条运行记录。`kweaver dataflow logs` 默认输出摘要；加上 `--detail` 会打印带缩进的 `input` 和 `output` 载荷。
 
+### Vega `sql` CLI 示例
+
+对 Catalog 资源执行直连 SQL（`POST /api/vega-backend/v1/resources/query`）。SQL 中使用 **`{{<resource_id>}}`** 或 **`{{.<resource_id>}}`**（资源 id 来自 `vega resource list` / `get`），后端据此解析物理表与 connector。`--resource-type` 为目标数据源的连接器类型，可通过 `kweaver vega connector-type list` 查看。简单模式下请**用引号包住整个 `--query` 参数**，避免 shell 对花括号做特殊处理。
+
+```bash
+# 简单模式（推荐）：避免在 JSON 里转义整段 SQL
+kweaver vega sql --resource-type mysql --query "SELECT * FROM {{res-1}} LIMIT 5"
+
+# 高级模式：完整 JSON（可带 query_timeout、stream_size，或 OpenSearch DSL 对象等）
+kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT * FROM {{res-1}} LIMIT 5"}'
+```
+
+若同时提供 `-d` 与 `--query` / `--resource-type`，**仅以 `-d` 为准**。
+
 **无 OAuth 的平台：** 使用 `kweaver auth <url> --no-auth`，或照常 `auth login`；若 `POST /oauth2/clients` 返回 **404**，CLI 会提示并自动保存为 no-auth。凭据仍在 `~/.kweaver/`，可用 `auth use` / `auth list` 切换。可选环境变量 `KWEAVER_NO_AUTH=1`（未设置 `KWEAVER_TOKEN` 时）配合 `KWEAVER_BASE_URL`。SDK：`new KWeaverClient({ baseUrl, auth: false })` 或 `kweaver.configure({ baseUrl, auth: false })`。
 
 ## 环境变量

--- a/packages/typescript/README.zh.md
+++ b/packages/typescript/README.zh.md
@@ -119,6 +119,19 @@ const queryRows = await client.dataviews.query(viewId, {
   needTotal: true,
 });
 
+// Vega — 可观测性与查询
+const catalogs = await client.vega.listCatalogs();
+const health   = await client.vega.health();
+// 结构化查询 — POST /api/vega-backend/v1/query/execute（body 为 JSON 字符串）
+const structured = await client.vega.executeQuery(
+  JSON.stringify({ tables: [{ resource_id: "res-1" }], output_fields: ["*"], limit: 20 }),
+);
+// 直连 SQL 或 OpenSearch DSL — POST /api/vega-backend/v1/resources/query
+// 使用 {{resource_id}} 占位符以路由到正确的 catalog connector
+const rows = await client.vega.sqlQuery(
+  JSON.stringify({ query: "SELECT * FROM {{res-1}} LIMIT 5", resource_type: "mysql" }),
+);
+
 // Context Loader（通过 MCP 对 BKN 做语义搜索）
 const cl      = client.contextLoader(mcpUrl, "bkn-id");
 const results = await cl.search({ query: "高血压 治疗" });
@@ -149,6 +162,7 @@ kweaver bkn action-execution get
 kweaver bkn action-log list/get/cancel
 kweaver agent list/get/chat/sessions/history
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
+kweaver vega health|stats|inspect|sql|catalog|resource|connector-type
 kweaver context-loader config set/use/list/show
 kweaver context-loader kn-search/query-object-instance/...
 kweaver call <path> [-X METHOD] [-d BODY] [-H header]

--- a/packages/typescript/src/api/vega.ts
+++ b/packages/typescript/src/api/vega.ts
@@ -838,6 +838,35 @@ export async function executeVegaQuery(options: ExecuteVegaQueryOptions): Promis
   return body;
 }
 
+// ── Resources SQL Query ──────────────────────────────────────────────────────
+
+export interface VegaSQLQueryOptions {
+  baseUrl: string;
+  accessToken: string;
+  body: string;
+  businessDomain?: string;
+}
+
+/** POST /api/vega-backend/v1/resources/query — direct SQL (or OpenSearch DSL) against catalog-backed resources. */
+export async function vegaSQLQuery(options: VegaSQLQueryOptions): Promise<string> {
+  const { baseUrl, accessToken, body: requestBody, businessDomain = "bd_public" } = options;
+  const base = baseUrl.replace(/\/+$/, "");
+  const url = `${base}${VEGA_BASE}/resources/query`;
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      ...buildHeaders(accessToken, businessDomain),
+      "content-type": "application/json",
+    },
+    body: requestBody,
+  });
+
+  const body = await response.text();
+  if (!response.ok) throw new HttpError(response.status, response.statusText, body);
+  return body;
+}
+
 // ── Resource List All ────────────────────────────────────────────────────────
 
 export interface ListAllVegaResourcesOptions {

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -103,6 +103,7 @@ Usage:
   kweaver vega health|stats|inspect
   kweaver vega catalog list|get|health|test-connection|discover|resources [options]
   kweaver vega resource list|get|query [options]
+  kweaver vega query execute|sql [options]
   kweaver vega connector-type list|get [options]
 
   kweaver context-loader config set|use|list|remove|show [options]
@@ -129,7 +130,7 @@ Commands:
                  object-type, relation-type, subgraph, action-type, action-execution, action-log)
   config         Per-platform configuration (business domain)
   skill          Skill registry and market (register, search, progressive read, download/install)
-  vega           Vega observability (catalog, resource, connector-type, health/stats/inspect)
+  vega           Vega observability (catalog, resource, query/sql, connector-type, health/stats/inspect)
   context-loader Context-loader MCP (config, tools, resources, prompts, kn-search, query-*, etc.)
   help           Show this message`);
 }

--- a/packages/typescript/src/commands/vega.ts
+++ b/packages/typescript/src/commands/vega.ts
@@ -30,6 +30,7 @@ import {
   buildVegaDataset,
   getVegaDatasetBuildStatus,
   executeVegaQuery,
+  vegaSQLQuery,
   listAllVegaResources,
 } from "../api/vega.js";
 import { formatCallOutput } from "./call.js";
@@ -68,7 +69,8 @@ Subcommands:
   dataset delete-docs-query <resource-id> -d <filter-json>
   dataset build <resource-id> [--mode full|incremental|realtime]
   dataset build-status <resource-id> <task-id>
-  query execute -d <json>
+  query execute -d <json>               Structured query (tables, joins, filters)
+  sql -d <json>                         Direct SQL / DSL (POST /resources/query)
   connector-type list                 List connector types
   connector-type get <type>           Get connector type details
   connector-type register -d <json>   Register a new connector type
@@ -141,6 +143,7 @@ export async function runVegaCommand(args: string[]): Promise<number> {
     if (subcommand === "resource") return runVegaResourceCommand(rest);
     if (subcommand === "dataset") return runVegaDatasetCommand(rest);
     if (subcommand === "query") return runVegaQueryCommand(rest);
+    if (subcommand === "sql") return runVegaSql(rest);
     if (subcommand === "connector-type") return runVegaConnectorTypeCommand(rest);
     return Promise.resolve(-1);
   };
@@ -1414,6 +1417,57 @@ Options:
 
   const token = await ensureValidToken();
   const body = await executeVegaQuery({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    body: data,
+    businessDomain,
+  });
+  console.log(formatCallOutput(body, pretty));
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// sql (POST /resources/query)
+// ---------------------------------------------------------------------------
+
+async function runVegaSql(args: string[]): Promise<number> {
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(`kweaver vega sql -d <json>
+
+POST /api/vega-backend/v1/resources/query — execute SQL (MySQL/MariaDB/PostgreSQL) or OpenSearch DSL.
+
+Body fields:
+  query          (required) SQL string or OpenSearch DSL object
+  resource_type  (required) one of: mysql, mariadb, postgresql, opensearch
+  stream_size    optional batch size for streaming (100–10000, default 10000)
+  query_timeout  optional seconds (1–3600, default 60)
+  query_id       optional cursor session id
+
+SQL may use {{.<vega_resource_id>}} or {{vega_resource_id}} placeholders; each token is the literal Vega resource id, replaced with that resource's physical table id (SourceIdentifier). Without placeholders, native SQL is allowed if the DB accepts the table names.
+
+Options:
+  -d, --data <json>   Request body (JSON string)`);
+    return 0;
+  }
+
+  let data: string | undefined;
+  const { remaining, businessDomain, pretty } = parseCommonFlags(args);
+
+  for (let i = 0; i < remaining.length; i += 1) {
+    const arg = remaining[i];
+    if ((arg === "-d" || arg === "--data") && remaining[i + 1]) {
+      data = remaining[++i];
+      continue;
+    }
+  }
+
+  if (!data) {
+    console.error("Usage: kweaver vega sql -d <json>");
+    return 1;
+  }
+
+  const token = await ensureValidToken();
+  const body = await vegaSQLQuery({
     baseUrl: token.baseUrl,
     accessToken: token.accessToken,
     body: data,

--- a/packages/typescript/src/commands/vega.ts
+++ b/packages/typescript/src/commands/vega.ts
@@ -70,7 +70,8 @@ Subcommands:
   dataset build <resource-id> [--mode full|incremental|realtime]
   dataset build-status <resource-id> <task-id>
   query execute -d <json>               Structured query (tables, joins, filters)
-  sql -d <json>                         Direct SQL / DSL (POST /resources/query)
+  sql --resource-type <t> --query <sql>  Direct SQL / DSL; use {{<resource_id>}} in SQL (quoted)
+  sql -d <json>                         Same API with full JSON body (advanced)
   connector-type list                 List connector types
   connector-type get <type>           Get connector type details
   connector-type register -d <json>   Register a new connector type
@@ -1432,52 +1433,96 @@ Options:
 
 async function runVegaSql(args: string[]): Promise<number> {
   if (args.includes("--help") || args.includes("-h")) {
-    console.log(`kweaver vega sql -d <json>
+    console.log(`kweaver vega sql --resource-type <type> --query "<sql-or-dsl>"
+kweaver vega sql -d <json>
 
 POST /api/vega-backend/v1/resources/query — execute SQL (MySQL/MariaDB/PostgreSQL) or OpenSearch DSL.
 
-Body fields:
+Simple mode (no JSON escaping for query + type):
+  --resource-type <t>   Required with --query unless using -d
+  --query <string>      One shell argument: the full SQL (or DSL string). Always quote it.
+
+Advanced mode (full request body, optional fields):
+  -d, --data <json>     Raw JSON body. When present, this mode is used and any --query / --resource-type are ignored.
+
+Resource placeholders (how to reference Vega tables in SQL):
+  {{<resource_id>}}     Required token form: double braces around the Vega resource id (from vega resource list / get).
+  {{.<resource_id>}}    Alternate form with a dot after {{ ; same replacement and routing.
+
+  The backend swaps each placeholder for that resource's physical SourceIdentifier and picks the catalog connector.
+  Without at least one placeholder, queries often fail (e.g. connector config is incomplete) unless a default connector exists.
+
+  Shell (simple mode) — wrap the whole SQL so braces are not interpreted by the shell:
+    kweaver vega sql --resource-type mysql --query "SELECT * FROM {{abc123xyz}} LIMIT 5"
+
+  Shell (-d mode) — placeholders live inside the JSON string value; use single quotes around the JSON so inner double quotes work:
+    kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT * FROM {{abc123xyz}} LIMIT 5"}'
+
+Body fields (JSON / simple mode mapping):
   query          (required) SQL string or OpenSearch DSL object
-  resource_type  (required) one of: mysql, mariadb, postgresql, opensearch
+  resource_type  (required) e.g. mysql, mariadb, postgresql, opensearch (see vega connector-type list)
   stream_size    optional batch size for streaming (100–10000, default 10000)
   query_timeout  optional seconds (1–3600, default 60)
   query_id       optional cursor session id
 
-SQL should use {{<vega_resource_id>}} or {{.<vega_resource_id>}} placeholders; the backend replaces each with the resource's physical table id (SourceIdentifier) and routes the query through the owning catalog's connector. Without placeholders the backend may fail with "connector config is incomplete" if no default connector is configured.
+Do not use --type; use --resource-type.
 
-Options:
-  -d, --data <json>   Request body (JSON string)`);
+Common flags:
+  -bd, --biz-domain <s>   Business domain (default: bd_public)
+  --pretty               Pretty-print JSON (default)`);
     return 0;
   }
 
   let data: string | undefined;
+  let query: string | undefined;
+  let resourceType: string | undefined;
   const { remaining, businessDomain, pretty } = parseCommonFlags(args);
 
   for (let i = 0; i < remaining.length; i += 1) {
     const arg = remaining[i];
+    if (arg === "--type") {
+      console.error("Use --resource-type instead of --type (e.g. --resource-type mysql).");
+      return 1;
+    }
     if ((arg === "-d" || arg === "--data") && remaining[i + 1]) {
       data = remaining[++i];
       continue;
     }
+    if (arg === "--query" && remaining[i + 1]) {
+      query = remaining[++i];
+      continue;
+    }
+    if (arg === "--resource-type" && remaining[i + 1]) {
+      resourceType = remaining[++i];
+      continue;
+    }
   }
 
-  if (!data) {
-    console.error("Usage: kweaver vega sql -d <json>");
-    return 1;
-  }
+  let requestBody: string;
 
-  try {
-    JSON.parse(data);
-  } catch {
-    console.error(`Invalid JSON: ${data}`);
-    return 1;
+  if (data !== undefined) {
+    try {
+      JSON.parse(data);
+    } catch {
+      console.error(`Invalid JSON: ${data}`);
+      return 1;
+    }
+    requestBody = data;
+  } else {
+    if (!query || !resourceType) {
+      console.error(
+        "Usage: kweaver vega sql --resource-type <type> --query \"<sql-or-dsl>\"\n       kweaver vega sql -d <json>",
+      );
+      return 1;
+    }
+    requestBody = JSON.stringify({ query, resource_type: resourceType });
   }
 
   const token = await ensureValidToken();
   const body = await vegaSQLQuery({
     baseUrl: token.baseUrl,
     accessToken: token.accessToken,
-    body: data,
+    body: requestBody,
     businessDomain,
   });
   console.log(formatCallOutput(body, pretty));

--- a/packages/typescript/src/commands/vega.ts
+++ b/packages/typescript/src/commands/vega.ts
@@ -1443,7 +1443,7 @@ Body fields:
   query_timeout  optional seconds (1–3600, default 60)
   query_id       optional cursor session id
 
-SQL may use {{.<vega_resource_id>}} or {{vega_resource_id}} placeholders; each token is the literal Vega resource id, replaced with that resource's physical table id (SourceIdentifier). Without placeholders, native SQL is allowed if the DB accepts the table names.
+SQL should use {{<vega_resource_id>}} or {{.<vega_resource_id>}} placeholders; the backend replaces each with the resource's physical table id (SourceIdentifier) and routes the query through the owning catalog's connector. Without placeholders the backend may fail with "connector config is incomplete" if no default connector is configured.
 
 Options:
   -d, --data <json>   Request body (JSON string)`);
@@ -1463,6 +1463,13 @@ Options:
 
   if (!data) {
     console.error("Usage: kweaver vega sql -d <json>");
+    return 1;
+  }
+
+  try {
+    JSON.parse(data);
+  } catch {
+    console.error(`Invalid JSON: ${data}`);
     return 1;
   }
 

--- a/packages/typescript/src/resources/vega.ts
+++ b/packages/typescript/src/resources/vega.ts
@@ -22,6 +22,7 @@ import {
   buildVegaDataset,
   getVegaDatasetBuildStatus,
   executeVegaQuery,
+  vegaSQLQuery,
   listAllVegaResources,
   listVegaConnectorTypes,
   getVegaConnectorType,
@@ -185,6 +186,12 @@ export class VegaResource {
 
   async executeQuery(body: string): Promise<unknown> {
     const raw = await executeVegaQuery({ ...this.ctx.base(), body });
+    return JSON.parse(raw);
+  }
+
+  /** POST /resources/query — direct SQL or OpenSearch DSL (see kweaver vega sql --help). */
+  async sqlQuery(body: string): Promise<unknown> {
+    const raw = await vegaSQLQuery({ ...this.ctx.base(), body });
     return JSON.parse(raw);
   }
 

--- a/packages/typescript/test/vega.test.ts
+++ b/packages/typescript/test/vega.test.ts
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { KWeaverClient } from "../src/client.js";
+import { runVegaCommand } from "../src/commands/vega.js";
 
 const BASE = "https://mock.kweaver.test";
 const TOKEN = "test-token-abc";
@@ -225,4 +230,135 @@ test("vega resource has no previewResource method (backend has no preview endpoi
     "undefined",
     "previewResource should not exist — backend has no /resources/{id}/preview endpoint",
   );
+});
+
+// ── vega sql CLI: flag mode vs -d ───────────────────────────────────────────
+
+function createVegaCliConfigDir(): string {
+  return mkdtempSync(join(tmpdir(), "kweaver-vega-sql-cli-"));
+}
+
+async function importStoreForVegaCli(configDir: string) {
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const moduleUrl = pathToFileURL(join(process.cwd(), "src/config/store.ts")).href;
+  return import(`${moduleUrl}?t=${Date.now()}-${Math.random()}`);
+}
+
+async function setupVegaCliToken(configDir: string, baseUrl = "https://mock.kweaver.test"): Promise<void> {
+  const store = await importStoreForVegaCli(configDir);
+  store.saveTokenConfig({
+    baseUrl,
+    accessToken: "token-abc",
+    tokenType: "Bearer",
+    scope: "openid offline all",
+    obtainedAt: new Date().toISOString(),
+  });
+  store.setCurrentPlatform(baseUrl);
+}
+
+async function runVegaSqlCli(
+  configDir: string,
+  sqlArgs: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...values: unknown[]) => stdout.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => stderr.push(values.map(String).join(" "));
+  try {
+    const code = await runVegaCommand(["sql", ...sqlArgs]);
+    return { code, stdout: stdout.join("\n"), stderr: stderr.join("\n") };
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+}
+
+test("vega sql flag mode posts query and resource_type JSON", async () => {
+  const configDir = createVegaCliConfigDir();
+  await setupVegaCliToken(configDir);
+  const mock = mockFetch({ columns: [{ name: "x" }], entries: [{ x: 1 }], total_count: 1 });
+  try {
+    const r = await runVegaSqlCli(configDir, [
+      "--resource-type",
+      "mysql",
+      "--query",
+      "SELECT 1 AS x",
+    ]);
+    assert.equal(r.code, 0);
+    assert.equal(mock.calls[0].method, "POST");
+    const url = new URL(mock.calls[0].url);
+    assert.equal(url.pathname, "/api/vega-backend/v1/resources/query");
+    const body = JSON.parse(mock.calls[0].body!);
+    assert.equal(body.query, "SELECT 1 AS x");
+    assert.equal(body.resource_type, "mysql");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("vega sql rejects --type with guidance", async () => {
+  const configDir = createVegaCliConfigDir();
+  await setupVegaCliToken(configDir);
+  const mock = mockFetch({});
+  try {
+    const r = await runVegaSqlCli(configDir, ["--type", "mysql", "--query", "SELECT 1"]);
+    assert.equal(r.code, 1);
+    assert.match(r.stderr, /--resource-type/);
+    assert.equal(mock.calls.length, 0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("vega sql flag mode requires both --query and --resource-type", async () => {
+  const configDir = createVegaCliConfigDir();
+  await setupVegaCliToken(configDir);
+  const mock = mockFetch({});
+  try {
+    const r = await runVegaSqlCli(configDir, ["--resource-type", "mysql"]);
+    assert.equal(r.code, 1);
+    assert.match(r.stderr, /Usage:/);
+    assert.equal(mock.calls.length, 0);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("vega sql flag mode passes arbitrary --resource-type to backend", async () => {
+  const configDir = createVegaCliConfigDir();
+  await setupVegaCliToken(configDir);
+  const mock = mockFetch({ ok: true });
+  try {
+    const r = await runVegaSqlCli(configDir, ["--resource-type", "oracle", "--query", "SELECT 1"]);
+    assert.equal(r.code, 0);
+    const body = JSON.parse(mock.calls[0].body!);
+    assert.equal(body.resource_type, "oracle");
+  } finally {
+    mock.restore();
+  }
+});
+
+test("vega sql -d mode ignores --query and --resource-type (precedence)", async () => {
+  const configDir = createVegaCliConfigDir();
+  await setupVegaCliToken(configDir);
+  const mock = mockFetch({ ok: true });
+  try {
+    const r = await runVegaSqlCli(configDir, [
+      "-d",
+      JSON.stringify({ query: "SELECT 1", resource_type: "mysql" }),
+      "--resource-type",
+      "postgresql",
+      "--query",
+      "SELECT 2",
+    ]);
+    assert.equal(r.code, 0);
+    const body = JSON.parse(mock.calls[0].body!);
+    assert.equal(body.query, "SELECT 1");
+    assert.equal(body.resource_type, "mysql");
+  } finally {
+    mock.restore();
+  }
 });

--- a/packages/typescript/test/vega.test.ts
+++ b/packages/typescript/test/vega.test.ts
@@ -199,6 +199,25 @@ test("setVegaConnectorTypeEnabled sends POST to /connector-types/:type/enabled",
   }
 });
 
+test("sqlQuery sends POST to /resources/query with JSON body", async () => {
+  const mock = mockFetch({ columns: [{ name: "x", type: "int" }], entries: [{ x: 1 }], total_count: 1 });
+  try {
+    const client = makeClient();
+    const result = await client.vega.sqlQuery(
+      JSON.stringify({ query: "SELECT 1 AS x", resource_type: "mysql" }),
+    );
+    assert.equal(mock.calls[0].method, "POST");
+    const url = new URL(mock.calls[0].url);
+    assert.equal(url.pathname, "/api/vega-backend/v1/resources/query");
+    const body = JSON.parse(mock.calls[0].body!);
+    assert.equal(body.query, "SELECT 1 AS x");
+    assert.equal(body.resource_type, "mysql");
+    assert.deepEqual((result as Record<string, unknown>).entries, [{ x: 1 }]);
+  } finally {
+    mock.restore();
+  }
+});
+
 test("vega resource has no previewResource method (backend has no preview endpoint)", () => {
   const client = makeClient();
   assert.equal(

--- a/skills/kweaver-core/SKILL.md
+++ b/skills/kweaver-core/SKILL.md
@@ -71,7 +71,7 @@ kweaver [--user <userId|username>] <command> [subcommand] [options]
 | `dataview` | 原子/自定义数据视图（mdl-data-model） | `dataview list`、`find --name`、`get`、`query`（SQL / mdl-uniquery）、`delete` | `references/dataview.md` |
 | `dataflow` | Dataflow 文档流程 | `dataflow list`, `dataflow run <dagId> --file <path>`, `dataflow run <dagId> --url <remote-url> --name <filename>`, `dataflow runs <dagId> [--since <date-like>]`, `dataflow logs <dagId> <instanceId> [--detail]` | `references/dataflow.md` |
 | `skill` | Skill 注册、市场查找、渐进式读取、下载与安装 | `skill list`、`market`、`register --zip-file`、`content`、`read-file`、`install` | `references/skill.md` |
-| `vega` | Vega 可观测平台 | `vega health`, `vega catalog list`, `vega resource list`, `vega query execute -d <json>`, `vega sql -d <json>` | `references/vega.md` |
+| `vega` | Vega 可观测平台 | `vega health`, `vega catalog list`, `vega resource list`, `vega query execute -d <json>`, `vega sql --resource-type <t> --query "<sql>"` / `vega sql -d <json>` | `references/vega.md` |
 | `context-loader` | MCP 分层检索 | `context-loader config show`, `context-loader kn-search <query>` | `references/context-loader.md` |
 | `call` | 通用 API 调用 | `call <url> [-X POST] [-d '...']`（可用 `curl` 别名；支持 `--url`、`--data-raw` 等，见 `kweaver --help`） | `references/call.md` |
 

--- a/skills/kweaver-core/SKILL.md
+++ b/skills/kweaver-core/SKILL.md
@@ -71,7 +71,7 @@ kweaver [--user <userId|username>] <command> [subcommand] [options]
 | `dataview` | 原子/自定义数据视图（mdl-data-model） | `dataview list`、`find --name`、`get`、`query`（SQL / mdl-uniquery）、`delete` | `references/dataview.md` |
 | `dataflow` | Dataflow 文档流程 | `dataflow list`, `dataflow run <dagId> --file <path>`, `dataflow run <dagId> --url <remote-url> --name <filename>`, `dataflow runs <dagId> [--since <date-like>]`, `dataflow logs <dagId> <instanceId> [--detail]` | `references/dataflow.md` |
 | `skill` | Skill 注册、市场查找、渐进式读取、下载与安装 | `skill list`、`market`、`register --zip-file`、`content`、`read-file`、`install` | `references/skill.md` |
-| `vega` | Vega 可观测平台 | `vega health`, `vega catalog list`, `vega resource list` | `references/vega.md` |
+| `vega` | Vega 可观测平台 | `vega health`, `vega catalog list`, `vega resource list`, `vega query execute -d <json>`, `vega sql -d <json>` | `references/vega.md` |
 | `context-loader` | MCP 分层检索 | `context-loader config show`, `context-loader kn-search <query>` | `references/context-loader.md` |
 | `call` | 通用 API 调用 | `call <url> [-X POST] [-d '...']`（可用 `curl` 别名；支持 `--url`、`--data-raw` 等，见 `kweaver --help`） | `references/call.md` |
 

--- a/skills/kweaver-core/references/vega.md
+++ b/skills/kweaver-core/references/vega.md
@@ -37,7 +37,7 @@ kweaver vega catalog create \
   --pretty
 ```
 
-- `connector-type` 可选值：`mysql` / `mariadb` / `postgresql` / `opensearch`
+- `connector-type` 取值通过 `kweaver vega connector-type list` 获取（常见：`mysql` / `mariadb` / `postgresql` / `opensearch`）
 - `connector-config` 字段因类型而异，用 `kweaver vega connector-type get <type>` 查看 `field_config`
 - 注册时后端会**测试连接**，密码错误或网络不通会被拒绝
 - **注意**：`host` 需用 Vega 后端容器能访问的地址（通常是 Docker/K8s 内网 IP，而非公网 IP）
@@ -128,16 +128,22 @@ kweaver vega query execute -d '{
 `POST /api/vega-backend/v1/resources/query` — 在 **MySQL / MariaDB / PostgreSQL** 上执行 SQL，或在 **OpenSearch** 上执行 DSL；由 vega-backend 直连数据源并可用 sqlglot 做方言转换。**不依赖** Etrino / Trino。
 
 ```bash
+# Simple mode (no JSON body): --resource-type + --query（SQL 须用引号包住；占位符 {{id}} 或 {{.id}}）
+kweaver vega sql --resource-type mysql --query "SELECT * FROM {{<your_resource_id>}} LIMIT 5"
+
+# Advanced mode: full JSON (stream_size, query_timeout, query_id, OpenSearch DSL object, etc.)
 kweaver vega sql -d '<json>'
 kweaver vega sql --help
 ```
+
+当同时使用 `-d` 与 `--query` / `--resource-type` 时，**仅使用 `-d` 的请求体**（后者被忽略）。
 
 请求体字段：
 
 | 字段 | 说明 |
 |------|------|
 | `query` | 必填。SQL 字符串，或 OpenSearch 的 DSL 对象 |
-| `resource_type` | 必填。`mysql` \| `mariadb` \| `postgresql` \| `opensearch` |
+| `resource_type` | 必填。如 `mysql`、`mariadb`、`postgresql`、`opensearch`（以 `vega connector-type list` 返回为准） |
 | `stream_size` | 可选，流式批次 100–10000，默认 10000 |
 | `query_timeout` | 可选，秒，1–3600，默认 60 |
 | `query_id` | 可选，游标会话 |
@@ -146,23 +152,26 @@ SQL 中**应使用**占位符 `{{.<资源ID>}}` 或 `{{<资源ID>}}`，**资源 
 
 > **重要**：占位符是 vega-backend 识别使用哪个 Catalog connector 的依据。不含占位符的裸 SQL（即便传了 `catalog_id`）可能因全局默认 connector 未配置而失败（`connector config is incomplete`）。**推荐始终使用 `{{resource_id}}` 占位符。**
 
-示例（占位符）：
+示例（占位符，简单模式）：
+
+```bash
+kweaver vega sql --resource-type mysql --query "SELECT supplier_name, city FROM {{<your_resource_id>}} LIMIT 5"
+```
+
+（将 `<your_resource_id>` 换为 `vega resource get` 返回的资源 id。）
+
+统计聚合示例（简单模式）：
+
+```bash
+kweaver vega sql --resource-type mysql --query "SELECT city, COUNT(*) AS cnt FROM {{<resource_id>}} GROUP BY city ORDER BY cnt DESC"
+```
+
+等价 JSON 模式示例：
 
 ```bash
 kweaver vega sql -d '{
   "resource_type":"mysql",
   "query":"SELECT supplier_name, city FROM {{<your_resource_id>}} LIMIT 5"
-}'
-```
-
-（将 `<your_resource_id>` 换为 `vega resource get` 返回的资源 id。）
-
-统计聚合示例：
-
-```bash
-kweaver vega sql -d '{
-  "resource_type":"mysql",
-  "query":"SELECT city, COUNT(*) AS cnt FROM {{<resource_id>}} GROUP BY city ORDER BY cnt DESC"
 }'
 ```
 
@@ -224,5 +233,6 @@ kweaver vega resource query <resource-id> -d '{"limit":10,"offset":0}'
 kweaver vega query execute -d '{"tables":[{"resource_id":"<id>"}],"limit":20}'
 
 # 直连 SQL（必须用 {{resource_id}} 占位符路由到正确的 connector）
-kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT * FROM {{<resource-id>}} LIMIT 10"}'
+kweaver vega sql --resource-type mysql --query "SELECT * FROM {{<resource-id>}} LIMIT 10"
+# 或完整 JSON：kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT * FROM {{<resource-id>}} LIMIT 10"}'
 ```

--- a/skills/kweaver-core/references/vega.md
+++ b/skills/kweaver-core/references/vega.md
@@ -27,9 +27,107 @@ kweaver vega catalog resources <id> [--category table|index|...] [--limit N]
 ```bash
 kweaver vega resource list [--catalog-id <id>] [--category table] [--status active] [--limit N] [--offset N]
 kweaver vega resource get <id>
-kweaver vega resource query <id> -d '<json-body>'
+kweaver vega resource query <id> -d '<json-body>'   # POST .../resources/:id/data（结构化过滤、分页）
 kweaver vega resource preview <id> [--limit N]
 ```
+
+## 结构化查询（vega-backend）
+
+`POST /api/vega-backend/v1/query/execute` — 单 Catalog 内多表 JOIN、过滤、排序、分页；**不经过** `vega-calculate-coordinator`（Trino）。
+
+```bash
+kweaver vega query execute -d '<json>'
+```
+
+请求体字段：
+
+| 字段 | 说明 |
+|------|------|
+| `query_id` | 同一轮分页保持一致；首页 `offset=0` 可不传，后端生成 |
+| `tables` | 必填。`[{ "resource_id": "...", "alias": "t1" }]` |
+| `joins` | 可选。`type`: inner / left / right / full；`left_table_alias` / `right_table_alias`；`on`: `[{ "left_field", "right_field" }]`（**JOIN ON 使用 schema 中的字段名**，与 `resource get` 中 `schema_definition[].name` 一致） |
+| `output_fields` | 可选，如 `["t1.col_a", "t2.col_b"]` |
+| `filter_condition` | 可选，见下方 |
+| `sort` | 可选，`[{ "field": "t1.col", "direction": "asc|desc" }]` |
+| `offset` / `limit` | 分页；`limit` 最大 10000 |
+| `need_total` | 是否返回 `total_count` |
+
+**限制**：所有 `tables` 必须属于**同一** Catalog；跨 Catalog JOIN 会返回 501。
+
+**filter_condition** 常用 `operation`：
+
+- 比较：`==` / `eq`，`!=` / `not_eq`，`>` / `gt`，`>=` / `gte`，`<` / `lt`，`<=` / `lte`
+- 集合：`in`，`not_in`（值为数组）
+- 模糊：`like`，`not_like`（**仅当字段在 schema 中为 string 类型时**）
+- 范围：`range`（数值或日期字段，值为 `[min, max]`）
+- 空值：`null`，`not_null`
+- 逻辑：`and` / `or`，子条件放在 `sub_conditions` 数组中
+
+叶子条件通常含：`field`、`operation`、`value`、`value_from`（常量用 `"const"`）。
+
+示例（单表）：
+
+```bash
+kweaver vega query execute -d '{"tables":[{"resource_id":"<res-id>"}],"limit":5,"need_total":true}'
+```
+
+示例（两表 JOIN + 过滤）：
+
+```bash
+kweaver vega query execute -d '{
+  "tables": [
+    {"resource_id":"<id-a>","alias":"a"},
+    {"resource_id":"<id-b>","alias":"b"}
+  ],
+  "joins":[{"type":"inner","left_table_alias":"a","right_table_alias":"b","on":[{"left_field":"fk_col","right_field":"pk_col"}]}],
+  "output_fields":["a.name","b.amount"],
+  "filter_condition":{"field":"a.status","operation":"==","value":"active","value_from":"const"},
+  "limit":10
+}'
+```
+
+## SQL 查询（vega-backend）
+
+`POST /api/vega-backend/v1/resources/query` — 在 **MySQL / MariaDB / PostgreSQL** 上执行 SQL，或在 **OpenSearch** 上执行 DSL；由 vega-backend 直连数据源并可用 sqlglot 做方言转换。**不依赖** Etrino / Trino。
+
+```bash
+kweaver vega sql -d '<json>'
+kweaver vega sql --help
+```
+
+请求体字段：
+
+| 字段 | 说明 |
+|------|------|
+| `query` | 必填。SQL 字符串，或 OpenSearch 的 DSL 对象 |
+| `resource_type` | 必填。`mysql` \| `mariadb` \| `postgresql` \| `opensearch` |
+| `stream_size` | 可选，流式批次 100–10000，默认 10000 |
+| `query_timeout` | 可选，秒，1–3600，默认 60 |
+| `query_id` | 可选，游标会话 |
+
+SQL 中可使用占位符 `{{.<资源ID>}}` 或 `{{<资源ID>}}`，**资源 ID** 为 Vega 资源 id（与 `vega resource get` 一致）；后端会替换为该资源的物理表标识（`SourceIdentifier`）。无占位符时也可提交**原生 SQL**（仍需 `resource_type`），表名需符合目标库语法。
+
+示例（占位符）：
+
+```bash
+kweaver vega sql -d '{
+  "resource_type":"mysql",
+  "query":"SELECT * FROM {{.d75jdh40iradml79p6f0}} LIMIT 5"
+}'
+```
+
+（将 `d75jdh40iradml79p6f0` 换为你的 `resource_id`。）
+
+响应含 `columns`、`entries`、`total_count`、`stats`（含 `has_more`、`search_after` 等，用于流式/分页）。
+
+## 三种查询方式对照
+
+| 方式 | 命令 / 路径 | 适用场景 |
+|------|-------------|----------|
+| 结构化查询 | `vega query execute` | 单 Catalog 内表/JOIN、统一 filter DSL、offset 分页 |
+| 直连 SQL | `vega sql` | 复杂 SQL、聚合、或 `{{.<资源ID>}}` / `{{<资源ID>}}` 占位符 |
+| 资源数据 API | `vega resource query <id> -d {...}` | 按单个 resource 拉数（filter、sort、search_after） |
+| Dataview + `--sql` | `dataview query ... --sql` | 走 **mdl-uniquery + Trino**，需 Etrino / coordinator |
 
 ## Connector Type
 
@@ -59,8 +157,14 @@ kweaver vega catalog resources <catalog-id> --category table
 # 预览资源数据
 kweaver vega resource preview <resource-id> --limit 5
 
-# 查询资源数据
-kweaver vega resource query <resource-id> -d '{"page": 1, "limit": 10}'
+# 查询资源数据（结构化 body）
+kweaver vega resource query <resource-id> -d '{"limit":10,"offset":0}'
+
+# 结构化多表查询
+kweaver vega query execute -d '{"tables":[{"resource_id":"<id>"}],"limit":20}'
+
+# 直连 SQL
+kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT 1 AS one"}'
 
 # 查看连接器类型
 kweaver vega connector-type list

--- a/skills/kweaver-core/references/vega.md
+++ b/skills/kweaver-core/references/vega.md
@@ -16,10 +16,44 @@ kweaver vega inspect                 # 聚合诊断（health + catalog 数量 + 
 ```bash
 kweaver vega catalog list [--status healthy|degraded|unhealthy|offline|disabled] [--limit N] [--offset N]
 kweaver vega catalog get <id>
+kweaver vega catalog create --name <n> --connector-type <t> --connector-config <json> [--tags t1,t2] [--description s]
+kweaver vega catalog update <id> [--name X] [--connector-type X] [--tags X] [--description X]
+kweaver vega catalog delete <ids...> [-y]
 kweaver vega catalog health <ids...> | --all
 kweaver vega catalog test-connection <id>
 kweaver vega catalog discover <id> [--wait]
 kweaver vega catalog resources <id> [--category table|index|...] [--limit N]
+```
+
+### Catalog 注册（关键流程）
+
+要通过 `vega sql` 查询 MySQL / PostgreSQL 等外部数据库，**必须先在 Vega 注册物理 Catalog**：
+
+```bash
+kweaver vega catalog create \
+  --name "my_mysql" \
+  --connector-type mysql \
+  --connector-config '{"host":"<db-host>","port":3306,"username":"<user>","password":"<pass>","databases":["<db>"]}' \
+  --pretty
+```
+
+- `connector-type` 可选值：`mysql` / `mariadb` / `postgresql` / `opensearch`
+- `connector-config` 字段因类型而异，用 `kweaver vega connector-type get <type>` 查看 `field_config`
+- 注册时后端会**测试连接**，密码错误或网络不通会被拒绝
+- **注意**：`host` 需用 Vega 后端容器能访问的地址（通常是 Docker/K8s 内网 IP，而非公网 IP）
+
+注册成功后，需**创建 Resource** 将物理表映射为 Vega 资源（`catalog discover` 可自动扫描；若 Redis 不可用则需手动创建）：
+
+```bash
+# 自动发现（需 Redis）
+kweaver vega catalog discover <catalog-id> --wait
+
+# 或手动创建
+kweaver vega resource create \
+  --catalog-id <catalog-id> \
+  --name "my_table" \
+  --category table \
+  -d '{"source_identifier":"<db>.<table>"}'
 ```
 
 ## Resource
@@ -27,6 +61,9 @@ kweaver vega catalog resources <id> [--category table|index|...] [--limit N]
 ```bash
 kweaver vega resource list [--catalog-id <id>] [--category table] [--status active] [--limit N] [--offset N]
 kweaver vega resource get <id>
+kweaver vega resource create --catalog-id <cid> --name <n> --category <cat> [-d <json>]
+kweaver vega resource update <id> [--name X] [--status X] [--tags X] [-d json]
+kweaver vega resource delete <ids...> [-y]
 kweaver vega resource query <id> -d '<json-body>'   # POST .../resources/:id/data（结构化过滤、分页）
 kweaver vega resource preview <id> [--limit N]
 ```
@@ -105,18 +142,29 @@ kweaver vega sql --help
 | `query_timeout` | 可选，秒，1–3600，默认 60 |
 | `query_id` | 可选，游标会话 |
 
-SQL 中可使用占位符 `{{.<资源ID>}}` 或 `{{<资源ID>}}`，**资源 ID** 为 Vega 资源 id（与 `vega resource get` 一致）；后端会替换为该资源的物理表标识（`SourceIdentifier`）。无占位符时也可提交**原生 SQL**（仍需 `resource_type`），表名需符合目标库语法。
+SQL 中**应使用**占位符 `{{.<资源ID>}}` 或 `{{<资源ID>}}`，**资源 ID** 为 Vega 资源 id（与 `vega resource get` 一致）；后端会替换为该资源的物理表标识（`SourceIdentifier`），并**通过资源所属 Catalog 的 connector 连接数据库**。
+
+> **重要**：占位符是 vega-backend 识别使用哪个 Catalog connector 的依据。不含占位符的裸 SQL（即便传了 `catalog_id`）可能因全局默认 connector 未配置而失败（`connector config is incomplete`）。**推荐始终使用 `{{resource_id}}` 占位符。**
 
 示例（占位符）：
 
 ```bash
 kweaver vega sql -d '{
   "resource_type":"mysql",
-  "query":"SELECT * FROM {{.d75jdh40iradml79p6f0}} LIMIT 5"
+  "query":"SELECT supplier_name, city FROM {{d7fks20ce1oc73ds19sg}} LIMIT 5"
 }'
 ```
 
-（将 `d75jdh40iradml79p6f0` 换为你的 `resource_id`。）
+（将 `d7fks20ce1oc73ds19sg` 换为你的 `resource_id`。）
+
+统计聚合示例：
+
+```bash
+kweaver vega sql -d '{
+  "resource_type":"mysql",
+  "query":"SELECT city, COUNT(*) AS cnt FROM {{<resource_id>}} GROUP BY city ORDER BY cnt DESC"
+}'
+```
 
 响应含 `columns`、`entries`、`total_count`、`stats`（含 `has_more`、`search_after` 等，用于流式/分页）。
 
@@ -150,6 +198,18 @@ kweaver vega connector-type get <type>
 kweaver vega inspect
 kweaver vega catalog health --all
 
+# ── 注册外部数据库为 Catalog ──
+kweaver vega connector-type list                     # 查看可用连接器
+kweaver vega connector-type get mysql                # 查看 MySQL 连接参数
+kweaver vega catalog create --name "my_db" \
+  --connector-type mysql \
+  --connector-config '{"host":"172.19.0.9","port":3306,"username":"user","password":"pass","databases":["mydb"]}'
+
+# ── 创建 Resource（手动 / 或 discover 自动扫描）──
+kweaver vega resource create --catalog-id <catalog-id> \
+  --name "orders" --category table \
+  -d '{"source_identifier":"mydb.orders"}'
+
 # 查看 catalog 下的资源
 kweaver vega catalog list
 kweaver vega catalog resources <catalog-id> --category table
@@ -163,9 +223,6 @@ kweaver vega resource query <resource-id> -d '{"limit":10,"offset":0}'
 # 结构化多表查询
 kweaver vega query execute -d '{"tables":[{"resource_id":"<id>"}],"limit":20}'
 
-# 直连 SQL
-kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT 1 AS one"}'
-
-# 查看连接器类型
-kweaver vega connector-type list
+# 直连 SQL（必须用 {{resource_id}} 占位符路由到正确的 connector）
+kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT * FROM {{<resource-id>}} LIMIT 10"}'
 ```

--- a/skills/kweaver-core/references/vega.md
+++ b/skills/kweaver-core/references/vega.md
@@ -151,11 +151,11 @@ SQL 中**应使用**占位符 `{{.<资源ID>}}` 或 `{{<资源ID>}}`，**资源 
 ```bash
 kweaver vega sql -d '{
   "resource_type":"mysql",
-  "query":"SELECT supplier_name, city FROM {{d7fks20ce1oc73ds19sg}} LIMIT 5"
+  "query":"SELECT supplier_name, city FROM {{<your_resource_id>}} LIMIT 5"
 }'
 ```
 
-（将 `d7fks20ce1oc73ds19sg` 换为你的 `resource_id`。）
+（将 `<your_resource_id>` 换为 `vega resource get` 返回的资源 id。）
 
 统计聚合示例：
 


### PR DESCRIPTION
## Summary

- Add `kweaver vega sql -d <json>` CLI command for direct SQL (MySQL/MariaDB/PostgreSQL) or OpenSearch DSL queries via `POST /api/vega-backend/v1/resources/query`
- TypeScript: `vegaSQLQuery()` API, `VegaResource.sqlQuery()` resource method, CLI subcommand with JSON validation and `--help`
- Python: `VegaQueryResource.sql_query()` method; improve `execute()` to accept table ID strings or dicts, add `joins`/`need_total`/`query_id` parameters
- Unit tests for both TypeScript and Python (`sqlQuery`, `sql_query`, error handling)
- Docs: fix `sql` → `query` field name in examples, document `{{resource_id}}` placeholder routing, add catalog registration workflow to skill reference

## Changes

| Area | Files |
|------|-------|
| TS API | `packages/typescript/src/api/vega.ts` |
| TS CLI | `packages/typescript/src/commands/vega.ts` |
| TS Resource | `packages/typescript/src/resources/vega.ts` |
| TS Test | `packages/typescript/test/vega.test.ts` |
| Python | `packages/python/src/kweaver/resources/vega/query.py` |
| Python Test | `packages/python/tests/unit/test_vega.py` |
| Docs | READMEs (EN/ZH), `skills/kweaver-core/references/vega.md` |

## Test plan

- [x] `make -C packages/typescript test` — TS unit tests pass (including new `sqlQuery` test)
- [x] `make -C packages/python test` — Python unit tests pass (including new `sql_query` / error tests)
- [ ] E2E: `kweaver vega sql -d '{"query":"SELECT ...","resource_type":"mysql"}'` against live environment


Made with [Cursor](https://cursor.com)