### PR TITLE
fix(ts): toolbox list/tool list URLs 404 — add missing /list segment …

### DIFF
--- a/packages/typescript/src/api/toolboxes.ts
+++ b/packages/typescript/src/api/toolboxes.ts
@@ -13,8 +13,8 @@ import { buildHeaders } from "./headers.js";
 //   POST   /tool-box/{id}/tools/status enable/disable (batch)
 //
 // Verified during Task 8 e2e against the live backend (2026-04-18):
-//   GET    /tool-box?keyword=&limit=&offset=  list toolboxes
-//   GET    /tool-box/{id}/tool                list tools
+//   GET    /tool-box/list?keyword=&limit=&offset=  list toolboxes
+//   GET    /tool-box/{id}/tools/list               list tools
 
 const PATH = "/api/agent-operator-integration/v1/tool-box";
 
@@ -120,7 +120,7 @@ export async function listToolboxes(opts: ListToolboxesOptions): Promise<string>
   if (opts.keyword !== undefined) qp.set("keyword", opts.keyword);
   if (opts.limit !== undefined) qp.set("limit", String(opts.limit));
   if (opts.offset !== undefined) qp.set("offset", String(opts.offset));
-  const suffix = qp.toString() ? `?${qp}` : "";
+  const suffix = `/list${qp.toString() ? `?${qp}` : ""}`;
   const { body } = await fetchTextOrThrow(url(opts.baseUrl, suffix), {
     method: "GET",
     headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
@@ -133,7 +133,7 @@ export interface ListToolsOptions extends BaseOpts {
 }
 
 export async function listTools(opts: ListToolsOptions): Promise<string> {
-  const { body } = await fetchTextOrThrow(url(opts.baseUrl, `/${encodeURIComponent(opts.boxId)}/tool`), {
+  const { body } = await fetchTextOrThrow(url(opts.baseUrl, `/${encodeURIComponent(opts.boxId)}/tools/list`), {
     method: "GET",
     headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
   });

--- a/packages/typescript/test/toolboxes.test.ts
+++ b/packages/typescript/test/toolboxes.test.ts
@@ -120,7 +120,7 @@ test("setToolStatuses POSTs JSON array to /tools/status", async () => {
   } finally { restore(); }
 });
 
-test("listToolboxes GETs /tool-box with query params", async () => {
+test("listToolboxes GETs /tool-box/list with query params", async () => {
   let captured: { url: string } | null = null;
   const restore = mockFetch(async (url) => {
     captured = { url: String(url) };
@@ -128,7 +128,7 @@ test("listToolboxes GETs /tool-box with query params", async () => {
   });
   try {
     await listToolboxes({ baseUrl: BASE, accessToken: TOKEN, keyword: "demo", limit: 20, offset: 0 });
-    assert.match(captured!.url, /\/tool-box\?/);
+    assert.match(captured!.url, /\/tool-box\/list\?/);
     assert.match(captured!.url, /keyword=demo/);
     assert.match(captured!.url, /limit=20/);
     assert.match(captured!.url, /offset=0/);
@@ -144,12 +144,12 @@ test("listToolboxes with no params produces no query string", async () => {
   try {
     await listToolboxes({ baseUrl: BASE, accessToken: TOKEN });
     assert.ok(captured);
-    assert.equal(captured!.url, `${BASE}/api/agent-operator-integration/v1/tool-box`);
+    assert.equal(captured!.url, `${BASE}/api/agent-operator-integration/v1/tool-box/list`);
     assert.ok(!captured!.url.includes("?"), `URL should have no '?' suffix; got ${captured!.url}`);
   } finally { restore(); }
 });
 
-test("listTools GETs /tool-box/{id}/tool", async () => {
+test("listTools GETs /tool-box/{id}/tools/list", async () => {
   let captured: { url: string } | null = null;
   const restore = mockFetch(async (url) => {
     captured = { url: String(url) };
@@ -157,6 +157,6 @@ test("listTools GETs /tool-box/{id}/tool", async () => {
   });
   try {
     await listTools({ baseUrl: BASE, accessToken: TOKEN, boxId: "b1" });
-    assert.match(captured!.url, /\/tool-box\/b1\/tool($|\?)/);
+    assert.match(captured!.url, /\/tool-box\/b1\/tools\/list($|\?)/);
   } finally { restore(); }
 });


### PR DESCRIPTION
Fixes #70

## Summary

- `listToolboxes` now hits `GET /tool-box/list` (was `GET /tool-box`)
- `listTools` now hits `GET /tool-box/{id}/tools/list` (was `GET /tool-box/{id}/tool`)
- Top-of-file comments corrected
- Three mock assertions in `test/toolboxes.test.ts` were locking in the wrong URLs — updated to the real routes

## Why tests didn't catch this

Mock tests in `test/toolboxes.test.ts` validated "SDK sends URL X" against hard-coded X, and X was wrong on both sides (code and test). The e2e test in `test/e2e/toolbox-tool.test.ts` is `skip`-by-default (requires `KWEAVER_E2E=1` + live creds), so it never ran as a gate.

## Test plan

- [x] Unit: `npm test` → 676/676 pass
- [x] Live verification against `https://115.190.186.186`:
  - `kweaver call -X GET /api/agent-operator-integration/v1/tool-box` → 404 (confirms bug)
  - `kweaver call -X GET /api/agent-operator-integration/v1/tool-box/list` → 6 toolboxes
  - `kweaver toolbox list` (with fix) → 6 toolboxes
  - `kweaver tool list --toolbox <id>` (with fix) → tool list for box

## Follow-ups (not in this PR)

Consider promoting the toolbox e2e smoke (login → `toolbox list` → expect 200 + non-empty) into regular regression so a 404 URL regression cannot reach main again.