### PR TITLE
fix: 修复 examples/02-csv-to-kn 全流程中的三处 CLI bug

### DIFF
--- a/packages/typescript/src/api/dataflow.ts
+++ b/packages/typescript/src/api/dataflow.ts
@@ -157,7 +157,10 @@ export async function pollDataflowResults(options: PollDataflowOptions): Promise
         return latest;
       }
       if (latest.status === "failed" || latest.status === "error") {
-        const reason = latest.reason ? `: ${latest.reason}` : "";
+        const reasonVal = latest.reason;
+        const reason = reasonVal
+          ? `: ${typeof reasonVal === "string" ? reasonVal : JSON.stringify(reasonVal)}`
+          : "";
         throw new Error(`Dataflow run ${latest.status}${reason}`);
       }
     }

--- a/packages/typescript/src/commands/context-loader.ts
+++ b/packages/typescript/src/commands/context-loader.ts
@@ -350,22 +350,27 @@ async function runKnSearch(
 ): Promise<number> {
   let query: string | undefined;
   let onlySchema = false;
+  let knIdOverride: string | undefined;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === "--only-schema") {
       onlySchema = true;
+    } else if ((arg === "--kn-id" || arg === "-k") && args[i + 1]) {
+      knIdOverride = args[i + 1];
+      i += 1;
     } else if (!arg.startsWith("-") && !query) {
       query = arg;
     }
   }
 
   if (!query) {
-    console.error("Usage: kweaver context-loader kn-search <query> [--only-schema]");
+    console.error("Usage: kweaver context-loader kn-search <query> [--kn-id <id>] [--only-schema]");
     return 1;
   }
 
-  const result = await knSearch(options, { query, only_schema: onlySchema });
+  const effectiveOptions = knIdOverride ? { ...options, knId: knIdOverride } : options;
+  const result = await knSearch(effectiveOptions, { query, only_schema: onlySchema });
   console.log(formatOutput(result, pretty));
   return 0;
 }

--- a/packages/typescript/src/commands/ds.ts
+++ b/packages/typescript/src/commands/ds.ts
@@ -422,6 +422,7 @@ export async function resolveFiles(pattern: string): Promise<string[]> {
 export interface ImportCsvResult {
   code: number;
   tables: string[]; // successfully imported table names
+  failed: string[]; // failed table names
   tableColumns: Record<string, string[]>; // tableName → column names
   sampleRows: Record<string, Array<Record<string, string | null>>>; // tableName → first 100 rows
 }
@@ -433,18 +434,18 @@ export async function runDsImportCsv(args: string[]): Promise<ImportCsvResult> {
   } catch (error) {
     if (error instanceof Error && error.message === "help") {
       console.log(IMPORT_CSV_HELP);
-      return { code: 0, tables: [], tableColumns: {}, sampleRows: {} };
+      return { code: 0, tables: [], failed: [], tableColumns: {}, sampleRows: {} };
     }
     throw error;
   }
 
   if (!options.datasourceId) {
     console.error("Usage: kweaver ds import-csv <ds-id> --files <glob_or_list> [options]");
-    return { code: 1, tables: [], tableColumns: {}, sampleRows: {} };
+    return { code: 1, tables: [], failed: [], tableColumns: {}, sampleRows: {} };
   }
   if (!options.files) {
     console.error("Error: --files is required");
-    return { code: 1, tables: [], tableColumns: {}, sampleRows: {} };
+    return { code: 1, tables: [], failed: [], tableColumns: {}, sampleRows: {} };
   }
 
   // 1. Get credentials
@@ -492,7 +493,7 @@ export async function runDsImportCsv(args: string[]): Promise<ImportCsvResult> {
 
   if (parsed.length === 0) {
     console.error("All files were skipped — nothing to import");
-    return { code: 1, tables: [], tableColumns: {}, sampleRows: {} };
+    return { code: 1, tables: [], failed: [], tableColumns: {}, sampleRows: {} };
   }
 
   // Phase 2: Import each file in batches
@@ -559,22 +560,21 @@ export async function runDsImportCsv(args: string[]): Promise<ImportCsvResult> {
     console.error(`Failed tables: ${failed.join(", ")}`);
   }
 
+  return { code: failed.length > 0 ? 1 : 0, tables: succeeded, failed, tableColumns, sampleRows };
+}
+
+export async function runDsImportCsvCommand(args: string[]): Promise<number> {
+  const result = await runDsImportCsv(args);
   console.log(
     JSON.stringify(
       {
-        tables: succeeded,
-        failed,
-        summary: { succeeded: succeeded.length, failed: failed.length },
+        tables: result.tables,
+        failed: result.failed,
+        summary: { succeeded: result.tables.length, failed: result.failed.length },
       },
       null,
       2
     )
   );
-
-  return { code: failed.length > 0 ? 1 : 0, tables: succeeded, tableColumns, sampleRows };
-}
-
-export async function runDsImportCsvCommand(args: string[]): Promise<number> {
-  const result = await runDsImportCsv(args);
   return result.code;
 }


### PR DESCRIPTION
Closes #60

## 变更内容

### `api/dataflow.ts`
Dataflow 失败时 `latest.reason` 为对象导致打印 `[object Object]`。改为对非字符串类型使用 `JSON.stringify` 序列化，确保错误信息可读。

### `commands/ds.ts`
`runDsImportCsv` 内部直接 `console.log` 导致 `create-from-csv` 捕获到两个 JSON 对象，`JSON.parse` 失败、KN_ID 为空。
- 将 `console.log` 移出 `runDsImportCsv`，改在 `runDsImportCsvCommand` 中打印
- `ImportCsvResult` 接口新增 `failed: string[]` 字段

### `commands/context-loader.ts`
`kn-search` 不解析 `--kn-id` 参数，始终使用本地配置的 KN，导致 semantic search 返回错误 KN 的 schema。
- `runKnSearch` 中解析 `--kn-id`，提供时覆盖 `options.knId`

## 测试

在 117 环境运行 `examples/02-csv-to-kn/run.sh` 全流程验证。