### PR TITLE
feat(ts): initial-password recovery and EACP change-password

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,10 @@ result = client.dataflows.execute(
 ## CLI Quick Reference
 
 ```bash
-kweaver auth login <url> [--alias name] [--no-browser] [-u user] [-p pass] [--http-signin] [--insecure|-k]
+kweaver auth login <url> [--alias name] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
 # -u/-p (with or without --http-signin): HTTP POST /oauth2/signin (yields refresh_token). Missing -u/-p are prompted from stdin (password hidden on TTY).
+# Initial-password lockout (401001017): TTY prompts to change password; scripts use --new-password <pwd>.
+kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (headless host)
 kweaver auth export [url|alias] [--json]
 kweaver auth status / whoami [url|alias] [--json]   # with KWEAVER_BASE_URL+KWEAVER_TOKEN when no ~/.kweaver/ platform

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ result = client.dataflows.execute(
 kweaver auth login <url> [--alias name] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
 # -u/-p (with or without --http-signin): HTTP POST /oauth2/signin (yields refresh_token). Missing -u/-p are prompted from stdin (password hidden on TTY).
 # Initial-password lockout (401001017): TTY prompts to change password; scripts use --new-password <pwd>.
-kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
+kweaver auth change-password [<url>] -u <account> [-o <old>] [-n <new>] [--insecure|-k]
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (headless host)
 kweaver auth export [url|alias] [--json]
 kweaver auth status / whoami [url|alias] [--json]   # with KWEAVER_BASE_URL+KWEAVER_TOKEN when no ~/.kweaver/ platform

--- a/README.zh.md
+++ b/README.zh.md
@@ -237,7 +237,7 @@ result = client.dataflows.execute(
 kweaver auth login <url> [--alias name] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
 # -u/-p（无论是否带 --http-signin）：HTTP POST /oauth2/signin（可拿 refresh_token）；缺失的用户名/密码会从 stdin 提示输入（TTY 下密码隐藏）
 # 初始密码 401001017：TTY 会提示修改；脚本请加 --new-password <pwd>。
-kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
+kweaver auth change-password [<url>] -u <account> [-o <old>] [-n <new>] [--insecure|-k]
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   （无浏览器主机）
 kweaver auth export [url|alias] [--json]
 kweaver auth status / whoami [url|alias] [--json]   # 无 ~/.kweaver/ 当前平台时可配 KWEAVER_BASE_URL+KWEAVER_TOKEN

--- a/README.zh.md
+++ b/README.zh.md
@@ -234,8 +234,10 @@ result = client.dataflows.execute(
 ## 命令速查
 
 ```bash
-kweaver auth login <url> [--alias name] [--no-browser] [-u user] [-p pass] [--http-signin] [--insecure|-k]
+kweaver auth login <url> [--alias name] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
 # -u/-p（无论是否带 --http-signin）：HTTP POST /oauth2/signin（可拿 refresh_token）；缺失的用户名/密码会从 stdin 提示输入（TTY 下密码隐藏）
+# 初始密码 401001017：TTY 会提示修改；脚本请加 --new-password <pwd>。
+kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   （无浏览器主机）
 kweaver auth export [url|alias] [--json]
 kweaver auth status / whoami [url|alias] [--json]   # 无 ~/.kweaver/ 当前平台时可配 KWEAVER_BASE_URL+KWEAVER_TOKEN

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -156,7 +156,7 @@ const skillMd = await client.skills.fetchContent("skill-id");
 kweaver auth login <url> [--alias name] [--no-auth] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
 # -u/-p (with or without --http-signin): HTTP POST /oauth2/signin (yields refresh_token). Missing -u/-p are prompted from stdin (password hidden when TTY).
 # If the server returns error 401001017 (initial password), TTY users get a prompt to set a new password; non-interactive scripts must pass --new-password <pwd>.
-kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
+kweaver auth change-password [<url>] -u <account> [-o <old>] [-n <new>] [--insecure|-k]
 # EACP POST /api/eacp/v1/auth1/modifypassword — no OAuth token required. Omit -o/-n on a TTY to be prompted.
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (headless login)
 kweaver auth export [url|alias] [--json]   (export command to run on a headless host)

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -153,8 +153,11 @@ const skillMd = await client.skills.fetchContent("skill-id");
 ## CLI Reference
 
 ```
-kweaver auth login <url> [--alias name] [--no-auth] [--no-browser] [-u user] [-p pass] [--http-signin] [--insecure|-k]
+kweaver auth login <url> [--alias name] [--no-auth] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
 # -u/-p (with or without --http-signin): HTTP POST /oauth2/signin (yields refresh_token). Missing -u/-p are prompted from stdin (password hidden when TTY).
+# If the server returns error 401001017 (initial password), TTY users get a prompt to set a new password; non-interactive scripts must pass --new-password <pwd>.
+kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
+# EACP POST /api/eacp/v1/auth1/modifypassword — no OAuth token required. Omit -o/-n on a TTY to be prompted.
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (headless login)
 kweaver auth export [url|alias] [--json]   (export command to run on a headless host)
 kweaver auth status / whoami [url|alias] [--json]   # whoami: --json; with KWEAVER_BASE_URL+KWEAVER_TOKEN when no ~/.kweaver/ platform

--- a/packages/typescript/README.zh.md
+++ b/packages/typescript/README.zh.md
@@ -146,8 +146,10 @@ const skillMd = await client.skills.fetchContent("skill-id");
 ## 命令速查
 
 ```
-kweaver auth login <url> [--alias name] [--no-auth] [--no-browser] [-u user] [-p pass] [--http-signin] [--insecure|-k]
+kweaver auth login <url> [--alias name] [--no-auth] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
 # -u/-p（无论是否带 --http-signin）：HTTP POST /oauth2/signin（可拿 refresh_token）；缺失的用户名/密码会从 stdin 提示输入（TTY 下密码隐藏）
+# 若服务端返回 401001017（初始密码），交互终端会引导修改；非交互请使用 --new-password <pwd>。
+kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (无浏览器登录)
 kweaver auth export [url|alias] [--json]   (导出在无浏览器机器上运行的命令)
 kweaver auth status / whoami [url|alias] [--json]   # whoami 支持 --json；无 ~/.kweaver/ 当前平台时可配 KWEAVER_BASE_URL+KWEAVER_TOKEN

--- a/packages/typescript/README.zh.md
+++ b/packages/typescript/README.zh.md
@@ -149,7 +149,7 @@ const skillMd = await client.skills.fetchContent("skill-id");
 kweaver auth login <url> [--alias name] [--no-auth] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
 # -u/-p（无论是否带 --http-signin）：HTTP POST /oauth2/signin（可拿 refresh_token）；缺失的用户名/密码会从 stdin 提示输入（TTY 下密码隐藏）
 # 若服务端返回 401001017（初始密码），交互终端会引导修改；非交互请使用 --new-password <pwd>。
-kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
+kweaver auth change-password [<url>] -u <account> [-o <old>] [-n <new>] [--insecure|-k]
 kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (无浏览器登录)
 kweaver auth export [url|alias] [--json]   (导出在无浏览器机器上运行的命令)
 kweaver auth status / whoami [url|alias] [--json]   # whoami 支持 --json；无 ~/.kweaver/ 当前平台时可配 KWEAVER_BASE_URL+KWEAVER_TOKEN

--- a/packages/typescript/src/auth/eacp-modify-password.ts
+++ b/packages/typescript/src/auth/eacp-modify-password.ts
@@ -1,0 +1,122 @@
+import {
+  constants as cryptoConstants,
+  createPrivateKey,
+  createPublicKey,
+  privateDecrypt,
+  publicEncrypt,
+  type KeyObject,
+} from "node:crypto";
+import { normalizeBaseUrl, runWithTlsInsecure } from "./oauth.js";
+
+/**
+ * 1024-bit RSA private key embedded in ShareServer
+ * (`isf/ShareServer/src/eachttpserver/ncEACHttpServerUtil.cpp`, function
+ * `ncEACHttpServerUtil::RSADecrypt`). It is the keypair used by the EACP
+ * `auth1/modifypassword` endpoint to decrypt `oldpwd` / `newpwd`.
+ *
+ * Note: this key is intentionally hard-coded in the C++ binary and shipped to
+ * every customer; it is not a secret. We embed it here so the CLI can perform
+ * the matching `RSA_PKCS1` encryption without contacting the server.
+ */
+const EACP_MODIFYPWD_PRIVATE_KEY_PEM = `-----BEGIN RSA PRIVATE KEY-----
+MIICXgIBAAKBgQDB2fhLla9rMx+6LWTXajnK11Kdp520s1Q+TfPfIXI/7G9+L2YC
+4RA3M5rgRi32s5+UFQ/CVqUFqMqVuzaZ4lw/uEdk1qHcP0g6LB3E9wkl2FclFR0M
++/HrWmxPoON+0y/tFQxxfNgsUodFzbdh0XY1rIVUIbPLvufUBbLKXHDPpwIDAQAB
+AoGBALCM/H6ajXFs1nCR903aCVicUzoS9qckzI0SIhIOPCfMBp8+PAJTSJl9/ohU
+YnhVj/kmVXwBvboxyJAmOcxdRPWL7iTk5nA1oiVXMer3Wby+tRg/ls91xQbJLVv3
+oGSt7q0CXxJpRH2oYkVVlMMlZUwKz3ovHiLKAnhw+jEsdL2BAkEA9hA97yyeA2eq
+f9dMu/ici99R3WJRRtk4NEI4WShtWPyziDg48d3SOzYmhEJjPuOo3g1ze01os70P
+ApE7d0qcyQJBAMmt+FR8h5MwxPQPAzjh/fTuTttvUfBeMiUDrIycK1I/L96lH+fU
+i4Nu+7TPOzExnPeGO5UJbZxrpIEUB7Zs8O8CQQCLzTCTGiNwxc5eMgH77kVrRudp
+Q7nv6ex/7Hu9VDXEUFbkdyULbj9KuvppPJrMmWZROw04qgNp02mayM8jeLXZAkEA
+o+PM/pMn9TPXiWE9xBbaMhUKXgXLd2KEq1GeAbHS/oY8l1hmYhV1vjwNLbSNrH9d
+yEP73TQJL+jFiONHFTbYXwJAU03Xgum5mLIkX/02LpOrz2QCdfX1IMJk2iKi9osV
+KqfbvHsF0+GvFGg18/FXStG9Kr4TjqLsygQJT76/MnMluw==
+-----END RSA PRIVATE KEY-----`;
+
+let cachedPubKey: KeyObject | undefined;
+
+function getModifyPwdPublicKey(): KeyObject {
+  if (!cachedPubKey) {
+    cachedPubKey = createPublicKey(createPrivateKey(EACP_MODIFYPWD_PRIVATE_KEY_PEM));
+  }
+  return cachedPubKey;
+}
+
+/** Encrypt a password with EACP modifypassword's RSA public key, base64-encoded. */
+export function encryptModifyPwd(plain: string, publicKeyPem?: string): string {
+  const key = publicKeyPem ? createPublicKey(publicKeyPem) : getModifyPwdPublicKey();
+  const buf = publicEncrypt(
+    { key, padding: cryptoConstants.RSA_PKCS1_PADDING },
+    Buffer.from(plain, "utf8"),
+  );
+  return buf.toString("base64");
+}
+
+/** @internal For unit tests: decrypt ciphertext produced by encryptModifyPwd with the embedded key. */
+export function decryptModifyPwdForTest(cipherB64: string): string {
+  const key = createPrivateKey(EACP_MODIFYPWD_PRIVATE_KEY_PEM);
+  const buf = privateDecrypt(
+    { key, padding: cryptoConstants.RSA_PKCS1_PADDING },
+    Buffer.from(cipherB64, "base64"),
+  );
+  return buf.toString("utf8");
+}
+
+export interface EacpModifyPasswordOptions {
+  account: string;
+  oldPassword: string;
+  newPassword: string;
+  /** Override the embedded RSA public key (PEM). */
+  publicKeyPem?: string;
+  tlsInsecure?: boolean;
+}
+
+export interface EacpModifyPasswordResult {
+  status: number;
+  ok: boolean;
+  body: string;
+  json?: unknown;
+}
+
+/**
+ * Call EACP `POST /api/eacp/v1/auth1/modifypassword` to change a user's password
+ * when the old password is known (`isforgetpwd: false`).
+ *
+ * No bearer token / cookie is required — the endpoint authenticates by old password.
+ */
+export async function eacpModifyPassword(
+  baseUrl: string,
+  options: EacpModifyPasswordOptions,
+): Promise<EacpModifyPasswordResult> {
+  return runWithTlsInsecure(options.tlsInsecure, async () => {
+    const body: Record<string, unknown> = {
+      account: options.account,
+      oldpwd: encryptModifyPwd(options.oldPassword, options.publicKeyPem),
+      newpwd: encryptModifyPwd(options.newPassword, options.publicKeyPem),
+      vcodeinfo: {
+        uuid: "",
+        vcode: "",
+      },
+      isforgetpwd: false,
+    };
+
+    const url = `${normalizeBaseUrl(baseUrl)}/api/eacp/v1/auth1/modifypassword`;
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/plain, */*",
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await resp.text();
+    let json: unknown;
+    try {
+      json = text ? JSON.parse(text) : undefined;
+    } catch {
+      /* not JSON */
+    }
+    return { status: resp.status, ok: resp.ok, body: text, json };
+  });
+}

--- a/packages/typescript/src/auth/oauth.ts
+++ b/packages/typescript/src/auth/oauth.ts
@@ -18,6 +18,23 @@ import {
 } from "../config/store.js";
 import { HttpError, NetworkRequestError, fetchWithRetry } from "../utils/http.js";
 
+/** Thrown when `POST /oauth2/signin` returns HTTP 401 with EACP code `401001017` (initial password must be changed). */
+export class InitialPasswordChangeRequiredError extends Error {
+  readonly code = 401001017;
+  readonly account: string;
+  readonly baseUrl: string;
+  readonly httpStatus = 401;
+  readonly serverMessage: string;
+
+  constructor(opts: { account: string; baseUrl: string; serverMessage: string }) {
+    super(opts.serverMessage);
+    this.name = "InitialPasswordChangeRequiredError";
+    this.account = opts.account;
+    this.baseUrl = opts.baseUrl;
+    this.serverMessage = opts.serverMessage;
+  }
+}
+
 const TOKEN_TTL_SECONDS = 3600;
 
 /** Seconds before access token expiry to trigger refresh (matches Python ConfigAuth). */
@@ -1535,6 +1552,25 @@ export async function oauth2PasswordSigninLogin(
           );
         }
       } else {
+        if (postResp.status === 401) {
+          try {
+            const j = JSON.parse(bodyText) as { code?: unknown; message?: unknown };
+            const c = j.code;
+            if (c === 401001017 || c === "401001017") {
+              const msg =
+                typeof j.message === "string" && j.message.trim() !== ""
+                  ? j.message.trim()
+                  : "Initial password must be changed before login.";
+              throw new InitialPasswordChangeRequiredError({
+                account: options.username,
+                baseUrl: base,
+                serverMessage: msg,
+              });
+            }
+          } catch (e) {
+            if (e instanceof InitialPasswordChangeRequiredError) throw e;
+          }
+        }
         throw new HttpError(postResp.status, postResp.statusText, bodyText);
       }
     }
@@ -1967,6 +2003,9 @@ function isTlsVerificationDisabledForProcess(): boolean {
 }
 
 export function formatHttpError(error: unknown): string {
+  if (error instanceof InitialPasswordChangeRequiredError) {
+    return `${error.serverMessage} (code ${error.code})`;
+  }
   if (error instanceof HttpError) {
     const oauthMessage = formatOAuthErrorBody(error.body);
     if (oauthMessage) {

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -24,9 +24,10 @@ Usage:
   kweaver --version | -V
   kweaver --help | -h
 
-  kweaver auth <platform-url> [--alias name] [--no-auth] [--no-browser] [-u user] [-p pass] [--http-signin] [--insecure|-k]
+  kweaver auth <platform-url> [--alias name] [--no-auth] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
   kweaver auth login <platform-url>          (alias for auth <url>)
   kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (run on host without browser)
+  kweaver auth change-password <platform-url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
   kweaver auth whoami [platform-url|alias] [--json]
   kweaver auth export [platform-url|alias] [--json]
   kweaver auth status [platform-url|alias]

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -27,7 +27,7 @@ Usage:
   kweaver auth <platform-url> [--alias name] [--no-auth] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--insecure|-k]
   kweaver auth login <platform-url>          (alias for auth <url>)
   kweaver auth login <url> --client-id ID --client-secret S --refresh-token T   (run on host without browser)
-  kweaver auth change-password <platform-url> -u <account> [-o <old>] [-n <new>] [--public-key-file <pem>] [--insecure|-k]
+  kweaver auth change-password [<platform-url>] -u <account> [-o <old>] [-n <new>] [--insecure|-k]
   kweaver auth whoami [platform-url|alias] [--json]
   kweaver auth export [platform-url|alias] [--json]
   kweaver auth status [platform-url|alias]

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -53,7 +53,7 @@ kweaver auth users [url|alias]       List all user profiles (with usernames) for
 kweaver auth switch [url|alias] --user <id|username>  Switch active user for a platform
 kweaver auth logout [url|alias] [--user <id>]  Logout (clear local token)
 kweaver auth delete <url|alias> [--user <id>]  Delete saved credentials
-kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>]  Change password (EACP modifypassword; no token required)
+kweaver auth change-password [<url>] -u <account> [-o <old>] [-n <new>]  Change password (EACP modifypassword; URL optional, no token required)
 
 Login options:
   --alias <name>         Save platform with a short alias (use with use / status / logout)
@@ -832,7 +832,7 @@ async function loginWithInitialPasswordRecovery(
 
 async function runAuthChangePasswordCommand(args: string[]): Promise<number> {
   if (args[0] === "--help" || args[0] === "-h") {
-    console.log(`kweaver auth change-password <platform-url> [options]
+    console.log(`kweaver auth change-password [<platform-url>] [options]
 
 Change the EACP account password via POST /api/eacp/v1/auth1/modifypassword.
 No saved OAuth token is required.
@@ -841,21 +841,10 @@ Options:
   -u, --account <name>       Account / login name (required)
   -o, --old-password <pwd>   Current password (omit on TTY to be prompted)
   -n, --new-password <pwd>   New password, 6-100 characters (omit on TTY to be prompted)
-  --public-key-file <path>   Override RSA public key (PEM) for password encryption
-  --insecure, -k             Skip TLS certificate verification`);
-    return 0;
-  }
+  --insecure, -k             Skip TLS certificate verification
 
-  const url = args[0];
-  if (!url || url.startsWith("-")) {
-    console.error(
-      "Usage: kweaver auth change-password <platform-url> -u <account> [-o <old-password>] [-n <new-password>] [--public-key-file <path>] [--insecure|-k]",
-    );
-    return 1;
-  }
-  if (!/^https?:\/\//.test(url)) {
-    console.error("Expected a platform URL starting with http:// or https://.");
-    return 1;
+Platform URL is optional; defaults to the current active platform (kweaver auth use).`);
+    return 0;
   }
 
   const KNOWN_CP_FLAGS = new Set([
@@ -865,7 +854,6 @@ Options:
     "--old-password",
     "-n",
     "--new-password",
-    "--public-key-file",
     "--insecure",
     "-k",
     "--help",
@@ -878,10 +866,14 @@ Options:
     "--old-password",
     "-n",
     "--new-password",
-    "--public-key-file",
   ]);
-  for (let i = 1; i < args.length; i++) {
-    const a = args[i];
+
+  // First positional (if present and not a flag) is the platform URL or alias.
+  const positional = args[0] && !args[0].startsWith("-") ? args[0] : undefined;
+  const flagArgs = positional ? args.slice(1) : args;
+
+  for (let i = 0; i < flagArgs.length; i++) {
+    const a = flagArgs[i];
     if (a.startsWith("-") && !KNOWN_CP_FLAGS.has(a)) {
       console.error(`Unknown option: ${a}`);
       console.error("Run 'kweaver auth change-password --help' for usage.");
@@ -890,13 +882,32 @@ Options:
     if (KNOWN_CP_VALUE.has(a)) i++;
   }
 
-  const normalizedTarget = normalizeBaseUrl(url);
+  let normalizedTarget: string;
+  if (positional) {
+    const resolved = /^https?:\/\//.test(positional)
+      ? positional
+      : resolvePlatformIdentifier(positional) ?? positional;
+    if (!/^https?:\/\//.test(resolved)) {
+      console.error(`Cannot resolve platform: ${positional}. Provide a full URL or a known alias (kweaver auth list).`);
+      return 1;
+    }
+    normalizedTarget = normalizeBaseUrl(resolved);
+  } else {
+    const current = getCurrentPlatform();
+    if (!current) {
+      console.error(
+        "No active platform. Pass <platform-url> or run `kweaver auth use <url|alias>` first.",
+      );
+      return 1;
+    }
+    normalizedTarget = current;
+  }
+
   const account =
-    readOption(args, "--account") ?? readOption(args, "-u");
-  let oldPassword = readOption(args, "--old-password") ?? readOption(args, "-o");
-  let newPassword = readOption(args, "--new-password") ?? readOption(args, "-n");
-  const publicKeyFile = readOption(args, "--public-key-file");
-  const tlsInsecure = args.includes("--insecure") || args.includes("-k");
+    readOption(flagArgs, "--account") ?? readOption(flagArgs, "-u");
+  let oldPassword = readOption(flagArgs, "--old-password") ?? readOption(flagArgs, "-o");
+  let newPassword = readOption(flagArgs, "--new-password") ?? readOption(flagArgs, "-n");
+  const tlsInsecure = flagArgs.includes("--insecure") || flagArgs.includes("-k");
 
   if (!account?.trim()) {
     console.error("Missing required -u/--account.");
@@ -929,16 +940,10 @@ Options:
 
     validateNewPasswordLengthForEacp(newPassword!);
 
-    let publicKeyPem: string | undefined;
-    if (publicKeyFile?.trim()) {
-      publicKeyPem = (await readFile(publicKeyFile.trim(), "utf8")).trim();
-    }
-
     const result = await eacpModifyPassword(normalizedTarget, {
       account: account.trim(),
       oldPassword: oldPassword!,
       newPassword: newPassword!,
-      publicKeyPem,
       tlsInsecure,
     });
 

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -22,10 +22,13 @@ import {
   setCurrentPlatform,
   setPlatformAlias,
 } from "../config/store.js";
+import { readFile } from "node:fs/promises";
 import { decodeJwtPayload } from "../config/jwt.js";
+import { eacpModifyPassword } from "../auth/eacp-modify-password.js";
 import {
   buildCopyCommand,
   formatHttpError,
+  InitialPasswordChangeRequiredError,
   normalizeBaseUrl,
   oauth2Login,
   oauth2PasswordSigninLogin,
@@ -50,6 +53,7 @@ kweaver auth users [url|alias]       List all user profiles (with usernames) for
 kweaver auth switch [url|alias] --user <id|username>  Switch active user for a platform
 kweaver auth logout [url|alias] [--user <id>]  Logout (clear local token)
 kweaver auth delete <url|alias> [--user <id>]  Delete saved credentials
+kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>]  Change password (EACP modifypassword; no token required)
 
 Login options:
   --alias <name>         Save platform with a short alias (use with use / status / logout)
@@ -67,6 +71,7 @@ Login options:
   -u, --username         Username for HTTP /oauth2/signin (POST). If -p is omitted, password is prompted.
   -p, --password         Password for HTTP /oauth2/signin (POST). If -u is omitted, username is prompted.
   --http-signin          Force HTTP /oauth2/signin (no browser). Missing -u/-p are prompted from stdin.
+  --new-password <pwd>   After HTTP sign-in error 401001017 (initial password), set the new password non-interactively, then retry login.
   --insecure, -k         Skip TLS certificate verification (self-signed / dev HTTPS only)
   --no-auth              Save platform without OAuth (servers with no authentication). Same as detecting OAuth 404 during login.`);
 
@@ -75,7 +80,7 @@ Login options:
 
   if (target === "login") {
     if (rest[0] === "--help" || rest[0] === "-h") {
-      console.log(`kweaver auth login <platform-url> [--alias <name>] [--no-auth] [--no-browser] [-u user] [-p pass] [--http-signin] [--refresh-token T --client-id ID --client-secret S]`);
+      console.log(`kweaver auth login <platform-url> [--alias <name>] [--no-auth] [--no-browser] [-u user] [-p pass] [--new-password <pwd>] [--http-signin] [--refresh-token T --client-id ID --client-secret S]`);
       return 0;
     }
     const url = rest[0];
@@ -104,6 +109,10 @@ Login options:
     return runAuthSwitchCommand(rest);
   }
 
+  if (target === "change-password") {
+    return runAuthChangePasswordCommand(rest);
+  }
+
   const LOGIN_SUBCOMMANDS = new Set(["status", "list", "use", "delete", "logout", "export", "whoami", "users", "switch"]);
   if (target && !LOGIN_SUBCOMMANDS.has(target)) {
     try {
@@ -122,6 +131,7 @@ Login options:
       const tlsInsecure = args.includes("--insecure") || args.includes("-k");
       const noAuth = args.includes("--no-auth");
       const noBrowser = args.includes("--no-browser");
+      const newPasswordFlag = readOption(args, "--new-password");
 
       if (args.includes("--redirect-uri")) {
         console.error("Warning: --redirect-uri is deprecated and ignored. The redirect URI is always http://127.0.0.1:<port>/callback.");
@@ -131,6 +141,7 @@ Login options:
         "--alias", "--client-id", "--client-secret", "--refresh-token",
         "--port", "--no-browser", "--username", "-u", "--password", "-p",
         "--http-signin",
+        "--new-password",
         "--oauth-product",
         "--signin-public-key-file",
         "--insecure", "-k", "--no-auth", "--redirect-uri",
@@ -138,6 +149,7 @@ Login options:
       const KNOWN_VALUE_FLAGS = new Set([
         "--alias", "--client-id", "--client-secret", "--refresh-token",
         "--port", "--username", "-u", "--password", "-p", "--redirect-uri",
+        "--new-password",
         "--oauth-product",
         "--signin-public-key-file",
       ]);
@@ -165,6 +177,10 @@ Login options:
       }
       if (noAuth && (username || password || httpSignin)) {
         console.error("--no-auth cannot be used with HTTP sign-in or -u/-p.");
+        return 1;
+      }
+      if (newPasswordFlag !== undefined && (!username || !password)) {
+        console.error("--new-password requires -u/--username and -p/--password (HTTP sign-in).");
         return 1;
       }
       if (noBrowser && httpSignin) {
@@ -206,30 +222,22 @@ Login options:
         token = await refreshTokenLogin(normalizedTarget, {
           clientId, clientSecret, refreshToken, tlsInsecure,
         });
-      } else if (username && password && httpSignin) {
-        console.log("Logging in (HTTP /oauth2/signin)...");
-        token = await oauth2PasswordSigninLogin(normalizedTarget, {
-          username,
-          password,
-          tlsInsecure,
-          port: customPort,
-          clientId: clientId ?? undefined,
-          clientSecret: clientSecret ?? undefined,
-          oauthProduct: oauthProduct ?? undefined,
-          signinPublicKeyPemPath: signinPublicKeyFile ?? undefined,
-        });
       } else if (username && password) {
         console.log("Logging in (HTTP /oauth2/signin)...");
-        token = await oauth2PasswordSigninLogin(normalizedTarget, {
-          username,
-          password,
-          tlsInsecure,
-          port: customPort,
-          clientId: clientId ?? undefined,
-          clientSecret: clientSecret ?? undefined,
-          oauthProduct: oauthProduct ?? undefined,
-          signinPublicKeyPemPath: signinPublicKeyFile ?? undefined,
-        });
+        token = await loginWithInitialPasswordRecovery(
+          normalizedTarget,
+          {
+            username,
+            password,
+            tlsInsecure,
+            port: customPort,
+            clientId: clientId ?? undefined,
+            clientSecret: clientSecret ?? undefined,
+            oauthProduct: oauthProduct ?? undefined,
+            signinPublicKeyPemPath: signinPublicKeyFile ?? undefined,
+          },
+          { newPasswordFlag, tlsInsecure },
+        );
       } else {
         if (noBrowser) {
           console.log("OAuth2 login (no browser — open the URL on any device, then paste the callback URL or code)...");
@@ -719,4 +727,230 @@ function readOption(args: string[], name: string): string | undefined {
   }
 
   return args[index + 1];
+}
+
+const EACP_NEW_PWD_MIN = 6;
+const EACP_NEW_PWD_MAX = 100;
+
+function validateNewPasswordLengthForEacp(pwd: string): void {
+  if (pwd.length < EACP_NEW_PWD_MIN || pwd.length > EACP_NEW_PWD_MAX) {
+    throw new Error(
+      `New password must be between ${EACP_NEW_PWD_MIN} and ${EACP_NEW_PWD_MAX} characters.`,
+    );
+  }
+}
+
+function formatEacpModifyFailure(
+  status: number,
+  json: unknown | undefined,
+  body: string,
+): string {
+  if (json && typeof json === "object" && json !== null) {
+    const o = json as { message?: unknown; cause?: unknown };
+    const msg =
+      typeof o.message === "string" && o.message.trim() !== ""
+        ? o.message
+        : typeof o.cause === "string"
+          ? o.cause
+          : "";
+    if (msg) return `Password change failed (HTTP ${status}): ${msg}`;
+  }
+  return `Password change failed (HTTP ${status}): ${body.slice(0, 500)}`;
+}
+
+async function promptYesNo(message: string): Promise<boolean> {
+  const { createInterface } = await import("node:readline");
+  const rl = createInterface({ input: process.stdin, output: process.stderr });
+  return await new Promise<boolean>((resolve, reject) => {
+    let answered = false;
+    rl.on("close", () => {
+      if (!answered) reject(new Error("Login cancelled."));
+    });
+    rl.question(`${message} [Y/n] `, (answer) => {
+      answered = true;
+      rl.close();
+      const a = answer.trim().toLowerCase();
+      resolve(a === "" || a === "y" || a === "yes");
+    });
+  });
+}
+
+async function loginWithInitialPasswordRecovery(
+  normalizedTarget: string,
+  signinOpts: Parameters<typeof oauth2PasswordSigninLogin>[1],
+  recovery: { newPasswordFlag: string | undefined; tlsInsecure: boolean },
+) {
+  try {
+    return await oauth2PasswordSigninLogin(normalizedTarget, signinOpts);
+  } catch (e) {
+    if (!(e instanceof InitialPasswordChangeRequiredError)) throw e;
+    const err = e;
+    const account = signinOpts.username;
+    const oldPwd = signinOpts.password;
+
+    let newPwd: string | undefined = recovery.newPasswordFlag;
+
+    if (newPwd !== undefined) {
+      validateNewPasswordLengthForEacp(newPwd);
+    } else if (process.stderr.isTTY) {
+      process.stderr.write(`${err.serverMessage}\n`);
+      const ok = await promptYesNo(
+        `Account "${account}" must change its initial password. Proceed with password change now?`,
+      );
+      if (!ok) {
+        throw new Error("Initial password change declined. Run again when ready.");
+      }
+      const np1 = await promptForPassword("New password (6-100 characters)");
+      const np2 = await promptForPassword("Confirm new password");
+      if (np1 !== np2) {
+        throw new Error("New passwords do not match.");
+      }
+      validateNewPasswordLengthForEacp(np1);
+      newPwd = np1;
+    } else {
+      throw new Error(
+        "This account must change its initial password (error 401001017). Re-run with --new-password <password> (non-interactive).",
+      );
+    }
+
+    const mod = await eacpModifyPassword(normalizedTarget, {
+      account,
+      oldPassword: oldPwd,
+      newPassword: newPwd,
+      tlsInsecure: recovery.tlsInsecure,
+    });
+    if (!mod.ok) {
+      throw new Error(formatEacpModifyFailure(mod.status, mod.json, mod.body));
+    }
+
+    return oauth2PasswordSigninLogin(normalizedTarget, {
+      ...signinOpts,
+      password: newPwd,
+    });
+  }
+}
+
+async function runAuthChangePasswordCommand(args: string[]): Promise<number> {
+  if (args[0] === "--help" || args[0] === "-h") {
+    console.log(`kweaver auth change-password <platform-url> [options]
+
+Change the EACP account password via POST /api/eacp/v1/auth1/modifypassword.
+No saved OAuth token is required.
+
+Options:
+  -u, --account <name>       Account / login name (required)
+  -o, --old-password <pwd>   Current password (omit on TTY to be prompted)
+  -n, --new-password <pwd>   New password, 6-100 characters (omit on TTY to be prompted)
+  --public-key-file <path>   Override RSA public key (PEM) for password encryption
+  --insecure, -k             Skip TLS certificate verification`);
+    return 0;
+  }
+
+  const url = args[0];
+  if (!url || url.startsWith("-")) {
+    console.error(
+      "Usage: kweaver auth change-password <platform-url> -u <account> [-o <old-password>] [-n <new-password>] [--public-key-file <path>] [--insecure|-k]",
+    );
+    return 1;
+  }
+  if (!/^https?:\/\//.test(url)) {
+    console.error("Expected a platform URL starting with http:// or https://.");
+    return 1;
+  }
+
+  const KNOWN_CP_FLAGS = new Set([
+    "-u",
+    "--account",
+    "-o",
+    "--old-password",
+    "-n",
+    "--new-password",
+    "--public-key-file",
+    "--insecure",
+    "-k",
+    "--help",
+    "-h",
+  ]);
+  const KNOWN_CP_VALUE = new Set([
+    "-u",
+    "--account",
+    "-o",
+    "--old-password",
+    "-n",
+    "--new-password",
+    "--public-key-file",
+  ]);
+  for (let i = 1; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith("-") && !KNOWN_CP_FLAGS.has(a)) {
+      console.error(`Unknown option: ${a}`);
+      console.error("Run 'kweaver auth change-password --help' for usage.");
+      return 1;
+    }
+    if (KNOWN_CP_VALUE.has(a)) i++;
+  }
+
+  const normalizedTarget = normalizeBaseUrl(url);
+  const account =
+    readOption(args, "--account") ?? readOption(args, "-u");
+  let oldPassword = readOption(args, "--old-password") ?? readOption(args, "-o");
+  let newPassword = readOption(args, "--new-password") ?? readOption(args, "-n");
+  const publicKeyFile = readOption(args, "--public-key-file");
+  const tlsInsecure = args.includes("--insecure") || args.includes("-k");
+
+  if (!account?.trim()) {
+    console.error("Missing required -u/--account.");
+    return 1;
+  }
+
+  const interactive = process.stdin.isTTY === true && process.stderr.isTTY === true;
+  try {
+    if (!interactive) {
+      if (!oldPassword || !newPassword) {
+        console.error(
+          "In non-interactive mode, --old-password and --new-password are required.",
+        );
+        return 1;
+      }
+    } else {
+      if (!oldPassword) {
+        oldPassword = await promptForPassword("Old password");
+      }
+      if (!newPassword) {
+        const n1 = await promptForPassword("New password (6-100 characters)");
+        const n2 = await promptForPassword("Confirm new password");
+        if (n1 !== n2) {
+          console.error("New passwords do not match.");
+          return 1;
+        }
+        newPassword = n1;
+      }
+    }
+
+    validateNewPasswordLengthForEacp(newPassword!);
+
+    let publicKeyPem: string | undefined;
+    if (publicKeyFile?.trim()) {
+      publicKeyPem = (await readFile(publicKeyFile.trim(), "utf8")).trim();
+    }
+
+    const result = await eacpModifyPassword(normalizedTarget, {
+      account: account.trim(),
+      oldPassword: oldPassword!,
+      newPassword: newPassword!,
+      publicKeyPem,
+      tlsInsecure,
+    });
+
+    if (!result.ok) {
+      console.error(formatEacpModifyFailure(result.status, result.json, result.body));
+      return 1;
+    }
+
+    console.log(`Password changed for ${account.trim()} on ${normalizedTarget}`);
+    return 0;
+  } catch (e) {
+    console.error(formatHttpError(e));
+    return 1;
+  }
 }

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -882,25 +882,16 @@ Platform URL is optional; defaults to the current active platform (kweaver auth 
     if (KNOWN_CP_VALUE.has(a)) i++;
   }
 
-  let normalizedTarget: string;
-  if (positional) {
-    const resolved = /^https?:\/\//.test(positional)
-      ? positional
-      : resolvePlatformIdentifier(positional) ?? positional;
-    if (!/^https?:\/\//.test(resolved)) {
-      console.error(`Cannot resolve platform: ${positional}. Provide a full URL or a known alias (kweaver auth list).`);
-      return 1;
-    }
-    normalizedTarget = normalizeBaseUrl(resolved);
-  } else {
-    const current = getCurrentPlatform();
-    if (!current) {
-      console.error(
-        "No active platform. Pass <platform-url> or run `kweaver auth use <url|alias>` first.",
-      );
-      return 1;
-    }
-    normalizedTarget = current;
+  const normalizedTarget = resolvePlatformArg(args);
+  if (!normalizedTarget) {
+    console.error(
+      "No platform resolved. Pass <platform-url|alias> or run `kweaver auth use <url|alias>` first.",
+    );
+    return 1;
+  }
+  if (!/^https?:\/\//.test(normalizedTarget)) {
+    console.error(`Cannot resolve platform: ${normalizedTarget}. Provide a full URL or a known alias (kweaver auth list).`);
+    return 1;
   }
 
   const account =

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -882,15 +882,11 @@ Platform URL is optional; defaults to the current active platform (kweaver auth 
     if (KNOWN_CP_VALUE.has(a)) i++;
   }
 
-  const normalizedTarget = resolvePlatformArg(args);
+  const normalizedTarget = resolvePlatformArg(positional ? [positional] : []);
   if (!normalizedTarget) {
     console.error(
       "No platform resolved. Pass <platform-url|alias> or run `kweaver auth use <url|alias>` first.",
     );
-    return 1;
-  }
-  if (!/^https?:\/\//.test(normalizedTarget)) {
-    console.error(`Cannot resolve platform: ${normalizedTarget}. Provide a full URL or a known alias (kweaver auth list).`);
     return 1;
   }
 

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -264,8 +264,11 @@ export { decodeJwtPayload, extractUserIdFromJwt } from "./config/jwt.js";
 // ── OAuth (advanced — CLI uses these internally; optional for custom login tools) ─
 export {
   DEFAULT_SIGNIN_RSA_MODULUS_HEX,
+  InitialPasswordChangeRequiredError,
   oauth2PasswordSigninLogin,
   parseSigninPageHtmlProps,
   rsaModulusHexToSpkiPem,
   STUDIOWEB_LOGIN_PUBLIC_KEY_PEM,
 } from "./auth/oauth.js";
+
+export { eacpModifyPassword, encryptModifyPwd } from "./auth/eacp-modify-password.js";

--- a/packages/typescript/test/auth-change-password.test.ts
+++ b/packages/typescript/test/auth-change-password.test.ts
@@ -1,0 +1,126 @@
+/**
+ * kweaver auth change-password CLI (EACP modifypassword).
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+function createConfigDir(): string {
+  return mkdtempSync(join(tmpdir(), "kweaver-auth-chpwd-"));
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+test("change-password: posts to modifypassword and passes -k (TLS insecure)", async () => {
+  const configDir = createConfigDir();
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const t = `${Date.now()}-${Math.random()}`;
+  const auth = await import(`${pathToFileURL(join(process.cwd(), "src/commands/auth.ts")).href}?${t}`);
+
+  let sawInsecure = false;
+  const originalTls = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const u = requestUrl(input);
+    if (u.includes("/api/eacp/v1/auth1/modifypassword")) {
+      if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === "0") sawInsecure = true;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response("unexpected", { status: 500 });
+  };
+
+  try {
+    const code = await auth.runAuthCommand([
+      "change-password",
+      "https://plat.example.com/",
+      "-u",
+      "alice",
+      "-o",
+      "oldsecret",
+      "-n",
+      "newsecret123456",
+      "-k",
+    ]);
+    assert.equal(code, 0);
+    assert.equal(sawInsecure, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    if (originalTls === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    else process.env.NODE_TLS_REJECT_UNAUTHORIZED = originalTls;
+  }
+});
+
+test("change-password: non-TTY missing -o / -n exits 1 without fetch", async () => {
+  const configDir = createConfigDir();
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const t = `${Date.now()}-${Math.random()}`;
+  const auth = await import(`${pathToFileURL(join(process.cwd(), "src/commands/auth.ts")).href}?${t}`);
+
+  let fetchCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCalls++;
+    return new Response("{}", { status: 200 });
+  };
+  const originalStdinIsTTY = process.stdin.isTTY;
+  const originalStderrIsTTY = process.stderr.isTTY;
+  process.stdin.isTTY = false;
+  process.stderr.isTTY = false;
+
+  try {
+    const code = await auth.runAuthCommand([
+      "change-password",
+      "https://plat.example.com/",
+      "-u",
+      "alice",
+      "-n",
+      "newsecret123456",
+    ]);
+    assert.equal(code, 1);
+    assert.equal(fetchCalls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+    process.stdin.isTTY = originalStdinIsTTY;
+    process.stderr.isTTY = originalStderrIsTTY;
+  }
+});
+
+test("change-password: server 4xx JSON message is surfaced", async () => {
+  const configDir = createConfigDir();
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const t = `${Date.now()}-${Math.random()}`;
+  const auth = await import(`${pathToFileURL(join(process.cwd(), "src/commands/auth.ts")).href}?${t}`);
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({ message: "bad old password", cause: "eacp" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+
+  try {
+    const code = await auth.runAuthCommand([
+      "change-password",
+      "https://plat.example.com/",
+      "-u",
+      "alice",
+      "-o",
+      "wrong",
+      "-n",
+      "newsecret123456",
+    ]);
+    assert.equal(code, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/typescript/test/auth-change-password.test.ts
+++ b/packages/typescript/test/auth-change-password.test.ts
@@ -95,6 +95,74 @@ test("change-password: non-TTY missing -o / -n exits 1 without fetch", async () 
   }
 });
 
+test("change-password: omitted URL falls back to current platform", async () => {
+  const configDir = createConfigDir();
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const t = `${Date.now()}-${Math.random()}`;
+  const auth = await import(`${pathToFileURL(join(process.cwd(), "src/commands/auth.ts")).href}?${t}`);
+  const store = await import(`${pathToFileURL(join(process.cwd(), "src/config/store.ts")).href}?${t}`);
+
+  store.saveNoAuthPlatform("https://plat.example.com/", { tlsInsecure: false });
+  store.setCurrentPlatform("https://plat.example.com");
+
+  let postUrl = "";
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    postUrl = requestUrl(input);
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const code = await auth.runAuthCommand([
+      "change-password",
+      "-u",
+      "alice",
+      "-o",
+      "oldsecret",
+      "-n",
+      "newsecret123456",
+    ]);
+    assert.equal(code, 0);
+    assert.ok(postUrl.startsWith("https://plat.example.com/"), `posted to ${postUrl}`);
+    assert.ok(postUrl.includes("/api/eacp/v1/auth1/modifypassword"));
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("change-password: omitted URL with no current platform exits 1", async () => {
+  const configDir = createConfigDir();
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const t = `${Date.now()}-${Math.random()}`;
+  const auth = await import(`${pathToFileURL(join(process.cwd(), "src/commands/auth.ts")).href}?${t}`);
+
+  let fetchCalls = 0;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    fetchCalls++;
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const code = await auth.runAuthCommand([
+      "change-password",
+      "-u",
+      "alice",
+      "-o",
+      "oldsecret",
+      "-n",
+      "newsecret123456",
+    ]);
+    assert.equal(code, 1);
+    assert.equal(fetchCalls, 0);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("change-password: server 4xx JSON message is surfaced", async () => {
   const configDir = createConfigDir();
   process.env.KWEAVERC_CONFIG_DIR = configDir;

--- a/packages/typescript/test/auth-initial-password-recovery.test.ts
+++ b/packages/typescript/test/auth-initial-password-recovery.test.ts
@@ -1,0 +1,121 @@
+/**
+ * HTTP sign-in: initial password (401001017) typed error and auth CLI hint.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+const SIGNIN_HTML = `<!DOCTYPE html><script id="__NEXT_DATA__" type="application/json">${JSON.stringify({
+  props: { pageProps: { challenge: "ch1", csrftoken: "csrf1" } },
+})}</script>`;
+
+function createConfigDir(): string {
+  return mkdtempSync(join(tmpdir(), "kweaver-oauth-initpwd-"));
+}
+
+async function importOauth(configDir: string) {
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const t = `${Date.now()}-${Math.random()}`;
+  return import(`../src/auth/oauth.ts?t=${t}`);
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function stubFetch401017(baseUrl: string): () => void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const u = requestUrl(input);
+    const method = init?.method ?? "GET";
+    if (method === "POST" && u.includes("/oauth2/signin")) {
+      return new Response(
+        JSON.stringify({
+          code: 401001017,
+          message: "must change initial password",
+        }),
+        { status: 401, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (u.includes("/oauth2/auth?")) {
+      return new Response(null, {
+        status: 302,
+        headers: { Location: `${baseUrl}/oauth2/signin?login_challenge=lc1` },
+      });
+    }
+    if (u.includes("/oauth2/signin")) {
+      return new Response(SIGNIN_HTML, {
+        status: 200,
+        headers: { "Content-Type": "text/html" },
+      });
+    }
+    return new Response(`unexpected: ${method} ${u}`, { status: 500 });
+  };
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+test("oauth2PasswordSigninLogin throws InitialPasswordChangeRequiredError on 401001017", async () => {
+  const configDir = createConfigDir();
+  const oauth = await importOauth(configDir);
+  const { InitialPasswordChangeRequiredError: IPwdErr } = oauth;
+  const baseUrl = "https://plat.example.com";
+  const restore = stubFetch401017(baseUrl);
+  try {
+    await assert.rejects(
+      () =>
+        oauth.oauth2PasswordSigninLogin(baseUrl, {
+          username: "u1",
+          password: "p1",
+          clientId: "cid",
+          clientSecret: "sec",
+        }),
+      (e: unknown) => {
+        assert.ok(e instanceof IPwdErr);
+        const err = e as InstanceType<typeof IPwdErr>;
+        assert.equal(err.code, 401001017);
+        assert.equal(err.account, "u1");
+        assert.equal(err.httpStatus, 401);
+        assert.equal(err.serverMessage, "must change initial password");
+        return true;
+      },
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("runAuthCommand: non-TTY exits 1 when 401001017 and no --new-password", async () => {
+  const configDir = createConfigDir();
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const t = `${Date.now()}-${Math.random()}`;
+  const auth = await import(`${pathToFileURL(join(process.cwd(), "src/commands/auth.ts")).href}?${t}`);
+
+  const restoreFetch = stubFetch401017("https://plat.example.com");
+  const originalStderrIsTTY = process.stderr.isTTY;
+  process.stderr.isTTY = false;
+
+  try {
+    const code = await auth.runAuthCommand([
+      "https://plat.example.com/",
+      "-u",
+      "u1",
+      "-p",
+      "old",
+      "--client-id",
+      "cid",
+      "--client-secret",
+      "sec",
+    ]);
+    assert.equal(code, 1);
+  } finally {
+    restoreFetch();
+    process.stderr.isTTY = originalStderrIsTTY;
+  }
+});

--- a/packages/typescript/test/eacp-modify-password.test.ts
+++ b/packages/typescript/test/eacp-modify-password.test.ts
@@ -1,0 +1,58 @@
+/**
+ * EACP modifypassword RSA encryption and request body shape.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  decryptModifyPwdForTest,
+  encryptModifyPwd,
+  eacpModifyPassword,
+} from "../src/auth/eacp-modify-password.js";
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+test("encryptModifyPwd round-trips with embedded key", () => {
+  const plain = "MySecret#1";
+  const b64 = encryptModifyPwd(plain);
+  assert.match(b64, /^[A-Za-z0-9+/]+=*$/);
+  assert.equal(decryptModifyPwdForTest(b64), plain);
+});
+
+test("eacpModifyPassword posts expected JSON body", async () => {
+  const calls: { url: string; body: string }[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = requestUrl(input);
+    calls.push({ url, body: typeof init?.body === "string" ? init.body : "" });
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  try {
+    const r = await eacpModifyPassword("https://plat.example.com/", {
+      account: "alice",
+      oldPassword: "old1",
+      newPassword: "newpass123456",
+      tlsInsecure: false,
+    });
+    assert.equal(r.ok, true);
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].url.endsWith("/api/eacp/v1/auth1/modifypassword"));
+    const j = JSON.parse(calls[0].body) as Record<string, unknown>;
+    assert.equal(j.account, "alice");
+    assert.equal(j.isforgetpwd, false);
+    const vi = j.vcodeinfo as { uuid: string; vcode: string };
+    assert.equal(vi.uuid, "");
+    assert.equal(vi.vcode, "");
+    assert.equal(decryptModifyPwdForTest(j.oldpwd as string), "old1");
+    assert.equal(decryptModifyPwdForTest(j.newpwd as string), "newpass123456");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/skills/kweaver-core/SKILL.md
+++ b/skills/kweaver-core/SKILL.md
@@ -64,7 +64,7 @@ kweaver [--user <userId|username>] <command> [subcommand] [options]
 
 | 命令组 | 说明 | 常用命令 | 详细参考 |
 |--------|------|---------|---------|
-| `auth` | 认证管理（支持多账号） | `auth login <url> [--alias name]`（简写：`auth <url> [--alias …]`）；可选 `--no-browser`（无浏览器时粘贴回调 URL/code，或配合 `-u/-p` 走 HTTP `/oauth2/signin`）；`-u`/`-p`（无论是否带 `--http-signin`）走 HTTP `/oauth2/signin`，缺失的用户名/密码从 stdin 提示输入；`auth list`（树形展示所有平台及用户）；`auth users`（列出用户名）；`auth switch --user <username>`（按用户名切换）；全局 `--user <name>` 可免切换使用指定用户凭证（env: `KWEAVER_USER`）；`auth use` / `status` / `logout` / `delete` 支持平台 URL 或别名；**无当前平台时** `auth status` / `whoami` 可用 `KWEAVER_BASE_URL`+`KWEAVER_TOKEN` 兜底（见 `references/auth.md`） | `references/auth.md` |
+| `auth` | 认证管理（支持多账号） | `auth login <url> [--alias name]`（简写：`auth <url> [--alias …]`）；可选 `--no-browser`、`-u/-p` HTTP `/oauth2/signin`；**初始密码**（401001017）下 TTY 可交互改密，脚本用 `--new-password`；`auth change-password <url> -u …`（EACP 改密，无需 token）；`auth list` / `auth users` / `auth switch`；全局 `--user` / `KWEAVER_USER`；**无当前平台时** `auth status` / `whoami` 可用 env 兜底（见 `references/auth.md`） | `references/auth.md` |
 | `token` | 打印当前 access token（自动刷新） | `token` | — |
 | `config` | **平台业务域（优先于多数 bkn/agent/ds 操作）** | `config show`, `config list-bd`, `config set-bd <uuid>` | `references/config.md` |
 | `bkn` | BKN 知识网络管理、Schema、查询、Action | `bkn validate`/`push` 默认检测 `.bkn` 编码并规范为 UTF-8，可用 `--no-detect-encoding` 或 `--source-encoding gb18030`；另有 `pull`、`object-type`、`search`、`create-from-ds`/`create-from-csv` 等，见 `references/bkn.md` | `references/bkn.md` |

--- a/skills/kweaver-core/SKILL.md
+++ b/skills/kweaver-core/SKILL.md
@@ -64,7 +64,7 @@ kweaver [--user <userId|username>] <command> [subcommand] [options]
 
 | 命令组 | 说明 | 常用命令 | 详细参考 |
 |--------|------|---------|---------|
-| `auth` | 认证管理（支持多账号） | `auth login <url> [--alias name]`（简写：`auth <url> [--alias …]`）；可选 `--no-browser`、`-u/-p` HTTP `/oauth2/signin`；**初始密码**（401001017）下 TTY 可交互改密，脚本用 `--new-password`；`auth change-password <url> -u …`（EACP 改密，无需 token）；`auth list` / `auth users` / `auth switch`；全局 `--user` / `KWEAVER_USER`；**无当前平台时** `auth status` / `whoami` 可用 env 兜底（见 `references/auth.md`） | `references/auth.md` |
+| `auth` | 认证管理（支持多账号） | `auth login <url> [--alias name]`（简写：`auth <url> [--alias …]`）；可选 `--no-browser`、`-u/-p` HTTP `/oauth2/signin`；**初始密码**（401001017）下 TTY 可交互改密，脚本用 `--new-password`；`auth change-password [<url>] -u …`（EACP 改密；URL 可省略，使用当前平台；无需 token）；`auth list` / `auth users` / `auth switch`；全局 `--user` / `KWEAVER_USER`；**无当前平台时** `auth status` / `whoami` 可用 env 兜底（见 `references/auth.md`） | `references/auth.md` |
 | `token` | 打印当前 access token（自动刷新） | `token` | — |
 | `config` | **平台业务域（优先于多数 bkn/agent/ds 操作）** | `config show`, `config list-bd`, `config set-bd <uuid>` | `references/config.md` |
 | `bkn` | BKN 知识网络管理、Schema、查询、Action | `bkn validate`/`push` 默认检测 `.bkn` 编码并规范为 UTF-8，可用 `--no-detect-encoding` 或 `--source-encoding gb18030`；另有 `pull`、`object-type`、`search`、`create-from-ds`/`create-from-csv` 等，见 `references/bkn.md` | `references/bkn.md` |

--- a/skills/kweaver-core/references/auth.md
+++ b/skills/kweaver-core/references/auth.md
@@ -8,9 +8,11 @@
 
 ```bash
 kweaver auth login <url> [--alias <name>] [--no-auth] [--no-browser] [-u user] [-p pass]
-                         [--http-signin]
+                         [--new-password <pwd>] [--http-signin]
                          [--port <n>] [--insecure|-k]
 kweaver auth <url> [--alias <name>] ...              # 同上（简写）
+kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>]
+                                 [--public-key-file <pem>] [--insecure|-k]
 kweaver auth whoami [url|alias] [--json]              # 显示当前用户身份
 kweaver auth export [url|alias] [--json]              # 导出凭据（用于无浏览器的服务器）
 kweaver auth status [url|alias]                       # 查看 token 状态
@@ -120,6 +122,8 @@ auth.login(no_browser=True)
 
 - **OAuth2 授权码登录**（默认）：浏览器流程，获取 `access_token` + `refresh_token`，过期自动刷新。
 - **HTTP 密码登录**（`-u`/`-p`，可选 `--http-signin`）：直接 `POST /oauth2/signin`，无需浏览器，可拿到 `refresh_token`。公钥优先取登录页，否则使用内置候选。缺失的 `-u`/`-p` 会从 stdin 提示输入（TTY 下密码隐藏）。DIP 可设 `KWEAVER_OAUTH_PRODUCT=dip`。解密失败等见 `packages/typescript/README.md` 环境变量说明。
+- **初始密码（错误码 401001017）**：服务端仍要求使用初始密码时，HTTP 登录会失败。交互终端可确认后按提示设置新密码（6–100 字符）并自动重试登录；非交互环境请使用 `--new-password <pwd>` 后重跑同一登录命令。
+- **修改密码**（`kweaver auth change-password <url> -u <account> -o <old> -n <new>`）：调用 EACP `POST /api/eacp/v1/auth1/modifypassword`，**不需要**已保存的 OAuth token；TTY 可省略 `-o`/`-n` 以隐藏输入。可选 `--public-key-file` 覆盖 RSA 公钥 PEM。
 - **`--no-browser` 粘贴流程**（不带 `-u`/`-p`）：打印授权 URL，由用户在任意浏览器登录后粘贴回调 URL 或 `code` 到终端。
 - **`--no-browser` + `-u`/`-p`**：等价于 HTTP 密码登录，缺失字段同样从 stdin 提示。
 - Token 有效期 1 小时

--- a/skills/kweaver-core/references/auth.md
+++ b/skills/kweaver-core/references/auth.md
@@ -11,8 +11,8 @@ kweaver auth login <url> [--alias <name>] [--no-auth] [--no-browser] [-u user] [
                          [--new-password <pwd>] [--http-signin]
                          [--port <n>] [--insecure|-k]
 kweaver auth <url> [--alias <name>] ...              # 同上（简写）
-kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>]
-                                 [--public-key-file <pem>] [--insecure|-k]
+kweaver auth change-password [<url>] -u <account> [-o <old>] [-n <new>]
+                                 [--insecure|-k]
 kweaver auth whoami [url|alias] [--json]              # 显示当前用户身份
 kweaver auth export [url|alias] [--json]              # 导出凭据（用于无浏览器的服务器）
 kweaver auth status [url|alias]                       # 查看 token 状态
@@ -123,7 +123,7 @@ auth.login(no_browser=True)
 - **OAuth2 授权码登录**（默认）：浏览器流程，获取 `access_token` + `refresh_token`，过期自动刷新。
 - **HTTP 密码登录**（`-u`/`-p`，可选 `--http-signin`）：直接 `POST /oauth2/signin`，无需浏览器，可拿到 `refresh_token`。公钥优先取登录页，否则使用内置候选。缺失的 `-u`/`-p` 会从 stdin 提示输入（TTY 下密码隐藏）。DIP 可设 `KWEAVER_OAUTH_PRODUCT=dip`。解密失败等见 `packages/typescript/README.md` 环境变量说明。
 - **初始密码（错误码 401001017）**：服务端仍要求使用初始密码时，HTTP 登录会失败。交互终端可确认后按提示设置新密码（6–100 字符）并自动重试登录；非交互环境请使用 `--new-password <pwd>` 后重跑同一登录命令。
-- **修改密码**（`kweaver auth change-password <url> -u <account> -o <old> -n <new>`）：调用 EACP `POST /api/eacp/v1/auth1/modifypassword`，**不需要**已保存的 OAuth token；TTY 可省略 `-o`/`-n` 以隐藏输入。可选 `--public-key-file` 覆盖 RSA 公钥 PEM。
+- **修改密码**（`kweaver auth change-password [<url>] -u <account> -o <old> -n <new>`）：调用 EACP `POST /api/eacp/v1/auth1/modifypassword`，**不需要**已保存的 OAuth token；`<url>` 省略时使用当前激活平台（`kweaver auth use`）。TTY 可省略 `-o`/`-n` 以隐藏输入。
 - **`--no-browser` 粘贴流程**（不带 `-u`/`-p`）：打印授权 URL，由用户在任意浏览器登录后粘贴回调 URL 或 `code` 到终端。
 - **`--no-browser` + `-u`/`-p`**：等价于 HTTP 密码登录，缺失字段同样从 stdin 提示。
 - Token 有效期 1 小时


### PR DESCRIPTION
## Summary

- Detect EACP **initial password** lockout: `POST /oauth2/signin` HTTP **401** with JSON `code: 401001017` throws `InitialPasswordChangeRequiredError` instead of a generic HTTP error.
- **`kweaver auth login`** with `-u` / `-p`: on 401001017, **TTY** prompts to confirm and set a new password (6–100 chars), then calls `POST /api/eacp/v1/auth1/modifypassword` and retries sign-in; **non-TTY** prints a hint to re-run with **`--new-password <pwd>`**.
- New **`kweaver auth change-password <url> -u <account> [-o <old>] [-n <new>]`** for explicit password changes (same EACP endpoint; no OAuth token required). Optional **`--public-key-file`**, **`--insecure` / `-k`**.
- New module **`eacp-modify-password.ts`** (embedded RSA key + PKCS#1 encryption, aligned with kweaver-admin).

## Out of scope

- Forgot-password / `isforgetpwd: true` (vcode + email/tel) — not implemented.
- Python SDK — unchanged.

## Verification

- `make ci` (lint + tests) passed locally.
