### PR TITLE
feat(cli): add toolbox/tool commands + call -F multipart (closes #63)

### DIFF
--- a/docs/cli_conventions.md
+++ b/docs/cli_conventions.md
@@ -1,0 +1,61 @@
+# KWeaver CLI 命令约定
+
+> 本文档定义 `kweaver` CLI 命令的结构、命名与扩展约定。**新增命令前必须先对齐本文档**。
+
+## 1 层级
+
+固定 **2 级**：`kweaver <资源> <动作>`。
+- ✅ `kweaver bkn create`
+- ✅ `kweaver toolbox publish <id>`
+- ❌ `kweaver factory toolbox create`（禁止 3 级分组）
+- ❌ `kweaver toolbox <id> tool upload`（禁止 RESTful 嵌套）
+
+## 2 同域多资源
+
+当一个域内多个资源是同一类时，用 `<前缀>-<子资源>` **软分组**，仍保持 2 级。
+- ✅ `bkn`, `bkn-ops`, `bkn-query`, `bkn-schema`（共享 `bkn` 前缀，仍是 2 级命令）
+- ✅ `explore-bkn`, `explore-chat`, `explore-vega`（同上）
+
+不同概念资源即便在同一业务域，也保持平铺顶层命令而非引入 3 级嵌套。例如 `toolbox` 与 `tool`：
+- ✅ `kweaver toolbox <action>` + `kweaver tool <action>`
+
+## 3 父子关系
+
+资源间的父子关系通过 **flag** 表达，不做 URL 风格嵌套。
+- ✅ `kweaver tool upload --toolbox <box_id> spec.yaml`
+- ❌ `kweaver toolbox <box_id> tool upload spec.yaml`
+
+## 4 底层逃生口
+
+`kweaver call` 必须能覆盖任何后端 API（含 multipart 文件上传），保证：
+- 缺专用命令时，用户**不必退回 raw `curl` + 手动拼 token**
+- 任何新接口可立刻通过 `kweaver call` 调用，专用命令是面向用户体验的糖
+
+具体能力清单见 `kweaver call --help`。
+
+## 5 Subcommand 一致性
+
+每个资源的 subcommand 命名遵循动词约定：
+| 动作 | Subcommand | 备注 |
+|---|---|---|
+| 列举 | `list` | 支持 `--keyword`, `--limit`, `--offset` 等通用过滤 |
+| 详情 | `get <id>` | |
+| 创建 | `create [args]` | |
+| 更新 | `update <id> [args]` | |
+| 删除 | `delete <id> [-y]` | `-y` 跳过确认 |
+| 上传文件 | `upload <file>` | 走 multipart |
+| 状态变更 | `<verb>`（如 `publish`, `enable`, `set-status`） | 优先具名动词，回退到 `set-status` |
+
+## 6 通用 flag
+
+所有命令必须支持：
+- `-bd, --biz-domain <value>` — 覆盖业务域
+- `--pretty` — 美化 JSON 输出（默认开启）
+- `-h, --help` — 子命令帮助
+
+## 7 测试要求
+
+新命令必须包含：
+1. **解析器单测**（`test/<cmd>-cmd.test.ts`）：覆盖每个 flag 的 happy path 与至少一个错误路径
+2. **API 客户端单测**（`test/<resource>.test.ts`）：mock `fetch`，断言 URL、method、headers、body
+3. **e2e smoke**（`test/e2e/<resource>.test.ts`）：跑通完整链路，环境变量缺失时跳过

--- a/docs/cli_conventions.md
+++ b/docs/cli_conventions.md
@@ -10,14 +10,18 @@
 - ❌ `kweaver factory toolbox create`（禁止 3 级分组）
 - ❌ `kweaver toolbox <id> tool upload`（禁止 RESTful 嵌套）
 
-## 2 同域多资源
+## 2 多资源同域
 
-当一个域内多个资源是同一类时，用 `<前缀>-<子资源>` **软分组**，仍保持 2 级。
-- ✅ `bkn`, `bkn-ops`, `bkn-query`, `bkn-schema`（共享 `bkn` 前缀，仍是 2 级命令）
-- ✅ `explore-bkn`, `explore-chat`, `explore-vega`（同上）
+一个域内有多个资源时，**优先在已有顶层命令下用 subcommand 分组**，而不是引入新的顶层命令。已成熟的例子是 `bkn`：
 
-不同概念资源即便在同一业务域，也保持平铺顶层命令而非引入 3 级嵌套。例如 `toolbox` 与 `tool`：
-- ✅ `kweaver toolbox <action>` + `kweaver tool <action>`
+- `kweaver bkn object-type {list,get,create,update,delete,query,properties}`
+- `kweaver bkn relation-type {list,get,create,update,delete}`
+- `kweaver bkn action-type {list,query,execute}`
+- `kweaver bkn action-schedule …`、`bkn action-log …`
+
+形式是 `kweaver <顶层> <子资源> <动作>`，仍属可接受范围（顶层命令依旧是 2 级分发：第二段是子资源名，自身在内部再分发动作）。
+
+只有当**两个资源在概念上彼此独立、其中一个完全可以脱离另一个使用**时，才拆成两个顶层命令。`toolbox` 与 `tool` 即如此：tool 必须属于某个 toolbox（父子关系靠 flag 表达，见 §3），但用户操作 toolbox 时（list/publish/delete）完全不需要触及 tool，反之亦然。
 
 ## 3 父子关系
 
@@ -33,6 +37,8 @@
 
 具体能力清单见 `kweaver call --help`。
 
+> ⚠️ `kweaver call --help` 与本节描述必须保持同步——新增 `call` 能力时，help 文本与本节同改。
+
 ## 5 Subcommand 一致性
 
 每个资源的 subcommand 命名遵循动词约定：
@@ -42,16 +48,23 @@
 | 详情 | `get <id>` | |
 | 创建 | `create [args]` | |
 | 更新 | `update <id> [args]` | |
-| 删除 | `delete <id> [-y]` | `-y` 跳过确认 |
+| 删除 | `delete <id> [-y\|--yes]` | `-y`/`--yes` 跳过确认 |
 | 上传文件 | `upload <file>` | 走 multipart |
 | 状态变更 | `<verb>`（如 `publish`, `enable`, `set-status`） | 优先具名动词，回退到 `set-status` |
 
 ## 6 通用 flag
 
-所有命令必须支持：
-- `-bd, --biz-domain <value>` — 覆盖业务域
-- `--pretty` — 美化 JSON 输出（默认开启）
+**返回 JSON 的命令**应该支持：
+- `-bd, --biz-domain <value>` — 覆盖业务域（凡需要打到平台 API 的命令都要支持）
+- `--pretty` / `--compact` — 输出格式开关；`--pretty` 默认开启，`--compact` 用于 pipeline 友好输出
+
+**所有命令**应该支持：
 - `-h, --help` — 子命令帮助
+
+**不适用的情形**（已有先例）：
+- `kweaver token` / `kweaver auth …` — 输出非 JSON、或交互流程，不需要 `--pretty`
+- `kweaver agent chat` — 流式文本输出，不需要 `--pretty`
+- 部分早期命令（如 `ds get`、`ds delete`）输出已经默认 pretty 且不可关闭——后续重构时统一即可，不阻塞新命令开发
 
 ## 7 测试要求
 

--- a/docs/kweaver_sdk_design.md
+++ b/docs/kweaver_sdk_design.md
@@ -78,6 +78,8 @@ CLI ──→ SDK ──→ HTTP     (AI Agent / 终端用户通过 CLI 操作)
 
 ### 3.2 CLI 命令粒度选择
 
+> **CLI 命名与结构约定见 [`docs/cli_conventions.md`](./cli_conventions.md)。** 新增命令前必须对齐。
+
 | 方案 | 优点 | 缺点 |
 |------|------|------|
 | 一个命令覆盖全流程 | Agent 一次调用完成 | 参数太多，灵活性差 |

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -180,7 +180,7 @@ kweaver skill list/market/get/register/status/delete/content/read-file/download/
 kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
 kweaver context-loader config set/use/list/show
 kweaver context-loader kn-search/query-object-instance/...
-kweaver toolbox create/list/get/publish/delete
+kweaver toolbox create/list/publish/unpublish/delete
 kweaver tool upload/list/enable/disable
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-F key=value]
 ```

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -180,7 +180,9 @@ kweaver skill list/market/get/register/status/delete/content/read-file/download/
 kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
 kweaver context-loader config set/use/list/show
 kweaver context-loader kn-search/query-object-instance/...
-kweaver call <path> [-X METHOD] [-d BODY] [-H header]
+kweaver toolbox create/list/get/publish/delete
+kweaver tool upload/list/enable/disable
+kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-F key=value]
 ```
 
 ### Dataflow CLI examples
@@ -210,6 +212,25 @@ kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT * FROM {{res-1}} L
 ```
 
 If both `-d` and `--query` / `--resource-type` are present, **only `-d` is used**.
+
+### Register an Agent toolbox
+
+```bash
+# 1. Create a toolbox pointing at your service
+kweaver toolbox create \
+  --name my_actions \
+  --service-url http://my-svc:8080 \
+  --description "Demo action backend"
+# → {"box_id":"<BOX_ID>"}
+
+# 2. Upload an OpenAPI spec as a tool
+kweaver tool upload --toolbox <BOX_ID> ./openapi.json
+# → {"success_ids":["<TOOL_ID>"]}
+
+# 3. Publish the toolbox and enable the tool
+kweaver toolbox publish <BOX_ID>
+kweaver tool enable --toolbox <BOX_ID> <TOOL_ID>
+```
 
 **No-auth platforms:** If OAuth is not enabled, use `kweaver auth <url> --no-auth` (or run a normal `auth login`; a **404** on `POST /oauth2/clients` switches to no-auth automatically). Credentials are still saved under `~/.kweaver/` and work with `auth use` / `auth list`. Optional: `KWEAVER_NO_AUTH=1` with `KWEAVER_BASE_URL` when no token env is set. SDK: `new KWeaverClient({ baseUrl, auth: false })` or `kweaver.configure({ baseUrl, auth: false })`.
 

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kweaver-ai/kweaver-sdk",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "KWeaver TypeScript SDK — CLI tool and programmatic API for knowledge networks and Decision Agents.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/typescript/src/api/dataflow.ts
+++ b/packages/typescript/src/api/dataflow.ts
@@ -29,7 +29,7 @@ export interface DataflowCreateBody {
 
 export interface DataflowResult {
   status: "success" | "completed" | "failed" | "error";
-  reason?: string;
+  reason?: unknown;
 }
 
 // ── createDataflow ────────────────────────────────────────────────────────────

--- a/packages/typescript/src/api/toolboxes.ts
+++ b/packages/typescript/src/api/toolboxes.ts
@@ -12,9 +12,9 @@ import { buildHeaders } from "./headers.js";
 //   POST   /tool-box/{id}/tool         upload tool (multipart)
 //   POST   /tool-box/{id}/tools/status enable/disable (batch)
 //
-// TBD — verify against live backend during Task 8 (e2e):
+// Verified during Task 8 e2e against the live backend (2026-04-18):
 //   GET    /tool-box?keyword=&limit=&offset=  list toolboxes
-//   GET    /tool-box/{id}/tool                 list tools
+//   GET    /tool-box/{id}/tool                list tools
 
 const PATH = "/api/agent-operator-integration/v1/tool-box";
 

--- a/packages/typescript/src/api/toolboxes.ts
+++ b/packages/typescript/src/api/toolboxes.ts
@@ -32,8 +32,8 @@ export interface CreateToolboxOptions extends BaseOpts {
   name: string;
   description: string;
   serviceUrl: string;
-  metadataType?: string; // default: openapi
-  source?: string;       // default: custom
+  metadataType?: "openapi"; // sole value the backend accepts today
+  source?: string;          // default: custom
 }
 
 export async function createToolbox(opts: CreateToolboxOptions): Promise<string> {
@@ -79,7 +79,7 @@ export async function setToolboxStatus(opts: SetToolboxStatusOptions): Promise<v
 export interface UploadToolOptions extends BaseOpts {
   boxId: string;
   filePath: string;
-  metadataType?: string; // default: openapi
+  metadataType?: "openapi"; // sole value the backend accepts today
 }
 
 export async function uploadTool(opts: UploadToolOptions): Promise<string> {
@@ -117,7 +117,7 @@ export interface ListToolboxesOptions extends BaseOpts {
 
 export async function listToolboxes(opts: ListToolboxesOptions): Promise<string> {
   const qp = new URLSearchParams();
-  if (opts.keyword) qp.set("keyword", opts.keyword);
+  if (opts.keyword !== undefined) qp.set("keyword", opts.keyword);
   if (opts.limit !== undefined) qp.set("limit", String(opts.limit));
   if (opts.offset !== undefined) qp.set("offset", String(opts.offset));
   const suffix = qp.toString() ? `?${qp}` : "";

--- a/packages/typescript/src/api/toolboxes.ts
+++ b/packages/typescript/src/api/toolboxes.ts
@@ -1,0 +1,141 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { fetchTextOrThrow } from "../utils/http.js";
+import { buildHeaders } from "./headers.js";
+
+// Backend endpoints under /api/agent-operator-integration/v1/tool-box.
+//
+// Verified against kweaver/examples/03-action-lifecycle/run.sh (lines 78–197):
+//   POST   /tool-box                   create
+//   DELETE /tool-box/{id}              delete
+//   POST   /tool-box/{id}/status       publish/draft
+//   POST   /tool-box/{id}/tool         upload tool (multipart)
+//   POST   /tool-box/{id}/tools/status enable/disable (batch)
+//
+// TBD — verify against live backend during Task 8 (e2e):
+//   GET    /tool-box?keyword=&limit=&offset=  list toolboxes
+//   GET    /tool-box/{id}/tool                 list tools
+
+const PATH = "/api/agent-operator-integration/v1/tool-box";
+
+interface BaseOpts {
+  baseUrl: string;
+  accessToken: string;
+  businessDomain?: string;
+}
+
+function url(base: string, suffix = ""): string {
+  return `${base.replace(/\/+$/, "")}${PATH}${suffix}`;
+}
+
+export interface CreateToolboxOptions extends BaseOpts {
+  name: string;
+  description: string;
+  serviceUrl: string;
+  metadataType?: string; // default: openapi
+  source?: string;       // default: custom
+}
+
+export async function createToolbox(opts: CreateToolboxOptions): Promise<string> {
+  const body = JSON.stringify({
+    metadata_type: opts.metadataType ?? "openapi",
+    box_name: opts.name,
+    box_desc: opts.description,
+    box_svc_url: opts.serviceUrl,
+    source: opts.source ?? "custom",
+  });
+  const { body: text } = await fetchTextOrThrow(url(opts.baseUrl), {
+    method: "POST",
+    headers: { ...buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"), "content-type": "application/json" },
+    body,
+  });
+  return text;
+}
+
+export interface DeleteToolboxOptions extends BaseOpts {
+  boxId: string;
+}
+
+export async function deleteToolbox(opts: DeleteToolboxOptions): Promise<void> {
+  await fetchTextOrThrow(url(opts.baseUrl, `/${encodeURIComponent(opts.boxId)}`), {
+    method: "DELETE",
+    headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
+  });
+}
+
+export interface SetToolboxStatusOptions extends BaseOpts {
+  boxId: string;
+  status: "published" | "draft";
+}
+
+export async function setToolboxStatus(opts: SetToolboxStatusOptions): Promise<void> {
+  await fetchTextOrThrow(url(opts.baseUrl, `/${encodeURIComponent(opts.boxId)}/status`), {
+    method: "POST",
+    headers: { ...buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"), "content-type": "application/json" },
+    body: JSON.stringify({ status: opts.status }),
+  });
+}
+
+export interface UploadToolOptions extends BaseOpts {
+  boxId: string;
+  filePath: string;
+  metadataType?: string; // default: openapi
+}
+
+export async function uploadTool(opts: UploadToolOptions): Promise<string> {
+  const buf = await readFile(opts.filePath);
+  const form = new FormData();
+  form.append("metadata_type", opts.metadataType ?? "openapi");
+  form.append("data", new Blob([buf]), basename(opts.filePath));
+  const { body: text } = await fetchTextOrThrow(url(opts.baseUrl, `/${encodeURIComponent(opts.boxId)}/tool`), {
+    method: "POST",
+    headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
+    body: form,
+  });
+  return text;
+}
+
+export interface SetToolStatusesOptions extends BaseOpts {
+  boxId: string;
+  updates: Array<{ toolId: string; status: "enabled" | "disabled" }>;
+}
+
+export async function setToolStatuses(opts: SetToolStatusesOptions): Promise<void> {
+  const body = JSON.stringify(opts.updates.map((u) => ({ tool_id: u.toolId, status: u.status })));
+  await fetchTextOrThrow(url(opts.baseUrl, `/${encodeURIComponent(opts.boxId)}/tools/status`), {
+    method: "POST",
+    headers: { ...buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"), "content-type": "application/json" },
+    body,
+  });
+}
+
+export interface ListToolboxesOptions extends BaseOpts {
+  keyword?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export async function listToolboxes(opts: ListToolboxesOptions): Promise<string> {
+  const qp = new URLSearchParams();
+  if (opts.keyword) qp.set("keyword", opts.keyword);
+  if (opts.limit !== undefined) qp.set("limit", String(opts.limit));
+  if (opts.offset !== undefined) qp.set("offset", String(opts.offset));
+  const suffix = qp.toString() ? `?${qp}` : "";
+  const { body } = await fetchTextOrThrow(url(opts.baseUrl, suffix), {
+    method: "GET",
+    headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
+  });
+  return body;
+}
+
+export interface ListToolsOptions extends BaseOpts {
+  boxId: string;
+}
+
+export async function listTools(opts: ListToolsOptions): Promise<string> {
+  const { body } = await fetchTextOrThrow(url(opts.baseUrl, `/${encodeURIComponent(opts.boxId)}/tool`), {
+    method: "GET",
+    headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
+  });
+  return body;
+}

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -12,6 +12,8 @@ import { runExploreCommand } from "./commands/explore.js";
 import { runDataviewCommand } from "./commands/dataview.js";
 import { runSkillCommand } from "./commands/skill.js";
 import { runTokenCommand } from "./commands/token.js";
+import { runToolboxCommand } from "./commands/toolbox.js";
+import { runToolCommand } from "./commands/tool.js";
 import { runVegaCommand } from "./commands/vega.js";
 
 function printHelp(): void {
@@ -100,6 +102,15 @@ Usage:
   kweaver skill read-file <skill-id> <rel-path> [--raw] [--output file]
   kweaver skill download|install <skill-id> [path] [options]
 
+  kweaver toolbox create --name <n> --service-url <url> [--description <d>] [-bd value]
+  kweaver toolbox list [--keyword X] [--limit N] [--offset N] [-bd value]
+  kweaver toolbox publish|unpublish <box-id> [-bd value]
+  kweaver toolbox delete <box-id> [-y] [-bd value]
+
+  kweaver tool upload --toolbox <box-id> <openapi-spec-path> [--metadata-type openapi]
+  kweaver tool list --toolbox <box-id> [-bd value]
+  kweaver tool enable|disable --toolbox <box-id> <tool-id>... [-bd value]
+
   kweaver vega health|stats|inspect
   kweaver vega catalog list|get|health|test-connection|discover|resources [options]
   kweaver vega resource list|get|query [options]
@@ -130,6 +141,8 @@ Commands:
                  object-type, relation-type, subgraph, action-type, action-execution, action-log)
   config         Per-platform configuration (business domain)
   skill          Skill registry and market (register, search, progressive read, download/install)
+  toolbox        Agent toolbox lifecycle (create, list, publish, delete)
+  tool           Tools inside a toolbox (upload OpenAPI spec, list, enable/disable)
   vega           Vega observability (catalog, resource, query/sql, connector-type, health/stats/inspect)
   context-loader Context-loader MCP (config, tools, resources, prompts, kn-search, query-*, etc.)
   help           Show this message`);
@@ -215,6 +228,14 @@ export async function run(argv: string[]): Promise<number> {
 
   if (command === "skill") {
     return runSkillCommand(rest);
+  }
+
+  if (command === "toolbox") {
+    return runToolboxCommand(rest);
+  }
+
+  if (command === "tool") {
+    return runToolCommand(rest);
   }
 
   if (command === "context-loader" || command === "context") {

--- a/packages/typescript/src/commands/bkn-ops.ts
+++ b/packages/typescript/src/commands/bkn-ops.ts
@@ -836,6 +836,7 @@ Options:
   --tables <a,b>       Tables to include in KN (default: all imported)
   --build (default)    Build after creation
   --no-build           Skip build
+  --recreate           Use "insert" mode on first batch (only effective for new tables)
   --timeout <n>        Build timeout in seconds (default: 300)
   -bd, --biz-domain    Business domain (default: bd_public)`;
 
@@ -847,6 +848,7 @@ export function parseKnCreateFromCsvArgs(args: string[]): {
   batchSize: number;
   tables: string[];
   build: boolean;
+  recreate: boolean;
   timeout: number;
   businessDomain: string;
 } {
@@ -857,6 +859,7 @@ export function parseKnCreateFromCsvArgs(args: string[]): {
   let batchSize = 500;
   let tablesStr = "";
   let build = true;
+  let recreate = false;
   let timeout = 300;
   let businessDomain = "";
 
@@ -892,6 +895,10 @@ export function parseKnCreateFromCsvArgs(args: string[]): {
       build = false;
       continue;
     }
+    if (arg === "--recreate") {
+      recreate = true;
+      continue;
+    }
     if (arg === "--timeout" && args[i + 1]) {
       timeout = parseInt(args[++i], 10);
       if (Number.isNaN(timeout) || timeout < 1) timeout = 300;
@@ -911,7 +918,7 @@ export function parseKnCreateFromCsvArgs(args: string[]): {
     throw new Error("Usage: kweaver bkn create-from-csv <ds-id> --files <glob> --name X [options]");
   }
   if (!businessDomain) businessDomain = resolveBusinessDomain();
-  return { dsId, files, name, tablePrefix, batchSize, tables, build, timeout, businessDomain };
+  return { dsId, files, name, tablePrefix, batchSize, tables, build, recreate, timeout, businessDomain };
 }
 
 export async function runKnCreateFromCsvCommand(args: string[]): Promise<number> {
@@ -935,6 +942,7 @@ export async function runKnCreateFromCsvCommand(args: string[]): Promise<number>
     "--table-prefix", options.tablePrefix,
     "--batch-size", String(options.batchSize),
     "-bd", options.businessDomain,
+    ...(options.recreate ? ["--recreate"] : []),
   ];
   const importResult = await runDsImportCsv(importArgs);
   if (importResult.code !== 0) {

--- a/packages/typescript/src/commands/call.ts
+++ b/packages/typescript/src/commands/call.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
 import { ensureValidToken, formatHttpError, with401RefreshRetry } from "../auth/oauth.js";
 import { isNoAuth } from "../config/no-auth.js";
 import { HttpError } from "../utils/http.js";
@@ -231,8 +233,6 @@ Options:
     let requestBody: BodyInit | undefined = invocation.body;
 
     if (invocation.formFields && invocation.formFields.length > 0) {
-      const { readFile } = await import("node:fs/promises");
-      const { basename } = await import("node:path");
       const form = new FormData();
       for (const field of invocation.formFields) {
         if (field.kind === "string") {

--- a/packages/typescript/src/commands/call.ts
+++ b/packages/typescript/src/commands/call.ts
@@ -3,11 +3,16 @@ import { isNoAuth } from "../config/no-auth.js";
 import { HttpError } from "../utils/http.js";
 import { resolveBusinessDomain } from "../config/store.js";
 
+export type FormField =
+  | { name: string; kind: "string"; value: string }
+  | { name: string; kind: "file"; path: string };
+
 export interface CallInvocation {
   url: string;
   method: string;
   headers: Headers;
   body?: string;
+  formFields?: FormField[];
   pretty: boolean;
   verbose: boolean;
   businessDomain: string;
@@ -17,6 +22,7 @@ export function parseCallArgs(args: string[]): CallInvocation {
   const headers = new Headers();
   let method = "GET";
   let body: string | undefined;
+  const formFields: FormField[] = [];
   let url: string | undefined;
   let pretty = true;
   let verbose = false;
@@ -52,6 +58,23 @@ export function parseCallArgs(args: string[]): CallInvocation {
       if (method === "GET") {
         method = "POST";
       }
+      index += 1;
+      continue;
+    }
+
+    if (arg === "-F" || arg === "--form") {
+      const raw = args[index + 1];
+      if (!raw) throw new Error("Missing value for -F flag");
+      const eq = raw.indexOf("=");
+      if (eq === -1) throw new Error(`Invalid -F format: ${raw} (expected key=value or key=@path)`);
+      const name = raw.slice(0, eq);
+      const rhs = raw.slice(eq + 1);
+      if (rhs.startsWith("@")) {
+        formFields.push({ name, kind: "file", path: rhs.slice(1) });
+      } else {
+        formFields.push({ name, kind: "string", value: rhs });
+      }
+      if (method === "GET") method = "POST";
       index += 1;
       continue;
     }
@@ -93,8 +116,21 @@ export function parseCallArgs(args: string[]): CallInvocation {
     throw new Error("Missing request URL");
   }
 
+  if (formFields.length > 0 && body !== undefined) {
+    throw new Error("-F and -d are mutually exclusive");
+  }
+
   if (!businessDomain) businessDomain = resolveBusinessDomain();
-  return { url, method, headers, body, pretty, verbose, businessDomain };
+  return {
+    url,
+    method,
+    headers,
+    body,
+    formFields: formFields.length > 0 ? formFields : undefined,
+    pretty,
+    verbose,
+    businessDomain,
+  };
 }
 
 function injectAuthHeaders(headers: Headers, accessToken: string, businessDomain: string): void {
@@ -146,13 +182,18 @@ export function formatVerboseRequest(invocation: CallInvocation): string[] {
     lines.push(`  ${name}: ${value}`);
   }
 
-  lines.push(`Body: ${invocation.body ? "present" : "empty"}`);
+  const bodyDesc = invocation.formFields && invocation.formFields.length > 0
+    ? `multipart (${invocation.formFields.length} field${invocation.formFields.length > 1 ? "s" : ""})`
+    : invocation.body
+      ? "present"
+      : "empty";
+  lines.push(`Body: ${bodyDesc}`);
   return lines;
 }
 
 export async function runCallCommand(args: string[]): Promise<number> {
   if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
-    console.log(`kweaver call <url> [-X METHOD] [-H "Name: value"] [-d BODY] [--pretty] [--verbose] [-bd value]
+    console.log(`kweaver call <url> [-X METHOD] [-H "Name: value"] [-d BODY] [-F key=value] [--pretty] [--verbose] [-bd value]
 
 Call an API with curl-style flags and auto-injected token headers.
 
@@ -161,6 +202,7 @@ Options:
   -X, --request      HTTP method (default: GET)
   -H, --header       Extra header (repeatable)
   -d, --data, --data-raw   JSON request body (sets Content-Type: application/json if not set)
+  -F, --form         Multipart form field. -F key=value or -F key=@/path/to/file. Repeatable. Mutually exclusive with -d.
   -bd, --biz-domain  Override x-business-domain (default: bd_public)
   -v, --verbose      Print request info to stderr
   --pretty           Pretty-print JSON output (default)`);
@@ -186,7 +228,27 @@ Options:
     const headers = new Headers(invocation.headers);
     injectAuthHeaders(headers, token.accessToken, invocation.businessDomain);
 
-    if (
+    let requestBody: BodyInit | undefined = invocation.body;
+
+    if (invocation.formFields && invocation.formFields.length > 0) {
+      const { readFile } = await import("node:fs/promises");
+      const { basename } = await import("node:path");
+      const form = new FormData();
+      for (const field of invocation.formFields) {
+        if (field.kind === "string") {
+          form.append(field.name, field.value);
+        } else {
+          const buf = await readFile(field.path);
+          form.append(
+            field.name,
+            new Blob([buf]),
+            basename(field.path),
+          );
+        }
+      }
+      requestBody = form;
+      // do not set content-type — fetch sets multipart boundary
+    } else if (
       invocation.body !== undefined &&
       invocation.body.length > 0 &&
       !headers.has("content-type") &&
@@ -204,7 +266,7 @@ Options:
     const response = await fetch(url, {
       method: invocation.method,
       headers,
-      body: invocation.body,
+      body: requestBody,
     });
 
     const rawText = await response.text();

--- a/packages/typescript/src/commands/ds.ts
+++ b/packages/typescript/src/commands/ds.ts
@@ -535,7 +535,7 @@ export async function runDsImportCsv(args: string[]): Promise<ImportCsvResult> {
         const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
         process.stderr.write(`${elapsed}s\n`);
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
+        const msg = formatHttpError(err);
         process.stderr.write(`FAILED\n`);
         console.error(`[${tableName}] batch ${batchLabel} error: ${msg}`);
         batchFailed = true;

--- a/packages/typescript/src/commands/import-csv.ts
+++ b/packages/typescript/src/commands/import-csv.ts
@@ -22,7 +22,7 @@ export interface DagBodyOptions {
   tableExist: boolean;
   data: Array<Record<string, string | null>>;
   fieldMappings: FieldMapping[];
-  /** When true on the first batch (`tableExist` false), use overwrite to drop/recreate table before import. */
+  /** When true on the first batch (`tableExist` false), use "insert" to force table recreation. */
   recreate?: boolean;
 }
 
@@ -123,7 +123,9 @@ export function buildFieldMappings(headers: string[]): FieldMapping[] {
 export function buildDagBody(options: DagBodyOptions): DataflowCreateBody {
   const { datasourceId, datasourceType, tableName, tableExist, data, fieldMappings, recreate } = options;
   const ts = Date.now();
-  const operateType = tableExist ? "append" : recreate ? "overwrite" : "append";
+  // "insert" creates/replaces the table; "append" adds rows to an existing table.
+  // With --recreate, use "insert" on first batch to force table recreation when schema changed.
+  const operateType = tableExist ? "append" : recreate ? "insert" : "append";
 
   const triggerStep = {
     id: "step-trigger",

--- a/packages/typescript/src/commands/tool.ts
+++ b/packages/typescript/src/commands/tool.ts
@@ -15,7 +15,8 @@ Subcommands:
 
 Options:
   -bd, --biz-domain <s>   Business domain (default: bd_public)
-  --pretty                Pretty-print JSON (default)`;
+  --pretty                Pretty-print JSON (default)
+  --compact               Single-line JSON (pipeline-friendly)`;
 
 export async function runToolCommand(args: string[]): Promise<number> {
   const [subcommand, ...rest] = args;
@@ -77,6 +78,7 @@ export function parseToolUploadArgs(args: string[]): ToolUploadOptions {
     }
     if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
     if (a === "--pretty") { pretty = true; continue; }
+    if (a === "--compact") { pretty = false; continue; }
     if (!a.startsWith("-") && !filePath) { filePath = a; continue; }
   }
 
@@ -118,6 +120,7 @@ async function runToolList(args: string[]): Promise<number> {
     if (a === "--toolbox" && args[i + 1]) { boxId = args[++i]; continue; }
     if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
     if (a === "--pretty") { pretty = true; continue; }
+    if (a === "--compact") { pretty = false; continue; }
   }
   if (!boxId) { console.error("Missing required flag: --toolbox"); return 1; }
   if (!businessDomain) businessDomain = resolveBusinessDomain();

--- a/packages/typescript/src/commands/tool.ts
+++ b/packages/typescript/src/commands/tool.ts
@@ -1,3 +1,4 @@
+import { access } from "node:fs/promises";
 import { ensureValidToken, formatHttpError, with401RefreshRetry } from "../auth/oauth.js";
 import { listTools, setToolStatuses, uploadTool } from "../api/toolboxes.js";
 import { formatCallOutput } from "./call.js";
@@ -51,7 +52,7 @@ export async function runToolCommand(args: string[]): Promise<number> {
 export interface ToolUploadOptions {
   boxId: string;
   filePath: string;
-  metadataType: string;
+  metadataType: "openapi";  // tightened — only value the backend accepts today
   businessDomain: string;
   pretty: boolean;
 }
@@ -59,14 +60,21 @@ export interface ToolUploadOptions {
 export function parseToolUploadArgs(args: string[]): ToolUploadOptions {
   let boxId = "";
   let filePath = "";
-  let metadataType = "openapi";
+  let metadataType: "openapi" = "openapi";
   let businessDomain = "";
   let pretty = true;
 
   for (let i = 0; i < args.length; i += 1) {
     const a = args[i];
     if (a === "--toolbox" && args[i + 1]) { boxId = args[++i]; continue; }
-    if (a === "--metadata-type" && args[i + 1]) { metadataType = args[++i]; continue; }
+    if (a === "--metadata-type" && args[i + 1]) {
+      const val = args[++i];
+      if (val !== "openapi") {
+        throw new Error(`Unsupported --metadata-type: ${val} (only "openapi" is supported)`);
+      }
+      metadataType = val;
+      continue;
+    }
     if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
     if (a === "--pretty") { pretty = true; continue; }
     if (!a.startsWith("-") && !filePath) { filePath = a; continue; }
@@ -83,6 +91,9 @@ async function runToolUpload(args: string[]): Promise<number> {
   try { opts = parseToolUploadArgs(args); }
   catch (e) { console.error(e instanceof Error ? e.message : String(e)); return 1; }
 
+  try { await access(opts.filePath); }
+  catch { console.error(`File not found: ${opts.filePath}`); return 1; }
+
   const token = await ensureValidToken();
   const body = await uploadTool({
     baseUrl: token.baseUrl,
@@ -90,7 +101,7 @@ async function runToolUpload(args: string[]): Promise<number> {
     businessDomain: opts.businessDomain,
     boxId: opts.boxId,
     filePath: opts.filePath,
-    metadataType: opts.metadataType as "openapi",
+    metadataType: opts.metadataType,
   });
   console.log(formatCallOutput(body, opts.pretty));
   return 0;

--- a/packages/typescript/src/commands/tool.ts
+++ b/packages/typescript/src/commands/tool.ts
@@ -1,0 +1,165 @@
+import { ensureValidToken, formatHttpError, with401RefreshRetry } from "../auth/oauth.js";
+import { listTools, setToolStatuses, uploadTool } from "../api/toolboxes.js";
+import { formatCallOutput } from "./call.js";
+import { resolveBusinessDomain } from "../config/store.js";
+
+const HELP = `kweaver tool
+
+Subcommands:
+  upload --toolbox <box-id> <openapi-spec-path> [--metadata-type openapi]
+                                          Upload an OpenAPI spec file as a tool
+  list --toolbox <box-id>                  List tools in a toolbox
+  enable --toolbox <box-id> <tool-id>...   Enable one or more tools
+  disable --toolbox <box-id> <tool-id>...  Disable one or more tools
+
+Options:
+  -bd, --biz-domain <s>   Business domain (default: bd_public)
+  --pretty                Pretty-print JSON (default)`;
+
+export async function runToolCommand(args: string[]): Promise<number> {
+  const [subcommand, ...rest] = args;
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    console.log(HELP);
+    return 0;
+  }
+
+  const dispatch = (): Promise<number> => {
+    if (subcommand === "upload") return runToolUpload(rest);
+    if (subcommand === "list") return runToolList(rest);
+    if (subcommand === "enable") return runToolStatus(rest, "enabled");
+    if (subcommand === "disable") return runToolStatus(rest, "disabled");
+    return Promise.resolve(-1);
+  };
+
+  try {
+    return await with401RefreshRetry(async () => {
+      const code = await dispatch();
+      if (code === -1) {
+        console.error(`Unknown tool subcommand: ${subcommand}`);
+        return 1;
+      }
+      return code;
+    });
+  } catch (error) {
+    console.error(formatHttpError(error));
+    return 1;
+  }
+}
+
+// ── upload ────────────────────────────────────────────────────────────────────
+
+export interface ToolUploadOptions {
+  boxId: string;
+  filePath: string;
+  metadataType: string;
+  businessDomain: string;
+  pretty: boolean;
+}
+
+export function parseToolUploadArgs(args: string[]): ToolUploadOptions {
+  let boxId = "";
+  let filePath = "";
+  let metadataType = "openapi";
+  let businessDomain = "";
+  let pretty = true;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--toolbox" && args[i + 1]) { boxId = args[++i]; continue; }
+    if (a === "--metadata-type" && args[i + 1]) { metadataType = args[++i]; continue; }
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
+    if (a === "--pretty") { pretty = true; continue; }
+    if (!a.startsWith("-") && !filePath) { filePath = a; continue; }
+  }
+
+  if (!boxId) throw new Error("Missing required flag: --toolbox");
+  if (!filePath) throw new Error("Missing required positional argument: <file-path>");
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+  return { boxId, filePath, metadataType, businessDomain, pretty };
+}
+
+async function runToolUpload(args: string[]): Promise<number> {
+  let opts: ToolUploadOptions;
+  try { opts = parseToolUploadArgs(args); }
+  catch (e) { console.error(e instanceof Error ? e.message : String(e)); return 1; }
+
+  const token = await ensureValidToken();
+  const body = await uploadTool({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    businessDomain: opts.businessDomain,
+    boxId: opts.boxId,
+    filePath: opts.filePath,
+    metadataType: opts.metadataType as "openapi",
+  });
+  console.log(formatCallOutput(body, opts.pretty));
+  return 0;
+}
+
+// ── list ──────────────────────────────────────────────────────────────────────
+
+async function runToolList(args: string[]): Promise<number> {
+  let boxId = "";
+  let businessDomain = "";
+  let pretty = true;
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--toolbox" && args[i + 1]) { boxId = args[++i]; continue; }
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
+    if (a === "--pretty") { pretty = true; continue; }
+  }
+  if (!boxId) { console.error("Missing required flag: --toolbox"); return 1; }
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+
+  const token = await ensureValidToken();
+  const body = await listTools({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    businessDomain,
+    boxId,
+  });
+  console.log(formatCallOutput(body, pretty));
+  return 0;
+}
+
+// ── enable / disable ──────────────────────────────────────────────────────────
+
+export interface ToolStatusOptions {
+  boxId: string;
+  toolIds: string[];
+  status: "enabled" | "disabled";
+  businessDomain: string;
+}
+
+export function parseToolStatusArgs(args: string[], status: "enabled" | "disabled"): ToolStatusOptions {
+  let boxId = "";
+  let businessDomain = "";
+  const toolIds: string[] = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--toolbox" && args[i + 1]) { boxId = args[++i]; continue; }
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
+    if (!a.startsWith("-")) toolIds.push(a);
+  }
+  if (!boxId) throw new Error("Missing required flag: --toolbox");
+  if (toolIds.length === 0) throw new Error("Missing tool id(s)");
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+  return { boxId, toolIds, status, businessDomain };
+}
+
+async function runToolStatus(args: string[], status: "enabled" | "disabled"): Promise<number> {
+  let opts: ToolStatusOptions;
+  try { opts = parseToolStatusArgs(args, status); }
+  catch (e) { console.error(e instanceof Error ? e.message : String(e)); return 1; }
+
+  const token = await ensureValidToken();
+  await setToolStatuses({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    businessDomain: opts.businessDomain,
+    boxId: opts.boxId,
+    updates: opts.toolIds.map((toolId) => ({ toolId, status: opts.status })),
+  });
+  console.error(`${status === "enabled" ? "Enabled" : "Disabled"} ${opts.toolIds.length} tool(s) in toolbox ${opts.boxId}`);
+  return 0;
+}

--- a/packages/typescript/src/commands/toolbox.ts
+++ b/packages/typescript/src/commands/toolbox.ts
@@ -15,7 +15,8 @@ Subcommands:
 
 Options:
   -bd, --biz-domain <s>   Business domain (default: bd_public)
-  --pretty                Pretty-print JSON (default)`;
+  --pretty                Pretty-print JSON (default)
+  --compact               Single-line JSON (pipeline-friendly)`;
 
 export async function runToolboxCommand(args: string[]): Promise<number> {
   const [subcommand, ...rest] = args;
@@ -72,6 +73,7 @@ export function parseToolboxCreateArgs(args: string[]): ToolboxCreateOptions {
     if (a === "--description" && args[i + 1]) { description = args[++i]; continue; }
     if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
     if (a === "--pretty") { pretty = true; continue; }
+    if (a === "--compact") { pretty = false; continue; }
   }
 
   if (!name) throw new Error("Missing required flag: --name");
@@ -129,6 +131,7 @@ async function runToolboxList(args: string[]): Promise<number> {
     }
     if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
     if (a === "--pretty") { pretty = true; continue; }
+    if (a === "--compact") { pretty = false; continue; }
   }
   if (!businessDomain) businessDomain = resolveBusinessDomain();
 

--- a/packages/typescript/src/commands/toolbox.ts
+++ b/packages/typescript/src/commands/toolbox.ts
@@ -1,0 +1,199 @@
+import { createInterface } from "node:readline";
+import { ensureValidToken, formatHttpError, with401RefreshRetry } from "../auth/oauth.js";
+import { createToolbox, deleteToolbox, listToolboxes, setToolboxStatus } from "../api/toolboxes.js";
+import { formatCallOutput } from "./call.js";
+import { resolveBusinessDomain } from "../config/store.js";
+
+const HELP = `kweaver toolbox
+
+Subcommands:
+  create --name <n> --service-url <url> [--description <d>]   Create a new toolbox
+  list [--keyword <s>] [--limit <n>] [--offset <n>]           List toolboxes
+  publish <box-id>                                            Publish a toolbox (status=published)
+  unpublish <box-id>                                          Unpublish (status=draft)
+  delete <box-id> [-y|--yes]                                  Delete a toolbox
+
+Options:
+  -bd, --biz-domain <s>   Business domain (default: bd_public)
+  --pretty                Pretty-print JSON (default)`;
+
+export async function runToolboxCommand(args: string[]): Promise<number> {
+  const [subcommand, ...rest] = args;
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    console.log(HELP);
+    return 0;
+  }
+
+  const dispatch = (): Promise<number> => {
+    if (subcommand === "create") return runToolboxCreate(rest);
+    if (subcommand === "list") return runToolboxList(rest);
+    if (subcommand === "publish") return runToolboxSetStatus(rest, "published");
+    if (subcommand === "unpublish") return runToolboxSetStatus(rest, "draft");
+    if (subcommand === "delete") return runToolboxDelete(rest);
+    return Promise.resolve(-1);
+  };
+
+  try {
+    return await with401RefreshRetry(async () => {
+      const code = await dispatch();
+      if (code === -1) {
+        console.error(`Unknown toolbox subcommand: ${subcommand}`);
+        return 1;
+      }
+      return code;
+    });
+  } catch (error) {
+    console.error(formatHttpError(error));
+    return 1;
+  }
+}
+
+// ── create ────────────────────────────────────────────────────────────────────
+
+export interface ToolboxCreateOptions {
+  name: string;
+  serviceUrl: string;
+  description: string;
+  businessDomain: string;
+  pretty: boolean;
+}
+
+export function parseToolboxCreateArgs(args: string[]): ToolboxCreateOptions {
+  let name = "";
+  let serviceUrl = "";
+  let description = "";
+  let businessDomain = "";
+  let pretty = true;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--name" && args[i + 1]) { name = args[++i]; continue; }
+    if (a === "--service-url" && args[i + 1]) { serviceUrl = args[++i]; continue; }
+    if (a === "--description" && args[i + 1]) { description = args[++i]; continue; }
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
+    if (a === "--pretty") { pretty = true; continue; }
+  }
+
+  if (!name) throw new Error("Missing required flag: --name");
+  if (!serviceUrl) throw new Error("Missing required flag: --service-url");
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+  return { name, serviceUrl, description, businessDomain, pretty };
+}
+
+async function runToolboxCreate(args: string[]): Promise<number> {
+  let opts: ToolboxCreateOptions;
+  try { opts = parseToolboxCreateArgs(args); }
+  catch (e) { console.error(e instanceof Error ? e.message : String(e)); return 1; }
+
+  const token = await ensureValidToken();
+  const body = await createToolbox({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    name: opts.name,
+    description: opts.description,
+    serviceUrl: opts.serviceUrl,
+    businessDomain: opts.businessDomain,
+  });
+  console.log(formatCallOutput(body, opts.pretty));
+  return 0;
+}
+
+// ── list ──────────────────────────────────────────────────────────────────────
+
+async function runToolboxList(args: string[]): Promise<number> {
+  let keyword: string | undefined;
+  let limit: number | undefined;
+  let offset: number | undefined;
+  let businessDomain = "";
+  let pretty = true;
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--keyword" && args[i + 1]) { keyword = args[++i]; continue; }
+    if (a === "--limit" && args[i + 1]) { limit = parseInt(args[++i], 10); continue; }
+    if (a === "--offset" && args[i + 1]) { offset = parseInt(args[++i], 10); continue; }
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
+    if (a === "--pretty") { pretty = true; continue; }
+  }
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+
+  const token = await ensureValidToken();
+  const body = await listToolboxes({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    businessDomain,
+    keyword, limit, offset,
+  });
+  console.log(formatCallOutput(body, pretty));
+  return 0;
+}
+
+// ── publish / unpublish ───────────────────────────────────────────────────────
+
+async function runToolboxSetStatus(args: string[], status: "published" | "draft"): Promise<number> {
+  const boxId = args.find((a) => !a.startsWith("-"));
+  if (!boxId) {
+    console.error(`Usage: kweaver toolbox ${status === "published" ? "publish" : "unpublish"} <box-id>`);
+    return 1;
+  }
+  let businessDomain = "";
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; }
+  }
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+
+  const token = await ensureValidToken();
+  await setToolboxStatus({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    businessDomain,
+    boxId,
+    status,
+  });
+  console.error(`${status === "published" ? "Published" : "Unpublished"} toolbox ${boxId}`);
+  return 0;
+}
+
+// ── delete ────────────────────────────────────────────────────────────────────
+
+function confirmYes(prompt: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`${prompt} [y/N] `, (answer) => {
+      rl.close();
+      const t = answer.trim().toLowerCase();
+      resolve(t === "y" || t === "yes");
+    });
+  });
+}
+
+async function runToolboxDelete(args: string[]): Promise<number> {
+  let boxId = "";
+  let yes = false;
+  let businessDomain = "";
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--yes" || a === "-y") yes = true;
+    else if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; }
+    else if (!a.startsWith("-")) boxId = a;
+  }
+  if (!boxId) {
+    console.error("Usage: kweaver toolbox delete <box-id> [-y|--yes]");
+    return 1;
+  }
+  if (!yes) {
+    const ok = await confirmYes(`Delete toolbox ${boxId}?`);
+    if (!ok) { console.error("Aborted."); return 1; }
+  }
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+
+  const token = await ensureValidToken();
+  await deleteToolbox({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    businessDomain,
+    boxId,
+  });
+  console.error(`Deleted toolbox ${boxId}`);
+  return 0;
+}

--- a/packages/typescript/src/commands/toolbox.ts
+++ b/packages/typescript/src/commands/toolbox.ts
@@ -109,8 +109,24 @@ async function runToolboxList(args: string[]): Promise<number> {
   for (let i = 0; i < args.length; i += 1) {
     const a = args[i];
     if (a === "--keyword" && args[i + 1]) { keyword = args[++i]; continue; }
-    if (a === "--limit" && args[i + 1]) { limit = parseInt(args[++i], 10); continue; }
-    if (a === "--offset" && args[i + 1]) { offset = parseInt(args[++i], 10); continue; }
+    if (a === "--limit" && args[i + 1]) {
+      const n = parseInt(args[++i], 10);
+      if (Number.isNaN(n)) {
+        console.error("--limit must be a number");
+        return 1;
+      }
+      limit = n;
+      continue;
+    }
+    if (a === "--offset" && args[i + 1]) {
+      const n = parseInt(args[++i], 10);
+      if (Number.isNaN(n)) {
+        console.error("--offset must be a number");
+        return 1;
+      }
+      offset = n;
+      continue;
+    }
     if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
     if (a === "--pretty") { pretty = true; continue; }
   }
@@ -129,28 +145,44 @@ async function runToolboxList(args: string[]): Promise<number> {
 
 // ── publish / unpublish ───────────────────────────────────────────────────────
 
-async function runToolboxSetStatus(args: string[], status: "published" | "draft"): Promise<number> {
-  const boxId = args.find((a) => !a.startsWith("-"));
-  if (!boxId) {
-    console.error(`Usage: kweaver toolbox ${status === "published" ? "publish" : "unpublish"} <box-id>`);
-    return 1;
-  }
+export interface ToolboxSetStatusOptions {
+  boxId: string;
+  businessDomain: string;
+}
+
+export function parseToolboxSetStatusArgs(args: string[]): ToolboxSetStatusOptions {
+  let boxId = "";
   let businessDomain = "";
   for (let i = 0; i < args.length; i += 1) {
     const a = args[i];
-    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; }
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) {
+      businessDomain = args[++i];
+      continue;
+    }
+    if (!a.startsWith("-")) boxId = a;
   }
+  if (!boxId) throw new Error("Missing required argument: <box-id>");
   if (!businessDomain) businessDomain = resolveBusinessDomain();
+  return { boxId, businessDomain };
+}
+
+async function runToolboxSetStatus(args: string[], status: "published" | "draft"): Promise<number> {
+  let opts: ToolboxSetStatusOptions;
+  try { opts = parseToolboxSetStatusArgs(args); }
+  catch (e) {
+    console.error(`Usage: kweaver toolbox ${status === "published" ? "publish" : "unpublish"} <box-id>`);
+    return 1;
+  }
 
   const token = await ensureValidToken();
   await setToolboxStatus({
     baseUrl: token.baseUrl,
     accessToken: token.accessToken,
-    businessDomain,
-    boxId,
+    businessDomain: opts.businessDomain,
+    boxId: opts.boxId,
     status,
   });
-  console.error(`${status === "published" ? "Published" : "Unpublished"} toolbox ${boxId}`);
+  console.error(`${status === "published" ? "Published" : "Unpublished"} toolbox ${opts.boxId}`);
   return 0;
 }
 

--- a/packages/typescript/test/cli.test.ts
+++ b/packages/typescript/test/cli.test.ts
@@ -110,6 +110,29 @@ test("parseCallArgs supports custom business domain", () => {
   assert.equal(parsed.businessDomain, "bd_enterprise");
 });
 
+test("parseCallArgs accepts -F string field", () => {
+  const inv = parseCallArgs(["/api/x", "-F", "metadata_type=openapi"]);
+  assert.equal(inv.method, "POST");
+  assert.ok(inv.formFields, "formFields should be set");
+  assert.deepEqual(inv.formFields, [{ name: "metadata_type", kind: "string", value: "openapi" }]);
+});
+
+test("parseCallArgs accepts -F file field", () => {
+  const inv = parseCallArgs(["/api/x", "-F", "data=@/tmp/spec.json"]);
+  assert.deepEqual(inv.formFields, [{ name: "data", kind: "file", path: "/tmp/spec.json" }]);
+});
+
+test("parseCallArgs rejects mixing -F and -d", () => {
+  assert.throws(
+    () => parseCallArgs(["/api/x", "-F", "a=b", "-d", "{}"]),
+    /-F.*-d/i
+  );
+});
+
+test("parseCallArgs rejects malformed -F", () => {
+  assert.throws(() => parseCallArgs(["/api/x", "-F", "noequalsign"]), /-F/);
+});
+
 test("parseTokenArgs accepts no flags", () => {
   assert.doesNotThrow(() => parseTokenArgs([]));
   assert.throws(() => parseTokenArgs(["--verbose"]), /Usage: kweaver token/);

--- a/packages/typescript/test/cli.test.ts
+++ b/packages/typescript/test/cli.test.ts
@@ -133,6 +133,19 @@ test("parseCallArgs rejects malformed -F", () => {
   assert.throws(() => parseCallArgs(["/api/x", "-F", "noequalsign"]), /-F/);
 });
 
+test("parseCallArgs accumulates multiple -F fields in order", () => {
+  const inv = parseCallArgs([
+    "/api/x",
+    "-F", "metadata_type=openapi",
+    "-F", "data=@/tmp/spec.json",
+  ]);
+  assert.equal(inv.formFields?.length, 2);
+  assert.equal(inv.formFields?.[0].name, "metadata_type");
+  assert.equal(inv.formFields?.[0].kind, "string");
+  assert.equal(inv.formFields?.[1].name, "data");
+  assert.equal(inv.formFields?.[1].kind, "file");
+});
+
 test("parseTokenArgs accepts no flags", () => {
   assert.doesNotThrow(() => parseTokenArgs([]));
   assert.throws(() => parseTokenArgs(["--verbose"]), /Usage: kweaver token/);

--- a/packages/typescript/test/e2e/toolbox-tool.test.ts
+++ b/packages/typescript/test/e2e/toolbox-tool.test.ts
@@ -1,0 +1,104 @@
+/**
+ * E2E smoke test for the toolbox + tool full lifecycle.
+ *
+ * Requires a running KWeaver instance with OAuth credentials configured:
+ *   export KWEAVER_BASE_URL=https://your-host
+ *   export KWEAVER_E2E=1
+ *
+ * Credentials are loaded via `ensureValidToken()` which reads the current
+ * platform's saved token from ~/.kweaver/ (same as the CLI).
+ *
+ * Run from `packages/typescript`:
+ *   npm run build && KWEAVER_E2E=1 npm run test:e2e -- --test-name-pattern "toolbox"
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createToolbox,
+  deleteToolbox,
+  listToolboxes,
+  listTools,
+  setToolboxStatus,
+  setToolStatuses,
+  uploadTool,
+} from "../../src/api/toolboxes.js";
+import { ensureValidToken } from "../../src/auth/oauth.js";
+
+const e2eEnabled = process.env.KWEAVER_E2E === "1";
+
+test("toolbox + tool full lifecycle (e2e)", { skip: !e2eEnabled }, async () => {
+  const token = await ensureValidToken();
+  const base = { baseUrl: token.baseUrl, accessToken: token.accessToken };
+
+  // 1. Create a toolbox
+  const ts = Date.now();
+  const created = JSON.parse(
+    await createToolbox({
+      ...base,
+      name: `e2e_toolbox_${ts}`,
+      description: "e2e test",
+      serviceUrl: "http://example.invalid:1",
+    }),
+  );
+  const boxId = created.box_id as string;
+  assert.ok(boxId, "create returned box_id");
+
+  try {
+    // 2. List should include the newly created toolbox
+    const list = JSON.parse(
+      await listToolboxes({ ...base, keyword: `e2e_toolbox_${ts}` }),
+    );
+    const entries = (list.entries ?? list) as Array<{
+      box_id?: string;
+      id?: string;
+    }>;
+    assert.ok(
+      entries.some((e) => (e.box_id ?? e.id) === boxId),
+      "new toolbox appears in list",
+    );
+
+    // 3. Upload a minimal OpenAPI spec as a tool
+    const dir = mkdtempSync(join(tmpdir(), "e2e-tool-"));
+    const specPath = join(dir, "openapi.json");
+    writeFileSync(
+      specPath,
+      JSON.stringify({
+        openapi: "3.0.0",
+        info: { title: "e2e", version: "1" },
+        paths: {
+          "/health": {
+            get: { responses: { "200": { description: "ok" } } },
+          },
+        },
+      }),
+    );
+    const uploaded = JSON.parse(await uploadTool({ ...base, boxId, filePath: specPath }));
+    const toolId = (uploaded.success_ids?.[0]) as string;
+    assert.ok(toolId, "upload returned a tool id");
+
+    // 4. Publish the toolbox and enable the tool
+    await setToolboxStatus({ ...base, boxId, status: "published" });
+    await setToolStatuses({
+      ...base,
+      boxId,
+      updates: [{ toolId, status: "enabled" }],
+    });
+
+    // 5. List tools should show the uploaded tool
+    const tools = JSON.parse(await listTools({ ...base, boxId }));
+    const toolEntries = (tools.entries ?? tools) as Array<{
+      tool_id?: string;
+      id?: string;
+      status?: string;
+    }>;
+    const me = toolEntries.find((t) => (t.tool_id ?? t.id) === toolId);
+    assert.ok(me, "uploaded tool present in list");
+  } finally {
+    // 6. Cleanup — runs even if inner steps throw
+    await deleteToolbox({ ...base, boxId });
+  }
+});

--- a/packages/typescript/test/fixtures/openapi.json
+++ b/packages/typescript/test/fixtures/openapi.json
@@ -1,0 +1,1 @@
+{"openapi":"3.0.0","info":{"title":"test","version":"1.0.0"},"paths":{}}

--- a/packages/typescript/test/import-csv.test.ts
+++ b/packages/typescript/test/import-csv.test.ts
@@ -179,7 +179,7 @@ test("buildDagBody: creates correct DAG with trigger step + write step", () => {
   assert.ok(params.sync_model_fields !== undefined, "sync_model_fields must be present");
 });
 
-test("buildDagBody uses overwrite on first batch when recreate is true", () => {
+test("buildDagBody uses insert on first batch when recreate is true", () => {
   const options: DagBodyOptions = {
     datasourceId: "ds-123",
     datasourceType: "postgresql",
@@ -196,7 +196,7 @@ test("buildDagBody uses overwrite on first batch when recreate is true", () => {
   const body = buildDagBody(options);
   const writeStep = body.steps[1];
   const params = writeStep!.parameters as Record<string, unknown>;
-  assert.equal(params.operate_type, "overwrite");
+  assert.equal(params.operate_type, "insert");
 });
 
 test("buildDagBody uses append on later batches even when recreate is true", () => {

--- a/packages/typescript/test/tool-cmd.test.ts
+++ b/packages/typescript/test/tool-cmd.test.ts
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseToolUploadArgs, parseToolStatusArgs } from "../src/commands/tool.js";
+
+test("parseToolUploadArgs requires --toolbox and a file path", () => {
+  assert.throws(() => parseToolUploadArgs([]), /--toolbox/);
+  assert.throws(() => parseToolUploadArgs(["--toolbox", "b1"]), /file/i);
+});
+
+test("parseToolUploadArgs parses positional file + flags", () => {
+  const opts = parseToolUploadArgs(["--toolbox", "b1", "/tmp/spec.json"]);
+  assert.equal(opts.boxId, "b1");
+  assert.equal(opts.filePath, "/tmp/spec.json");
+  assert.equal(opts.metadataType, "openapi");
+});
+
+test("parseToolStatusArgs requires --toolbox and at least one id", () => {
+  assert.throws(() => parseToolStatusArgs([], "enabled"), /--toolbox/);
+  assert.throws(() => parseToolStatusArgs(["--toolbox", "b1"], "enabled"), /tool.*id/i);
+});
+
+test("parseToolStatusArgs accepts multiple tool ids", () => {
+  const opts = parseToolStatusArgs(["--toolbox", "b1", "t1", "t2"], "enabled");
+  assert.equal(opts.boxId, "b1");
+  assert.deepEqual(opts.toolIds, ["t1", "t2"]);
+  assert.equal(opts.status, "enabled");
+});

--- a/packages/typescript/test/tool-cmd.test.ts
+++ b/packages/typescript/test/tool-cmd.test.ts
@@ -25,3 +25,21 @@ test("parseToolStatusArgs accepts multiple tool ids", () => {
   assert.deepEqual(opts.toolIds, ["t1", "t2"]);
   assert.equal(opts.status, "enabled");
 });
+
+test("parseToolStatusArgs flows status='disabled' through", () => {
+  const opts = parseToolStatusArgs(["--toolbox", "b1", "t1"], "disabled");
+  assert.equal(opts.status, "disabled");
+});
+
+test("parseToolUploadArgs handles file-path before --toolbox", () => {
+  const opts = parseToolUploadArgs(["/tmp/spec.json", "--toolbox", "b1"]);
+  assert.equal(opts.boxId, "b1");
+  assert.equal(opts.filePath, "/tmp/spec.json");
+});
+
+test("parseToolUploadArgs rejects unsupported --metadata-type", () => {
+  assert.throws(
+    () => parseToolUploadArgs(["--toolbox", "b1", "--metadata-type", "swagger", "/tmp/spec.json"]),
+    /metadata-type/i
+  );
+});

--- a/packages/typescript/test/tool-cmd.test.ts
+++ b/packages/typescript/test/tool-cmd.test.ts
@@ -43,3 +43,8 @@ test("parseToolUploadArgs rejects unsupported --metadata-type", () => {
     /metadata-type/i
   );
 });
+
+test("parseToolUploadArgs --compact flips pretty to false", () => {
+  const opts = parseToolUploadArgs(["--toolbox", "b1", "/tmp/spec.json", "--compact"]);
+  assert.equal(opts.pretty, false);
+});

--- a/packages/typescript/test/toolbox-cmd.test.ts
+++ b/packages/typescript/test/toolbox-cmd.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { parseToolboxCreateArgs } from "../src/commands/toolbox.js";
+import { parseToolboxCreateArgs, parseToolboxSetStatusArgs } from "../src/commands/toolbox.js";
 
 test("parseToolboxCreateArgs requires --name and --service-url", () => {
   assert.throws(() => parseToolboxCreateArgs([]), /--name/);
@@ -25,4 +25,21 @@ test("parseToolboxCreateArgs reads all flags", () => {
 test("parseToolboxCreateArgs defaults description to empty string", () => {
   const opts = parseToolboxCreateArgs(["--name", "a", "--service-url", "u"]);
   assert.equal(opts.description, "");
+});
+
+test("parseToolboxSetStatusArgs extracts boxId after -bd flag (regression: bd value was being treated as boxId)", () => {
+  const opts = parseToolboxSetStatusArgs(["-bd", "bd_x", "my-box-id"]);
+  assert.equal(opts.boxId, "my-box-id");
+  assert.equal(opts.businessDomain, "bd_x");
+});
+
+test("parseToolboxSetStatusArgs accepts boxId before flags too", () => {
+  const opts = parseToolboxSetStatusArgs(["my-box-id", "-bd", "bd_x"]);
+  assert.equal(opts.boxId, "my-box-id");
+  assert.equal(opts.businessDomain, "bd_x");
+});
+
+test("parseToolboxSetStatusArgs throws when no boxId provided", () => {
+  assert.throws(() => parseToolboxSetStatusArgs([]), /box-id/);
+  assert.throws(() => parseToolboxSetStatusArgs(["-bd", "bd_x"]), /box-id/);
 });

--- a/packages/typescript/test/toolbox-cmd.test.ts
+++ b/packages/typescript/test/toolbox-cmd.test.ts
@@ -1,0 +1,28 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseToolboxCreateArgs } from "../src/commands/toolbox.js";
+
+test("parseToolboxCreateArgs requires --name and --service-url", () => {
+  assert.throws(() => parseToolboxCreateArgs([]), /--name/);
+  assert.throws(() => parseToolboxCreateArgs(["--name", "a"]), /--service-url/);
+});
+
+test("parseToolboxCreateArgs reads all flags", () => {
+  const opts = parseToolboxCreateArgs([
+    "--name", "demo",
+    "--service-url", "http://svc:1234",
+    "--description", "d",
+    "-bd", "bd_x",
+    "--pretty",
+  ]);
+  assert.equal(opts.name, "demo");
+  assert.equal(opts.serviceUrl, "http://svc:1234");
+  assert.equal(opts.description, "d");
+  assert.equal(opts.businessDomain, "bd_x");
+  assert.equal(opts.pretty, true);
+});
+
+test("parseToolboxCreateArgs defaults description to empty string", () => {
+  const opts = parseToolboxCreateArgs(["--name", "a", "--service-url", "u"]);
+  assert.equal(opts.description, "");
+});

--- a/packages/typescript/test/toolbox-cmd.test.ts
+++ b/packages/typescript/test/toolbox-cmd.test.ts
@@ -27,6 +27,11 @@ test("parseToolboxCreateArgs defaults description to empty string", () => {
   assert.equal(opts.description, "");
 });
 
+test("parseToolboxCreateArgs --compact flips pretty to false", () => {
+  const opts = parseToolboxCreateArgs(["--name", "a", "--service-url", "u", "--compact"]);
+  assert.equal(opts.pretty, false);
+});
+
 test("parseToolboxSetStatusArgs extracts boxId after -bd flag (regression: bd value was being treated as boxId)", () => {
   const opts = parseToolboxSetStatusArgs(["-bd", "bd_x", "my-box-id"]);
   assert.equal(opts.boxId, "my-box-id");

--- a/packages/typescript/test/toolboxes.test.ts
+++ b/packages/typescript/test/toolboxes.test.ts
@@ -47,15 +47,17 @@ test("createToolbox POSTs JSON to /tool-box and returns body", async () => {
 });
 
 test("deleteToolbox DELETEs /tool-box/{id}", async () => {
-  let captured: { url: string; method?: string } | null = null;
+  let captured: { url: string; method?: string; init?: RequestInit } | null = null;
   const restore = mockFetch(async (url, init) => {
-    captured = { url: String(url), method: init?.method };
+    captured = { url: String(url), method: init?.method, init };
     return new Response("", { status: 200 });
   });
   try {
     await deleteToolbox({ baseUrl: BASE, accessToken: TOKEN, boxId: "b1" });
     assert.equal(captured!.url, `${BASE}/api/agent-operator-integration/v1/tool-box/b1`);
     assert.equal(captured!.method, "DELETE");
+    const authHeader = new Headers(captured!.init?.headers).get("authorization");
+    assert.equal(authHeader, `Bearer ${TOKEN}`);
   } finally { restore(); }
 });
 
@@ -129,6 +131,21 @@ test("listToolboxes GETs /tool-box with query params", async () => {
     assert.match(captured!.url, /\/tool-box\?/);
     assert.match(captured!.url, /keyword=demo/);
     assert.match(captured!.url, /limit=20/);
+    assert.match(captured!.url, /offset=0/);
+  } finally { restore(); }
+});
+
+test("listToolboxes with no params produces no query string", async () => {
+  let captured: { url: string } | null = null;
+  const restore = mockFetch(async (url) => {
+    captured = { url: String(url) };
+    return new Response(JSON.stringify({ entries: [] }), { status: 200 });
+  });
+  try {
+    await listToolboxes({ baseUrl: BASE, accessToken: TOKEN });
+    assert.ok(captured);
+    assert.equal(captured!.url, `${BASE}/api/agent-operator-integration/v1/tool-box`);
+    assert.ok(!captured!.url.includes("?"), `URL should have no '?' suffix; got ${captured!.url}`);
   } finally { restore(); }
 });
 

--- a/packages/typescript/test/toolboxes.test.ts
+++ b/packages/typescript/test/toolboxes.test.ts
@@ -1,0 +1,145 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createToolbox,
+  deleteToolbox,
+  setToolboxStatus,
+  uploadTool,
+  setToolStatuses,
+  listToolboxes,
+  listTools,
+} from "../src/api/toolboxes.js";
+
+const BASE = "https://platform.example";
+const TOKEN = "tok-1";
+
+function mockFetch(handler: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = handler as typeof fetch;
+  return () => { globalThis.fetch = original; };
+}
+
+test("createToolbox POSTs JSON to /tool-box and returns body", async () => {
+  let captured: { url: string; init?: RequestInit } | null = null;
+  const restore = mockFetch(async (url, init) => {
+    captured = { url: String(url), init };
+    return new Response(JSON.stringify({ box_id: "b1" }), { status: 200 });
+  });
+  try {
+    const body = await createToolbox({
+      baseUrl: BASE,
+      accessToken: TOKEN,
+      name: "demo",
+      description: "d",
+      serviceUrl: "http://svc:1234",
+    });
+    assert.ok(captured);
+    assert.equal(captured!.url, `${BASE}/api/agent-operator-integration/v1/tool-box`);
+    assert.equal(captured!.init?.method, "POST");
+    const sent = JSON.parse(captured!.init?.body as string);
+    assert.equal(sent.box_name, "demo");
+    assert.equal(sent.box_desc, "d");
+    assert.equal(sent.box_svc_url, "http://svc:1234");
+    assert.equal(sent.metadata_type, "openapi");
+    assert.equal(sent.source, "custom");
+    assert.equal(JSON.parse(body).box_id, "b1");
+  } finally { restore(); }
+});
+
+test("deleteToolbox DELETEs /tool-box/{id}", async () => {
+  let captured: { url: string; method?: string } | null = null;
+  const restore = mockFetch(async (url, init) => {
+    captured = { url: String(url), method: init?.method };
+    return new Response("", { status: 200 });
+  });
+  try {
+    await deleteToolbox({ baseUrl: BASE, accessToken: TOKEN, boxId: "b1" });
+    assert.equal(captured!.url, `${BASE}/api/agent-operator-integration/v1/tool-box/b1`);
+    assert.equal(captured!.method, "DELETE");
+  } finally { restore(); }
+});
+
+test("setToolboxStatus POSTs {status} to /status", async () => {
+  let captured: { url: string; body: string } | null = null;
+  const restore = mockFetch(async (url, init) => {
+    captured = { url: String(url), body: init?.body as string };
+    return new Response("", { status: 200 });
+  });
+  try {
+    await setToolboxStatus({ baseUrl: BASE, accessToken: TOKEN, boxId: "b1", status: "published" });
+    assert.equal(captured!.url, `${BASE}/api/agent-operator-integration/v1/tool-box/b1/status`);
+    assert.deepEqual(JSON.parse(captured!.body), { status: "published" });
+  } finally { restore(); }
+});
+
+test("uploadTool POSTs multipart with metadata_type=openapi and data file", async () => {
+  let captured: { url: string; body: BodyInit | null | undefined; contentType: string | null } | null = null;
+  const restore = mockFetch(async (url, init) => {
+    captured = {
+      url: String(url),
+      body: init?.body,
+      contentType: new Headers(init?.headers).get("content-type"),
+    };
+    return new Response(JSON.stringify({ success_ids: ["t1"] }), { status: 200 });
+  });
+  try {
+    const body = await uploadTool({
+      baseUrl: BASE,
+      accessToken: TOKEN,
+      boxId: "b1",
+      filePath: new URL("./fixtures/openapi.json", import.meta.url).pathname,
+    });
+    assert.equal(captured!.url, `${BASE}/api/agent-operator-integration/v1/tool-box/b1/tool`);
+    assert.ok(captured!.body instanceof FormData);
+    // content-type should not be set explicitly — fetch will set the multipart boundary
+    assert.equal(captured!.contentType, null);
+    assert.deepEqual(JSON.parse(body).success_ids, ["t1"]);
+  } finally { restore(); }
+});
+
+test("setToolStatuses POSTs JSON array to /tools/status", async () => {
+  let captured: { url: string; body: string } | null = null;
+  const restore = mockFetch(async (url, init) => {
+    captured = { url: String(url), body: init?.body as string };
+    return new Response("", { status: 200 });
+  });
+  try {
+    await setToolStatuses({
+      baseUrl: BASE,
+      accessToken: TOKEN,
+      boxId: "b1",
+      updates: [{ toolId: "t1", status: "enabled" }, { toolId: "t2", status: "disabled" }],
+    });
+    assert.equal(captured!.url, `${BASE}/api/agent-operator-integration/v1/tool-box/b1/tools/status`);
+    assert.deepEqual(JSON.parse(captured!.body), [
+      { tool_id: "t1", status: "enabled" },
+      { tool_id: "t2", status: "disabled" },
+    ]);
+  } finally { restore(); }
+});
+
+test("listToolboxes GETs /tool-box with query params", async () => {
+  let captured: { url: string } | null = null;
+  const restore = mockFetch(async (url) => {
+    captured = { url: String(url) };
+    return new Response(JSON.stringify({ entries: [] }), { status: 200 });
+  });
+  try {
+    await listToolboxes({ baseUrl: BASE, accessToken: TOKEN, keyword: "demo", limit: 20, offset: 0 });
+    assert.match(captured!.url, /\/tool-box\?/);
+    assert.match(captured!.url, /keyword=demo/);
+    assert.match(captured!.url, /limit=20/);
+  } finally { restore(); }
+});
+
+test("listTools GETs /tool-box/{id}/tool", async () => {
+  let captured: { url: string } | null = null;
+  const restore = mockFetch(async (url) => {
+    captured = { url: String(url) };
+    return new Response(JSON.stringify({ entries: [] }), { status: 200 });
+  });
+  try {
+    await listTools({ baseUrl: BASE, accessToken: TOKEN, boxId: "b1" });
+    assert.match(captured!.url, /\/tool-box\/b1\/tool($|\?)/);
+  } finally { restore(); }
+});


### PR DESCRIPTION
Closes #63

## Summary

替换 `kweaver/examples/03-action-lifecycle/run.sh` 里的 4 处 `kweaver call` + 1 处 raw `curl` 为一等公民命令，并在底层补齐 `kweaver call` 的 multipart 支持。

### 主线（toolbox/tool 域）
- **`kweaver toolbox`**: `create / list / publish / unpublish / delete`
- **`kweaver tool`**: `upload / list / enable / disable`
- **`kweaver call -F`**: multipart 表单字段（`-F key=value` 字符串 / `-F key=@/path` 文件）；与 `-d` 互斥
- **`docs/cli_conventions.md`**: 锁定 CLI 结构约定，新命令必读

### 顺手修的 SDK bug（e2e 验证过程中发现）
- `import-csv`: `operate_type` 后端只接 `insert`/`append`，原代码错传 `overwrite` → fix
- `bkn create-from-csv`: `--recreate` flag 没透传到底层 import-csv → 补上
- `dataflow polling`: failure `reason` 字段可能是结构化 payload，不是 string，原代码会渲染 `[object Object]` → 用 JSON.stringify
- `ds import-csv` 的 catch：用 `formatHttpError` 替代 `err.message`，HTTP 响应体不再被吞

## Verification

- \`npm run lint\` clean
- \`npm test\`: 638 pass / 0 fail
- \`KWEAVER_E2E=1 npm run test:e2e -- --test-name-pattern toolbox\` 已在真实后端通过（作者本机验证）
- \`kweaver/examples/03-action-lifecycle/run.sh\` 全程跑通（已用本 PR 的新命令重写，待另开 PR）

## Test plan

- [ ] CI 单测全绿
- [ ] reviewer 用 \`KWEAVER_E2E=1 npm run test:e2e -- --test-name-pattern toolbox\` 在自己环境再跑一次（可选，作者已验证）

## Follow-ups (non-blocking)

- 抽取共享 dispatch shell + \`confirmYes\`（现已在 \`ds.ts\` / \`toolbox.ts\` / \`tool.ts\` 三处重复，过了 rule-of-three 门槛）
- dispatcher 级 wiring 测试（目前路由正确性靠 e2e 兜底；不开 KWEAVER_E2E 的 CI 抓不到路由回归）
- \`kweaver\` 主仓的 example 03 \`run.sh\` 改写为新命令（依赖本 SDK 0.6.4 发版）

## Version

\`0.6.3\` → \`0.6.4\`