### PR TITLE
fix(skill): document toolbox/tool commands in kweaver-core

### DIFF
--- a/skills/kweaver-core/SKILL.md
+++ b/skills/kweaver-core/SKILL.md
@@ -5,11 +5,13 @@ description: >-
   语义搜索、执行 Action、Agent CRUD 与对话、Trace 数据分析。
   操作 Dataflow 文档流程 — 列出流程、触发运行、查询运行历史、查看步骤日志。
   操作 Skill 管理模块 — 注册 Skill、市场查找、渐进式读取、下载与安装。
+  操作 Toolbox / Tool — 创建工具箱、上传 OpenAPI 工具、发布与启停。
   操作 Vega 可观测平台 — 查询 Catalog/资源/连接器类型、健康巡检。
   当用户提到"知识网络"、"知识图谱"、"查询对象类"、
   "执行 Action"、"有哪些 Agent"、"创建 Agent"、"跟 Agent 对话"、"列出所有 Agent 模板"、"列出我创建的Agent"、
   "列出私人空间的Agent"、"dataflow"、"数据流"、"流程编排"、"流程运行记录"、"流程日志"、
   "触发 dataflow"、"查看 dataflow 运行历史"、"Skill"、"技能包"、"注册 Skill"、"安装 Skill"、"读取 SKILL.md"、
+  "toolbox"、"工具箱"、"上传工具"、"注册工具"、"OpenAPI 工具"、"启用工具"、"发布 toolbox"、
   "数据源"、"数据视图"、"原子视图"、"Catalog"、"Vega"、
   "健康检查"、"巡检"、"trace"、"证据链"、"数据流追踪"、"数据来源"、"数据怎么得到的"等意图时自动使用。
 allowed-tools: Bash(kweaver *), Bash(npx kweaver *)
@@ -71,6 +73,8 @@ kweaver [--user <userId|username>] <command> [subcommand] [options]
 | `dataview` | 数据视图（mdl-data-model / vega-backend） | `dataview list`、`find --name`、`get`、`query`、`delete`；BKN 绑定也可用 `vega resource` ID（type=resource） | `references/dataview.md` |
 | `dataflow` | Dataflow 文档流程 | `dataflow list`, `dataflow run <dagId> --file <path>`, `dataflow run <dagId> --url <remote-url> --name <filename>`, `dataflow runs <dagId> [--since <date-like>]`, `dataflow logs <dagId> <instanceId> [--detail]` | `references/dataflow.md` |
 | `skill` | Skill 注册、市场查找、渐进式读取、下载与安装 | `skill list`、`market`、`register --zip-file`、`content`、`read-file`、`install` | `references/skill.md` |
+| `toolbox` | 平台工具箱（toolbox）管理 | `toolbox create --name <n> --service-url <url>`、`toolbox list`、`toolbox publish/unpublish <id>`、`toolbox delete <id> [-y]` | `references/toolbox.md` |
+| `tool` | 工具箱内 tool 注册与启停（OpenAPI） | `tool upload --toolbox <id> <openapi-spec>`、`tool list --toolbox <id>`、`tool enable/disable --toolbox <id> <tool-id>...` | `references/tool.md` |
 | `vega` | Vega 可观测平台 | `vega health`, `vega catalog list`, `vega resource list`, `vega query execute -d <json>`, `vega sql --resource-type <t> --query "<sql>"` / `vega sql -d <json>` | `references/vega.md` |
 | `context-loader` | MCP 分层检索 | `context-loader config show`, `context-loader kn-search <query>` | `references/context-loader.md` |
 | `call` | 通用 API 调用 | `call <url> [-X POST] [-d '...']`（可用 `curl` 别名；支持 `--url`、`--data-raw` 等，见 `kweaver --help`） | `references/call.md` |
@@ -86,6 +90,7 @@ kweaver [--user <userId|username>] <command> [subcommand] [options]
 | 管理 Dataflow 文档流程 | `list` 看 DAG；`run` 触发本地文件或远程 URL；`runs --since` 看自然日运行记录；`logs --detail` 查步骤载荷 | [references/dataflow.md](references/dataflow.md) |
 | Trace 数据分析 | `agent trace <conversation_id>` 获取 trace 数据，构建证据链 | — |
 | 管理 Skill | `list` / `market` 查找 Skill；`content` / `read-file` 渐进式读取；`install` 下载并解压本地使用 | [references/skill.md](references/skill.md) |
+| 注册外部工具 | `toolbox create` 建箱 → `tool upload` 上传 OpenAPI → `tool list` 拿 `tool_id` → `tool enable` 启用 → `toolbox publish` 切到 published | [references/toolbox.md](references/toolbox.md) · [references/tool.md](references/tool.md) |
 
 **按需阅读**：需要子命令完整参数或编排示例时，读取对应的 reference 文件。
 
@@ -106,6 +111,8 @@ kweaver [--user <userId|username>] <command> [subcommand] [options]
 /kweaver-core 基于 "数据分析助手" 模板创建一个新的 Agent
 /kweaver-core 在 skill market 里查找名字包含 kweaver 的 skill
 /kweaver-core 读取 skill xxx 的 SKILL.md 并保存到本地目录
+/kweaver-core 创建一个名为 weather-svc 的 toolbox，对接 https://weather.example.com
+/kweaver-core 把 ./openapi.json 上传到 toolbox 1234567890 并启用所有工具，最后发布
 ```
 
 ## 注意事项

--- a/skills/kweaver-core/references/tool.md
+++ b/skills/kweaver-core/references/tool.md
@@ -1,0 +1,68 @@
+# Tool 命令参考（tool）
+
+在指定 [`toolbox`](toolbox.md) 下注册、启停具体工具（tool）。当前后端只接受 **OpenAPI** 规范作为元数据来源。
+
+后端：`/api/agent-operator-integration/v1/tool-box/{boxId}/...`。
+
+## 命令
+
+```bash
+kweaver tool upload  --toolbox <box-id> <openapi-spec-path> [--metadata-type openapi] [-bd value] [--pretty|--compact]
+kweaver tool list    --toolbox <box-id> [-bd value] [--pretty|--compact]
+kweaver tool enable  --toolbox <box-id> <tool-id>... [-bd value]
+kweaver tool disable --toolbox <box-id> <tool-id>... [-bd value]
+```
+
+## 子命令说明
+
+### `upload`
+
+- 以 multipart 方式把一个 OpenAPI 规范文件上传到指定 toolbox，由后端解析并注册 tool。
+- 必填：`--toolbox <box-id>` 和位置参数 `<openapi-spec-path>`。位置参数与 `--toolbox` 顺序无关（解析器允许任一在前）。
+- `--metadata-type` 仅支持 `openapi`（默认即 `openapi`；传入其他值会以 `Unsupported --metadata-type: ...` 报错并退出非零）。
+- 文件不存在时报 `File not found: ...` 并退出非零。
+- 输出：后端原始响应，典型形如 `{"success_ids": ["<tool-id>", ...]}`，可直接喂给 `tool enable`（CLI 不解析其结构）。
+
+```bash
+kweaver tool upload --toolbox 1234567890123456789 ./openapi.json
+kweaver tool upload --toolbox 1234567890123456789 ./openapi.yaml --compact
+```
+
+### `list`
+
+- 列出指定 toolbox 下的 tool。
+- 必填：`--toolbox`。CLI 未发分页参数，分页行为完全由后端决定。
+- 输出：后端原始 JSON（典型形如 `{"entries": [{"tool_id": "...", "status": "..."}, ...]}`），按 `--pretty`/`--compact` 格式化。
+
+```bash
+kweaver tool list --toolbox 1234567890123456789
+```
+
+### `enable` / `disable`
+
+- 批量切换 tool 的启用状态（`enabled` / `disabled`）。
+- 必填：`--toolbox` + 一个或多个 `<tool-id>`（通过位置参数传入）。
+- 成功在 stderr 打印 `Enabled N tool(s) in toolbox <box-id>`，stdout 无内容（脚本友好）。
+
+```bash
+kweaver tool enable  --toolbox 1234567890123456789 tool-a tool-b
+kweaver tool disable --toolbox 1234567890123456789 tool-c
+```
+
+## 通用选项
+
+| 选项 | 说明 | 适用子命令 |
+|------|------|-----------|
+| `-bd, --biz-domain <s>` | 覆盖业务域。默认走 `resolveBusinessDomain()`（`KWEAVER_BUSINESS_DOMAIN` env → 当前平台 `config.json` → `bd_public`） | 全部 |
+| `--pretty` | 把响应体当作 JSON 解析后以 2 空格缩进重排（解析失败则按原文输出，默认） | `upload`、`list` |
+| `--compact` | 原样输出后端响应文本，不做美化（便于管道处理） | `upload`、`list` |
+
+## 注意
+
+- 上传的 OpenAPI 文件路径相对于当前 shell 工作目录解析。
+- 上传响应里的 `success_ids` 即本次新注册的 `tool_id`，可直接传给 `tool enable`；如果只需要后续按需启用，也可以用 `tool list` 兜底。
+- 新注册 tool 的初始启停状态由后端决定，CLI 不假设。
+
+## 关联
+
+- Toolbox 管理与发布：[toolbox.md](toolbox.md)

--- a/skills/kweaver-core/references/toolbox.md
+++ b/skills/kweaver-core/references/toolbox.md
@@ -1,0 +1,98 @@
+# Toolbox 命令参考（toolbox）
+
+管理 KWeaver 平台 **工具箱（toolbox）**。一个 toolbox 关联一个外部服务（`service-url`），承载一组可被 Agent 调用的工具（tool）。
+工具的注册（OpenAPI 上传）与启停由配套的 [`tool` 命令组](tool.md) 负责。
+
+后端：`/api/agent-operator-integration/v1/tool-box`。
+
+## 命令
+
+```bash
+kweaver toolbox create --name <n> --service-url <url> [--description <d>] [-bd value] [--pretty|--compact]
+kweaver toolbox list   [--keyword <s>] [--limit <n>] [--offset <n>] [-bd value] [--pretty|--compact]
+kweaver toolbox publish   <box-id> [-bd value]
+kweaver toolbox unpublish <box-id> [-bd value]
+kweaver toolbox delete    <box-id> [-y|--yes] [-bd value]
+```
+
+## 子命令说明
+
+### `create`
+
+- 创建一个新 toolbox。
+- 必填：`--name`、`--service-url`。`--description` 可选。
+- 请求体固定字段：`metadata_type=openapi`、`source=custom`（CLI 不暴露）。
+- 输出：后端原始响应（典型形如 `{"box_id": "..."}`），按 `--pretty`（默认）格式化。
+
+```bash
+kweaver toolbox create \
+  --name "weather-svc" \
+  --service-url "https://weather.example.com" \
+  --description "外部天气查询服务"
+```
+
+### `list`
+
+- 列出当前 business domain 下的 toolbox。
+- 可选过滤：`--keyword`（透传给后端）、`--limit`、`--offset`。CLI 不设默认值，未传时由后端决定分页行为。
+- `--limit` / `--offset` 必须是数字，否则报 `--limit must be a number` / `--offset must be a number` 并退出非零。
+- 输出：后端原始 JSON（典型形如 `{"entries": [...]}`），按 `--pretty`/`--compact` 格式化。
+
+```bash
+kweaver toolbox list
+kweaver toolbox list --keyword weather --limit 10
+```
+
+### `publish` / `unpublish`
+
+- `publish`：把 toolbox 状态改为 `published`。
+- `unpublish`：状态改回 `draft`。
+- 成功只在 stderr 打印一行 `Published toolbox <id>` / `Unpublished toolbox <id>`，stdout 无内容（适合脚本）。
+
+```bash
+kweaver toolbox publish 1234567890123456789
+kweaver toolbox unpublish 1234567890123456789
+```
+
+### `delete`
+
+- 删除指定 toolbox。
+- 默认交互式确认（输入 `y` / `yes` 才执行，否则 stderr 打印 `Aborted.` 并退出非零）；脚本中用 `-y` / `--yes` 跳过确认。
+- 成功在 stderr 打印 `Deleted toolbox <id>`。
+
+```bash
+kweaver toolbox delete 1234567890123456789          # 交互式
+kweaver toolbox delete 1234567890123456789 -y       # 自动确认
+```
+
+## 通用选项
+
+| 选项 | 说明 | 适用子命令 |
+|------|------|-----------|
+| `-bd, --biz-domain <s>` | 覆盖业务域。默认走 `resolveBusinessDomain()`（`KWEAVER_BUSINESS_DOMAIN` env → 当前平台 `config.json` → `bd_public`） | 全部 |
+| `--pretty` | 把响应体当作 JSON 解析后以 2 空格缩进重排（解析失败则按原文输出，默认） | `create`、`list` |
+| `--compact` | 原样输出后端响应文本，不做美化（便于管道处理） | `create`、`list` |
+
+## 典型工作流
+
+```bash
+# 1. 建 toolbox（拿到 box_id）
+BOX_ID=$(kweaver toolbox create --name my-svc --service-url https://my.svc --compact \
+         | jq -r '.box_id')
+
+# 2. 上传 OpenAPI 规范，得到该次注册的 tool id 列表
+TOOL_IDS=$(kweaver tool upload --toolbox $BOX_ID ./openapi.json --compact \
+           | jq -r '.success_ids[]')
+
+# 3. 启用刚注册的 tool
+kweaver tool enable --toolbox $BOX_ID $TOOL_IDS
+
+# 4. 发布 toolbox（状态切到 published）
+kweaver toolbox publish $BOX_ID
+```
+
+> 上面的 `box_id` / `success_ids` 字段以 `packages/typescript/test/e2e/toolbox-tool.test.ts` 验证过的真实响应为准；如果后端版本变更，回退到 `kweaver tool list --toolbox $BOX_ID` 拿 id 即可。
+
+## 关联
+
+- 工具上传/启停：[tool.md](tool.md)


### PR DESCRIPTION
## Summary

\`kweaver toolbox\` 和 \`kweaver tool\` 两组命令在 v0.6.5 (#64) 已经发布，但 \`skills/kweaver-core/\` 没有对应的 reference，\`SKILL.md\` 总览表里也没列出。这意味着挂载 kweaver-core 这个 skill 的 LLM 实际上发现不了这两组能力。

本 PR 仅补文档：

- 新增 \`skills/kweaver-core/references/toolbox.md\` —— 覆盖 \`create\` / \`list\` / \`publish\` / \`unpublish\` / \`delete\`
- 新增 \`skills/kweaver-core/references/tool.md\` —— 覆盖 \`upload\` / \`list\` / \`enable\` / \`disable\`
- \`SKILL.md\`：description 加触发关键词、命令组总览表新增两行、操作指南新增"注册外部工具"工作流、底部示例提示加两条

## Accuracy

每条措辞都对着源码 / 测试核对过，避免臆造：

| 文档点 | 源码出处 |
|--------|----------|
| help 字段、子命令、必填校验、错误文本 | \`packages/typescript/src/commands/toolbox.ts\` · \`commands/tool.ts\` |
| \`metadata_type=openapi\` / \`source=custom\` 是请求体硬编码 | \`api/toolboxes.ts\` + \`test/toolboxes.test.ts\` |
| \`box_id\` / \`success_ids\` / \`entries\` 真实响应字段 | \`test/e2e/toolbox-tool.test.ts\` |
| \`-bd\` 默认链路（env → config → bd_public） | \`config/store.ts\` 中的 \`resolveBusinessDomain\` |
| \`--pretty/--compact\` 实际语义（\`compact\` = 原样输出，不做 JSON 转换） | \`commands/call.ts\` 的 \`formatCallOutput\` |

刻意避免了几条没有源码依据的措辞：删除"对外可见、可被 Agent 装载"、"同时删除其下全部 tool"、"OpenAPI 自动拆分多个 tool"、"默认状态通常 disabled" 等推断式描述。

## Test plan

- [x] \`make -C packages/typescript test\` 不受影响（doc-only 改动）
- [ ] reviewer 浏览两份新 reference，确认表述与团队一致

Made with [Cursor](https://cursor.com)