### PR TITLE
feat(agent): kweaver agent skill {add,remove,list} for #72

### DIFF
--- a/docs/superpowers/plans/2026-04-21-agent-member-cli.md
+++ b/docs/superpowers/plans/2026-04-21-agent-member-cli.md
@@ -1,0 +1,1565 @@
+# Agent Member CLI (skill/tool/mcp) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship 9 sub-subcommands (`kweaver agent {skill|tool|mcp} {add|remove|list}`) that let users attach / detach / inspect agent members without hand-editing JSON, closing [issue #72](https://github.com/kweaver-ai/kweaver-sdk/issues/72).
+
+**Architecture:** One pure mutation utility (`mutateConfigMembers`) + one orchestrator (`patchAgentMembers`) + three `MemberSpec` adapters (skill/tool/mcp) that plug into existing `getAgent` / `updateAgent` API calls. A separate `listAgentMembers` orchestrator handles the read path. All new code lives in a new file `packages/typescript/src/commands/agent-members.ts`; `agent.ts` only gains a dispatch branch.
+
+**Tech Stack:** TypeScript, Node built-in `node:test`, existing `fetchTextOrThrow` / `HttpError` utilities, existing `getAgent` / `updateAgent` / `getSkill` API functions.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-agent-member-cli-design.md`
+
+---
+
+## File Structure
+
+```
+packages/typescript/
+  src/
+    commands/
+      agent.ts                          — MODIFY: add skill|tool|mcp dispatch in runAgentCommand, update help text
+      agent-members.ts                  — NEW: MemberSpec + mutateConfigMembers + patchAgentMembers + listAgentMembers + three command handlers
+    api/
+      toolboxes.ts                      — MODIFY (only if Task 1 finds no suitable fetch): add getToolboxById helper
+      mcp-servers.ts                    — NEW (only if Task 1 probe shows mcp support): thin API wrapper
+  test/
+    agent-members-mutate.test.ts        — NEW: pure mutation tests
+    agent-members-orchestrator.test.ts  — NEW: patchAgentMembers / listAgentMembers with fetch mocks
+    agent-members-cmd.test.ts           — NEW: command parsing + help text + router wiring
+    e2e/
+      agent-member-skill.test.ts        — NEW: end-to-end on real platform, skill group only
+docs/superpowers/plans/research/
+  2026-04-21-agent-config-probe.md      — NEW: findings from Task 1
+```
+
+---
+
+## Task 1: Probe Live Agent Config
+
+**Why:** Spec deliberately left three platform-contract facts unresolved: (a) exact `config` paths for skills/tools/mcps, (b) id-field names inside each array element, (c) whether mcp is even supported today. These determine the `MemberSpec` constants and whether the mcp group ships in this plan.
+
+**Files:**
+- Create: `docs/superpowers/plans/research/2026-04-21-agent-config-probe.md`
+
+- [ ] **Step 1: Find an agent that has skills attached on dip-poc**
+
+Use the platform the user has already configured. Run:
+
+```bash
+kweaver agent personal-list --compact | head -50
+```
+
+Pick an agent id from the output — ideally one that already has a skill or tool attached. If none found, create a test agent first:
+
+```bash
+kweaver agent create --name "probe-agent" --profile "config shape probe"
+```
+
+- [ ] **Step 2: Fetch its full config**
+
+```bash
+kweaver agent get <agent-id> --save-config /tmp/agent-probe.json --verbose
+```
+
+Output file contains the full agent payload including `config`.
+
+- [ ] **Step 3: Inspect the config's associative fields**
+
+Read `/tmp/agent-probe.json` and look specifically inside `config` for:
+
+1. A `skills` key — note its **shape**: is it `config.skills: [...]` (flat array of `{skill_id}`)? Or `config.skills: {skills: [{skill_id}, ...]}` (nested, as issue #72 shows)? Or something else?
+2. A `tools` / `toolboxes` / similar key — note shape and id-field name (`tool_id` vs `toolbox_id`).
+3. A `mcps` / `mcp_servers` / similar key — same.
+4. If any key is absent because that agent has none attached, that's fine — note its absence, and if feasible, attach one via the platform web UI, re-fetch, and re-inspect.
+
+- [ ] **Step 4: Write the probe report**
+
+Create `docs/superpowers/plans/research/2026-04-21-agent-config-probe.md` with this template, filled in:
+
+```markdown
+# Agent Config Probe — 2026-04-21
+
+Source: `kweaver agent get <agent-id>` on dip-poc, <date>.
+
+## Skill attachment
+
+- configPath: `config.skills.skills` (array)   ← FILL IN ACTUAL OBSERVED PATH
+- idField: `skill_id`                          ← FILL IN
+- Sample element: `{"skill_id": "sk_xxx"}`     ← FILL IN
+- fetchById endpoint: `getSkill({skillId})` → returns `{status: "published"|"unpublish"|"offline", name, ...}`
+
+## Tool attachment
+
+- configPath: `???`                            ← FILL IN or mark ABSENT
+- idField: `???`                               ← FILL IN
+- Sample element: `???`
+- Attachment unit: toolbox (container) / individual tool / other  ← CHOOSE ONE
+- fetchById endpoint plan: `???` (may require listToolboxes + filter)
+
+## MCP attachment
+
+- configPath: `???` or ABSENT
+- idField: `???`
+- Sample element: `???`
+- Platform support: YES / NO  ← if NO, mcp group is deferred out of this plan
+- fetchById endpoint plan: `???`
+
+## Decisions for this plan
+
+- Tool command verb: `agent tool` or `agent toolbox` → ___
+- MCP group: IN / DEFERRED (if DEFERRED, remove Tasks 10-12 from this plan before proceeding)
+```
+
+- [ ] **Step 5: Commit the probe report**
+
+```bash
+git add docs/superpowers/plans/research/2026-04-21-agent-config-probe.md
+git commit -m "docs(plan): agent config probe findings for #72"
+```
+
+- [ ] **Step 6: Update this plan based on findings**
+
+Edit this plan file in place:
+
+1. In Task 2, replace `SKILL_SPEC.configPath = ["skills", "skills"]` with the actually-observed path.
+2. In Task 7 / 8 / 9, replace the `<TOOL_CONFIG_PATH>` placeholder with the observed path and `<TOOL_ID_FIELD>` with the observed id-field name. Update the command verb if probe chose `toolbox` over `tool`.
+3. If MCP is ABSENT: delete Tasks 10, 11, 12 from this plan entirely, and mark the mcp group as "deferred — tracked in follow-up issue" in Task 14's writeup.
+
+Do NOT commit the plan edits separately — they'll flow in with Task 2.
+
+---
+
+## Task 2: Pure Mutation Utility (TDD)
+
+**Files:**
+- Create: `packages/typescript/src/commands/agent-members.ts`
+- Test: `packages/typescript/test/agent-members-mutate.test.ts`
+
+This task establishes the pure, synchronous, I/O-free core: given a config object, a path, an id-field name, and add/remove lists, produce the mutated config plus a report of what changed.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/typescript/test/agent-members-mutate.test.ts`:
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mutateConfigMembers } from "../src/commands/agent-members.js";
+
+test("mutateConfigMembers adds ids to existing array", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }] } };
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: ["sk_b", "sk_c"],
+    removeIds: [],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills.map((x) => x.skill_id),
+    ["sk_a", "sk_b", "sk_c"],
+  );
+  assert.deepEqual(report.added, ["sk_b", "sk_c"]);
+  assert.deepEqual(report.alreadyAttached, []);
+});
+
+test("mutateConfigMembers dedupes already-attached ids", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }] } };
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: ["sk_a", "sk_b"],
+    removeIds: [],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills.map((x) => x.skill_id),
+    ["sk_a", "sk_b"],
+  );
+  assert.deepEqual(report.added, ["sk_b"]);
+  assert.deepEqual(report.alreadyAttached, ["sk_a"]);
+});
+
+test("mutateConfigMembers creates missing path nodes", () => {
+  const config: Record<string, unknown> = {};
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: ["sk_a"],
+    removeIds: [],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills,
+    [{ skill_id: "sk_a" }],
+  );
+  assert.deepEqual(report.added, ["sk_a"]);
+});
+
+test("mutateConfigMembers removes ids and preserves order", () => {
+  const config = {
+    skills: { skills: [{ skill_id: "sk_a" }, { skill_id: "sk_b" }, { skill_id: "sk_c" }] },
+  };
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: [],
+    removeIds: ["sk_b"],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills.map((x) => x.skill_id),
+    ["sk_a", "sk_c"],
+  );
+  assert.deepEqual(report.removed, ["sk_b"]);
+  assert.deepEqual(report.notAttached, []);
+});
+
+test("mutateConfigMembers reports not-attached on remove miss", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }] } };
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: [],
+    removeIds: ["sk_a", "sk_missing"],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills,
+    [],
+  );
+  assert.deepEqual(report.removed, ["sk_a"]);
+  assert.deepEqual(report.notAttached, ["sk_missing"]);
+});
+
+test("mutateConfigMembers does not mutate input config", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }] } };
+  const original = JSON.parse(JSON.stringify(config));
+  mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: ["sk_b"],
+    removeIds: [],
+  });
+  assert.deepEqual(config, original);
+});
+
+test("mutateConfigMembers lists current ids", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }, { skill_id: "sk_b" }] } };
+  const { currentIds } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: [],
+    removeIds: [],
+  });
+  assert.deepEqual(currentIds, ["sk_a", "sk_b"]);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd packages/typescript && npm test -- --test-name-pattern=mutateConfigMembers 2>&1 | head -40
+```
+
+Expected: all 7 tests FAIL with "Cannot find module" or "mutateConfigMembers is not a function".
+
+- [ ] **Step 3: Implement the utility**
+
+Create `packages/typescript/src/commands/agent-members.ts` with this content:
+
+```ts
+/**
+ * Pure helpers and orchestrators for managing agent member associations
+ * (skills, tools, mcps) via get → mutate(config) → update.
+ */
+
+export interface MutationReport {
+  currentIds: string[];
+  added: string[];
+  alreadyAttached: string[];
+  removed: string[];
+  notAttached: string[];
+}
+
+export interface MutateConfigMembersInput {
+  config: Record<string, unknown>;
+  path: string[];
+  idField: string;
+  addIds: string[];
+  removeIds: string[];
+}
+
+export interface MutateConfigMembersResult {
+  newConfig: Record<string, unknown>;
+  report: MutationReport;
+  currentIds: string[];
+}
+
+/** Deep-clone a JSON-serializable object so mutations don't leak to callers. */
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Descend into `config` along `path`, creating empty objects and a terminal
+ * empty array along the way if any node is missing. Returns the terminal array.
+ */
+function ensureArrayAtPath(
+  root: Record<string, unknown>,
+  path: string[],
+): Record<string, unknown>[] {
+  let cursor: Record<string, unknown> = root;
+  for (let i = 0; i < path.length - 1; i += 1) {
+    const key = path[i]!;
+    const next = cursor[key];
+    if (next === undefined || next === null) {
+      cursor[key] = {};
+    } else if (typeof next !== "object" || Array.isArray(next)) {
+      throw new Error(
+        `Config path conflict at ${path.slice(0, i + 1).join(".")}: expected object, got ${Array.isArray(next) ? "array" : typeof next}`,
+      );
+    }
+    cursor = cursor[key] as Record<string, unknown>;
+  }
+  const terminalKey = path[path.length - 1]!;
+  const terminal = cursor[terminalKey];
+  if (terminal === undefined || terminal === null) {
+    cursor[terminalKey] = [];
+  } else if (!Array.isArray(terminal)) {
+    throw new Error(
+      `Config path conflict at ${path.join(".")}: expected array, got ${typeof terminal}`,
+    );
+  }
+  return cursor[terminalKey] as Record<string, unknown>[];
+}
+
+export function mutateConfigMembers(input: MutateConfigMembersInput): MutateConfigMembersResult {
+  const newConfig = clone(input.config);
+  const arr = ensureArrayAtPath(newConfig, input.path);
+
+  const currentIds: string[] = arr.map((el) => String(el[input.idField] ?? ""));
+  const currentSet = new Set(currentIds);
+
+  const added: string[] = [];
+  const alreadyAttached: string[] = [];
+  for (const id of input.addIds) {
+    if (currentSet.has(id)) {
+      alreadyAttached.push(id);
+    } else {
+      arr.push({ [input.idField]: id });
+      currentSet.add(id);
+      added.push(id);
+    }
+  }
+
+  const removeSet = new Set(input.removeIds);
+  const removed: string[] = [];
+  const notAttached: string[] = [];
+  if (removeSet.size > 0) {
+    const survivors: Record<string, unknown>[] = [];
+    const survivingIdSet = new Set<string>();
+    for (const el of arr) {
+      const id = String(el[input.idField] ?? "");
+      if (removeSet.has(id)) {
+        if (!removed.includes(id)) removed.push(id);
+        continue;
+      }
+      survivors.push(el);
+      survivingIdSet.add(id);
+    }
+    for (const id of input.removeIds) {
+      if (!removed.includes(id) && !survivingIdSet.has(id)) {
+        notAttached.push(id);
+      }
+    }
+    arr.length = 0;
+    arr.push(...survivors);
+  }
+
+  const finalIds = arr.map((el) => String(el[input.idField] ?? ""));
+
+  return {
+    newConfig,
+    currentIds: finalIds,
+    report: {
+      currentIds: finalIds,
+      added,
+      alreadyAttached,
+      removed,
+      notAttached,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd packages/typescript && npm test -- --test-name-pattern=mutateConfigMembers 2>&1 | tail -20
+```
+
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Run lint and full test suite**
+
+```bash
+cd packages/typescript && npm run lint && npm test 2>&1 | tail -10
+```
+
+Expected: no TypeScript errors; all tests pass (pre-existing tests untouched).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/typescript/src/commands/agent-members.ts packages/typescript/test/agent-members-mutate.test.ts docs/superpowers/plans/2026-04-21-agent-member-cli.md
+git commit -m "feat(agent): pure config mutation utility for member management
+
+Part of #72. Adds mutateConfigMembers — a pure, dependency-free helper
+that adds/removes member ids inside a nested config array, handling
+dedupe, missing-path creation, and order preservation. TDD-verified
+with 7 unit tests.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: MemberSpec + patchAgentMembers Orchestrator (TDD)
+
+**Files:**
+- Modify: `packages/typescript/src/commands/agent-members.ts`
+- Test: `packages/typescript/test/agent-members-orchestrator.test.ts`
+
+Wraps `mutateConfigMembers` with the validate → fetch → mutate → write pipeline. The orchestrator is parameterized by a `MemberSpec` so the same code drives skill, tool, and mcp.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/typescript/test/agent-members-orchestrator.test.ts`:
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  patchAgentMembers,
+  type MemberSpec,
+  type MemberFetchResult,
+} from "../src/commands/agent-members.js";
+
+interface MockAgentStore {
+  agent: Record<string, unknown>;
+  updateCalls: Record<string, unknown>[];
+}
+
+function makeDeps(store: MockAgentStore, members: Record<string, MemberFetchResult>) {
+  return {
+    getAgent: async (id: string) => {
+      if (id !== "ag_1") throw new Error(`agent ${id} not found`);
+      return JSON.stringify(store.agent);
+    },
+    updateAgent: async (id: string, body: Record<string, unknown>) => {
+      store.updateCalls.push(body);
+      return "ok";
+    },
+    fetchById: async (id: string): Promise<MemberFetchResult> => {
+      if (!(id in members)) return { exists: false, published: false };
+      return members[id]!;
+    },
+  };
+}
+
+function skillSpec(): MemberSpec {
+  return {
+    memberKind: "skill",
+    configPath: ["skills", "skills"],
+    idField: "skill_id",
+  };
+}
+
+test("patchAgentMembers add happy path", async () => {
+  const store: MockAgentStore = {
+    agent: { id: "ag_1", name: "a", profile: "p", config: {} },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, {
+    sk_a: { exists: true, published: true, name: "alpha" },
+  });
+
+  const report = await patchAgentMembers({
+    agentId: "ag_1",
+    spec: skillSpec(),
+    addIds: ["sk_a"],
+    removeIds: [],
+    strict: false,
+    deps,
+  });
+
+  assert.equal(store.updateCalls.length, 1);
+  const config = store.updateCalls[0]!.config as { skills: { skills: { skill_id: string }[] } };
+  assert.deepEqual(config.skills.skills, [{ skill_id: "sk_a" }]);
+  assert.deepEqual(report.added, ["sk_a"]);
+  assert.deepEqual(report.warnings, []);
+});
+
+test("patchAgentMembers add aborts when any id does not exist", async () => {
+  const store: MockAgentStore = {
+    agent: { id: "ag_1", name: "a", profile: "p", config: {} },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, {
+    sk_a: { exists: true, published: true },
+  });
+
+  await assert.rejects(
+    () =>
+      patchAgentMembers({
+        agentId: "ag_1",
+        spec: skillSpec(),
+        addIds: ["sk_a", "sk_missing"],
+        removeIds: [],
+        strict: false,
+        deps,
+      }),
+    (err: Error) => /sk_missing.*not found/.test(err.message),
+  );
+
+  assert.equal(store.updateCalls.length, 0, "updateAgent must not be called when any id is missing");
+});
+
+test("patchAgentMembers add warns on draft in non-strict mode and still writes", async () => {
+  const store: MockAgentStore = {
+    agent: { id: "ag_1", name: "a", profile: "p", config: {} },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, {
+    sk_draft: { exists: true, published: false, name: "draft-one" },
+  });
+
+  const report = await patchAgentMembers({
+    agentId: "ag_1",
+    spec: skillSpec(),
+    addIds: ["sk_draft"],
+    removeIds: [],
+    strict: false,
+    deps,
+  });
+
+  assert.equal(store.updateCalls.length, 1);
+  assert.deepEqual(report.added, ["sk_draft"]);
+  assert.equal(report.warnings.length, 1);
+  assert.match(report.warnings[0]!, /sk_draft.*draft/);
+});
+
+test("patchAgentMembers add errors on draft in strict mode and does not write", async () => {
+  const store: MockAgentStore = {
+    agent: { id: "ag_1", name: "a", profile: "p", config: {} },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, {
+    sk_draft: { exists: true, published: false },
+  });
+
+  await assert.rejects(
+    () =>
+      patchAgentMembers({
+        agentId: "ag_1",
+        spec: skillSpec(),
+        addIds: ["sk_draft"],
+        removeIds: [],
+        strict: true,
+        deps,
+      }),
+    (err: Error) => /sk_draft.*draft/.test(err.message),
+  );
+
+  assert.equal(store.updateCalls.length, 0);
+});
+
+test("patchAgentMembers remove does not call fetchById", async () => {
+  const store: MockAgentStore = {
+    agent: {
+      id: "ag_1",
+      name: "a",
+      profile: "p",
+      config: { skills: { skills: [{ skill_id: "sk_a" }, { skill_id: "sk_b" }] } },
+    },
+    updateCalls: [],
+  };
+  let fetchCalls = 0;
+  const deps = {
+    getAgent: async () => JSON.stringify(store.agent),
+    updateAgent: async (_id: string, body: Record<string, unknown>) => {
+      store.updateCalls.push(body);
+      return "ok";
+    },
+    fetchById: async () => {
+      fetchCalls += 1;
+      return { exists: true, published: true };
+    },
+  };
+
+  const report = await patchAgentMembers({
+    agentId: "ag_1",
+    spec: skillSpec(),
+    addIds: [],
+    removeIds: ["sk_a", "sk_missing"],
+    strict: false,
+    deps,
+  });
+
+  assert.equal(fetchCalls, 0, "fetchById must not be invoked for remove");
+  assert.equal(store.updateCalls.length, 1);
+  assert.deepEqual(report.removed, ["sk_a"]);
+  assert.deepEqual(report.notAttached, ["sk_missing"]);
+});
+
+test("patchAgentMembers preserves sibling config fields", async () => {
+  const store: MockAgentStore = {
+    agent: {
+      id: "ag_1",
+      name: "a",
+      profile: "p",
+      config: {
+        system_prompt: "keep me",
+        llms: [{ is_default: true, llm_config: { id: "m1", name: "n", max_tokens: 1 } }],
+        data_source: { knowledge_network: [{ knowledge_network_id: "kn_x", knowledge_network_name: "" }] },
+      },
+    },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, { sk_a: { exists: true, published: true } });
+
+  await patchAgentMembers({
+    agentId: "ag_1",
+    spec: skillSpec(),
+    addIds: ["sk_a"],
+    removeIds: [],
+    strict: false,
+    deps,
+  });
+
+  const written = store.updateCalls[0]!.config as Record<string, unknown>;
+  assert.equal(written.system_prompt, "keep me");
+  assert.ok(Array.isArray(written.llms));
+  assert.ok((written.data_source as Record<string, unknown>).knowledge_network);
+  assert.ok((written.skills as Record<string, unknown>).skills);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd packages/typescript && npm test -- --test-name-pattern=patchAgentMembers 2>&1 | head -20
+```
+
+Expected: all 6 tests FAIL with "patchAgentMembers is not exported" or similar.
+
+- [ ] **Step 3: Extend agent-members.ts with spec + orchestrator**
+
+Append to `packages/typescript/src/commands/agent-members.ts`:
+
+```ts
+// ── MemberSpec + orchestrator ───────────────────────────────────────────────
+
+export interface MemberFetchResult {
+  exists: boolean;
+  published: boolean;
+  name?: string;
+  /** Optional free-form status label for `list` output; e.g. "published" | "draft" | "offline". */
+  status?: string;
+}
+
+export interface MemberSpec {
+  /** Human-readable noun used in error/warning messages. */
+  memberKind: string;
+  /** Path inside the agent `config` object where the member array lives. */
+  configPath: string[];
+  /** Key inside each array element that identifies the member. */
+  idField: string;
+}
+
+export interface AgentMembersDeps {
+  getAgent: (agentId: string) => Promise<string>;
+  updateAgent: (agentId: string, body: Record<string, unknown>) => Promise<string>;
+  fetchById: (id: string) => Promise<MemberFetchResult>;
+}
+
+export interface PatchAgentMembersInput {
+  agentId: string;
+  spec: MemberSpec;
+  addIds: string[];
+  removeIds: string[];
+  strict: boolean;
+  deps: AgentMembersDeps;
+}
+
+export interface PatchAgentMembersReport extends MutationReport {
+  warnings: string[];
+}
+
+function mergeAgentBody(current: Record<string, unknown>, newConfig: Record<string, unknown>): Record<string, unknown> {
+  return {
+    name: current.name,
+    profile: current.profile,
+    avatar_type: current.avatar_type,
+    avatar: current.avatar,
+    product_key: current.product_key,
+    config: newConfig,
+  };
+}
+
+export async function patchAgentMembers(input: PatchAgentMembersInput): Promise<PatchAgentMembersReport> {
+  const { agentId, spec, addIds, removeIds, strict, deps } = input;
+
+  const warnings: string[] = [];
+
+  // 1. validate (add only)
+  if (addIds.length > 0) {
+    const results = await Promise.all(
+      addIds.map(async (id) => ({ id, info: await deps.fetchById(id) })),
+    );
+    const missing = results.filter((r) => !r.info.exists).map((r) => r.id);
+    if (missing.length > 0) {
+      throw new Error(
+        `${spec.memberKind}(s) not found: ${missing.join(", ")} (aborting, agent not modified)`,
+      );
+    }
+    const drafts = results.filter((r) => r.info.exists && !r.info.published).map((r) => r.id);
+    if (drafts.length > 0) {
+      if (strict) {
+        throw new Error(
+          `${spec.memberKind}(s) not published: ${drafts.join(", ")} (aborted by --strict)`,
+        );
+      }
+      for (const id of drafts) {
+        warnings.push(`${spec.memberKind} ${id} is in draft status (use --strict to reject, or publish it first)`);
+      }
+    }
+  }
+
+  // 2. fetch current agent
+  const currentRaw = await deps.getAgent(agentId);
+  const current = JSON.parse(currentRaw) as Record<string, unknown>;
+  const config = (current.config ?? {}) as Record<string, unknown>;
+
+  // 3. mutate
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: spec.configPath,
+    idField: spec.idField,
+    addIds,
+    removeIds,
+  });
+
+  // Short-circuit: no-op
+  const nothingChanged =
+    report.added.length === 0 && report.removed.length === 0;
+  if (nothingChanged && (addIds.length > 0 || removeIds.length > 0)) {
+    // Still call updateAgent? No — skipping avoids an unnecessary write round-trip.
+    return { ...report, warnings };
+  }
+  if (nothingChanged) {
+    return { ...report, warnings };
+  }
+
+  // 4. write
+  await deps.updateAgent(agentId, mergeAgentBody(current, newConfig));
+
+  // 5. report
+  return { ...report, warnings };
+}
+
+// ── List orchestrator ────────────────────────────────────────────────────────
+
+export interface ListAgentMembersInput {
+  agentId: string;
+  spec: MemberSpec;
+  deps: Pick<AgentMembersDeps, "getAgent" | "fetchById">;
+}
+
+export interface ListedMember {
+  id: string;
+  name: string | null;
+  status: string;
+}
+
+export async function listAgentMembers(input: ListAgentMembersInput): Promise<ListedMember[]> {
+  const { agentId, spec, deps } = input;
+  const currentRaw = await deps.getAgent(agentId);
+  const current = JSON.parse(currentRaw) as Record<string, unknown>;
+  const config = (current.config ?? {}) as Record<string, unknown>;
+
+  // Read (don't create) the path. If any segment is missing, result is empty.
+  let cursor: unknown = config;
+  for (const key of spec.configPath) {
+    if (cursor && typeof cursor === "object" && !Array.isArray(cursor) && key in (cursor as Record<string, unknown>)) {
+      cursor = (cursor as Record<string, unknown>)[key];
+    } else {
+      return [];
+    }
+  }
+  if (!Array.isArray(cursor)) return [];
+
+  const ids = (cursor as Record<string, unknown>[]).map((el) => String(el[spec.idField] ?? ""));
+
+  const results = await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const info = await deps.fetchById(id);
+        return {
+          id,
+          name: info.name ?? null,
+          status: info.status ?? (info.exists ? (info.published ? "published" : "unpublish") : "unknown"),
+        };
+      } catch {
+        return { id, name: null, status: "unknown" };
+      }
+    }),
+  );
+
+  return results;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd packages/typescript && npm test -- --test-name-pattern=patchAgentMembers 2>&1 | tail -20
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/typescript/src/commands/agent-members.ts packages/typescript/test/agent-members-orchestrator.test.ts
+git commit -m "feat(agent): patchAgentMembers + listAgentMembers orchestrators
+
+Part of #72. MemberSpec-parameterized orchestrators wrapping
+mutateConfigMembers with validate → fetch → mutate → update flow.
+TDD-verified against 6 scenarios: happy path, missing-id abort,
+draft warn vs strict-abort, remove-without-fetchById, sibling field
+preservation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Skill Command Handlers (TDD)
+
+**Files:**
+- Modify: `packages/typescript/src/commands/agent-members.ts` — add `runAgentSkillCommand`
+- Modify: `packages/typescript/src/commands/agent.ts` — dispatch `skill` subcommand and update help
+- Test: `packages/typescript/test/agent-members-cmd.test.ts`
+
+Wire the skill group end-to-end: argv parsing, the three subverbs (`add`/`remove`/`list`), help text, and skill-specific `fetchById` backed by `getSkill`.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/typescript/test/agent-members-cmd.test.ts`:
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { runAgentCommand } from "../src/commands/agent.js";
+
+const originalFetch = globalThis.fetch;
+
+function createConfigDir(): string {
+  return mkdtempSync(join(tmpdir(), "kweaver-agent-members-"));
+}
+
+async function importStoreModule(configDir: string) {
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const moduleUrl = pathToFileURL(join(process.cwd(), "src/config/store.ts")).href;
+  return import(`${moduleUrl}?t=${Date.now()}-${Math.random()}`);
+}
+
+async function primeToken() {
+  const configDir = createConfigDir();
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const store = await importStoreModule(configDir);
+  store.saveTokenConfig({
+    baseUrl: "https://dip.aishu.cn",
+    accessToken: "token-test",
+    tokenType: "bearer",
+    scope: "openid",
+    obtainedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  });
+  store.setCurrentPlatform("https://dip.aishu.cn");
+}
+
+test("agent help lists skill subcommand", async () => {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(" ")); };
+  try {
+    await runAgentCommand([]);
+    assert.ok(lines.join("\n").includes("skill"), "help should mention skill");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+test("agent skill help lists add/remove/list", async () => {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(" ")); };
+  try {
+    await runAgentCommand(["skill", "--help"]);
+    const help = lines.join("\n");
+    assert.ok(help.includes("add"), "help should list add");
+    assert.ok(help.includes("remove"), "help should list remove");
+    assert.ok(help.includes("list"), "help should list list");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+test("agent skill rejects unknown subverb", { concurrency: false }, async () => {
+  await primeToken();
+  const errors: string[] = [];
+  const originalErr = console.error;
+  console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+  try {
+    const code = await runAgentCommand(["skill", "foobar", "ag_1"]);
+    assert.equal(code, 1);
+    assert.ok(errors.join("\n").toLowerCase().includes("unknown"), `expected 'unknown' in stderr, got: ${errors.join("\n")}`);
+  } finally {
+    console.error = originalErr;
+  }
+});
+
+test("agent skill add — rejects missing id", { concurrency: false }, async () => {
+  await primeToken();
+
+  globalThis.fetch = async (urlInput: string | URL | Request) => {
+    const urlStr = typeof urlInput === "string" ? urlInput : urlInput instanceof URL ? urlInput.href : urlInput.url;
+    // getSkill probe fails → exists=false
+    if (urlStr.includes("/skills/sk_missing")) {
+      return new Response("not found", { status: 404 });
+    }
+    // agent get — should NOT be reached
+    if (urlStr.includes("/agent-factory/v3/agent/")) {
+      throw new Error("agent get called despite missing skill id");
+    }
+    return new Response("{}", { status: 200 });
+  };
+
+  const errors: string[] = [];
+  const originalErr = console.error;
+  console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+  try {
+    const code = await runAgentCommand(["skill", "add", "ag_1", "sk_missing"]);
+    assert.equal(code, 1);
+    assert.match(errors.join("\n"), /sk_missing/);
+  } finally {
+    console.error = originalErr;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("agent skill add — happy path writes and reports", { concurrency: false }, async () => {
+  await primeToken();
+
+  const updateBodies: string[] = [];
+  globalThis.fetch = async (urlInput: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof urlInput === "string" ? urlInput : urlInput instanceof URL ? urlInput.href : urlInput.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (urlStr.includes("/skills/sk_a") && method === "GET") {
+      return new Response(JSON.stringify({ data: { id: "sk_a", name: "alpha", status: "published" } }), {
+        status: 200, headers: { "content-type": "application/json" },
+      });
+    }
+    if (urlStr.includes("/agent-factory/v3/agent/ag_1") && method === "GET") {
+      return new Response(JSON.stringify({ id: "ag_1", name: "A", profile: "P", config: {} }), {
+        status: 200, headers: { "content-type": "application/json" },
+      });
+    }
+    if (urlStr.includes("/agent-factory/v3/agent/ag_1") && method === "PUT") {
+      updateBodies.push(String(init?.body ?? ""));
+      return new Response("ok", { status: 200 });
+    }
+    throw new Error(`unexpected fetch ${method} ${urlStr}`);
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+  try {
+    const code = await runAgentCommand(["skill", "add", "ag_1", "sk_a"]);
+    assert.equal(code, 0);
+    assert.equal(updateBodies.length, 1);
+    const body = JSON.parse(updateBodies[0]!) as { config: { skills: { skills: { skill_id: string }[] } } };
+    assert.deepEqual(body.config.skills.skills, [{ skill_id: "sk_a" }]);
+    assert.ok(logs.join("\n").includes("sk_a"));
+  } finally {
+    console.log = originalLog;
+    globalThis.fetch = originalFetch;
+  }
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd packages/typescript && npm test -- --test-file-pattern=agent-members-cmd 2>&1 | head -30
+```
+
+Expected: tests FAIL because the dispatch branch doesn't exist yet.
+
+- [ ] **Step 3: Append command handler to agent-members.ts**
+
+Append to `packages/typescript/src/commands/agent-members.ts`:
+
+```ts
+// ── Skill command handler ────────────────────────────────────────────────────
+
+import { getAgent, updateAgent } from "../api/agent-list.js";
+import { getSkill } from "../api/skills.js";
+import { ensureValidToken, formatHttpError } from "../auth/oauth.js";
+import { resolveBusinessDomain } from "../config/store.js";
+
+const SKILL_SPEC: MemberSpec = {
+  memberKind: "skill",
+  configPath: ["skills", "skills"],  // ← replace with Task 1 finding if different
+  idField: "skill_id",                // ← replace with Task 1 finding if different
+};
+
+interface ParsedWriteArgs {
+  agentId: string;
+  ids: string[];
+  strict: boolean;
+  businessDomain: string;
+}
+
+function parseWriteArgs(args: string[], verb: "add" | "remove"): ParsedWriteArgs {
+  const agentId = args[0];
+  if (!agentId || agentId.startsWith("-")) {
+    throw new Error(`Missing <agent-id> for ${verb}`);
+  }
+  const ids: string[] = [];
+  let strict = false;
+  let businessDomain = "";
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === "--strict") { strict = true; continue; }
+    if (arg === "-bd" || arg === "--biz-domain") {
+      businessDomain = args[i + 1] ?? "";
+      if (!businessDomain || businessDomain.startsWith("-")) {
+        throw new Error("Missing value for biz-domain flag");
+      }
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unsupported flag: ${arg}`);
+    }
+    ids.push(arg);
+  }
+  if (ids.length === 0) {
+    throw new Error(`Missing <member-id> for ${verb}`);
+  }
+  return { agentId, ids, strict, businessDomain };
+}
+
+function printReport(kind: string, agentId: string, report: PatchAgentMembersReport): void {
+  for (const w of report.warnings) process.stderr.write(`! ${w}\n`);
+  for (const id of report.added) console.log(`✓ ${id}  added`);
+  for (const id of report.alreadyAttached) console.log(`• ${id}  already attached (skipped)`);
+  for (const id of report.removed) console.log(`✓ ${id}  removed`);
+  for (const id of report.notAttached) console.log(`• ${id}  not attached (skipped)`);
+  console.log(`Agent ${agentId} now has ${report.currentIds.length} ${kind}(s) attached.`);
+}
+
+async function runSkillAdd(args: string[]): Promise<number> {
+  const parsed = parseWriteArgs(args, "add");
+  const token = await ensureValidToken();
+  const businessDomain = parsed.businessDomain || resolveBusinessDomain();
+
+  const deps: AgentMembersDeps = {
+    getAgent: (id) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
+    updateAgent: (id, body) => updateAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, body: JSON.stringify(body), businessDomain }),
+    fetchById: async (id) => {
+      try {
+        const info = await getSkill({ baseUrl: token.baseUrl, accessToken: token.accessToken, skillId: id, businessDomain });
+        return {
+          exists: true,
+          published: info.status === "published",
+          name: info.name,
+          status: info.status,
+        };
+      } catch {
+        return { exists: false, published: false };
+      }
+    },
+  };
+
+  try {
+    const report = await patchAgentMembers({
+      agentId: parsed.agentId,
+      spec: SKILL_SPEC,
+      addIds: parsed.ids,
+      removeIds: [],
+      strict: parsed.strict,
+      deps,
+    });
+    printReport("skill", parsed.agentId, report);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`✗ ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+async function runSkillRemove(args: string[]): Promise<number> {
+  const parsed = parseWriteArgs(args, "remove");
+  const token = await ensureValidToken();
+  const businessDomain = parsed.businessDomain || resolveBusinessDomain();
+
+  const deps: AgentMembersDeps = {
+    getAgent: (id) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
+    updateAgent: (id, body) => updateAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, body: JSON.stringify(body), businessDomain }),
+    fetchById: async () => ({ exists: true, published: true }),  // never invoked for remove
+  };
+
+  try {
+    const report = await patchAgentMembers({
+      agentId: parsed.agentId,
+      spec: SKILL_SPEC,
+      addIds: [],
+      removeIds: parsed.ids,
+      strict: false,
+      deps,
+    });
+    printReport("skill", parsed.agentId, report);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`✗ ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+async function runSkillList(args: string[]): Promise<number> {
+  const agentId = args[0];
+  if (!agentId || agentId.startsWith("-")) {
+    process.stderr.write("Missing <agent-id> for list\n");
+    return 1;
+  }
+  let pretty = true;
+  let businessDomain = "";
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === "--pretty") { pretty = true; continue; }
+    if (arg === "--compact") { pretty = false; continue; }
+    if (arg === "-bd" || arg === "--biz-domain") {
+      businessDomain = args[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    process.stderr.write(`Unsupported flag: ${arg}\n`);
+    return 1;
+  }
+
+  const token = await ensureValidToken();
+  businessDomain = businessDomain || resolveBusinessDomain();
+
+  const deps = {
+    getAgent: (id: string) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
+    fetchById: async (id: string): Promise<MemberFetchResult> => {
+      try {
+        const info = await getSkill({ baseUrl: token.baseUrl, accessToken: token.accessToken, skillId: id, businessDomain });
+        return { exists: true, published: info.status === "published", name: info.name, status: info.status };
+      } catch {
+        return { exists: false, published: false };
+      }
+    },
+  };
+
+  try {
+    const rows = await listAgentMembers({ agentId, spec: SKILL_SPEC, deps });
+    const output = rows.map((r) => ({ skill_id: r.id, name: r.name, status: r.status }));
+    console.log(JSON.stringify(output, null, pretty ? 2 : 0));
+    return 0;
+  } catch (error) {
+    process.stderr.write(`✗ ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+export async function runAgentSkillCommand(args: string[]): Promise<number> {
+  const [verb, ...rest] = args;
+  if (!verb || verb === "--help" || verb === "-h") {
+    console.log(`kweaver agent skill
+
+Subcommands:
+  add <agent-id> <skill-id>... [--strict] [-bd <bd>]      Attach skills to an agent
+  remove <agent-id> <skill-id>... [-bd <bd>]              Detach skills from an agent
+  list <agent-id> [--pretty|--compact] [-bd <bd>]         List skills attached to an agent
+
+Notes:
+  --strict         On add, reject skills that exist but are not in 'published' status.
+                   Default behaviour: warn and continue.
+  Dedupe is automatic for add; remove silently skips not-attached ids.`);
+    return 0;
+  }
+  try {
+    if (verb === "add") return await runSkillAdd(rest);
+    if (verb === "remove") return await runSkillRemove(rest);
+    if (verb === "list") return await runSkillList(rest);
+    process.stderr.write(`Unknown agent skill subcommand: ${verb}\n`);
+    return 1;
+  } catch (error) {
+    process.stderr.write(`${formatHttpError(error)}\n`);
+    return 1;
+  }
+}
+```
+
+- [ ] **Step 4: Wire dispatch in agent.ts**
+
+In `packages/typescript/src/commands/agent.ts`, modify the imports at the top:
+
+Add the import (next to other command-module imports, around line 2):
+
+```ts
+import { runAgentSkillCommand } from "./agent-members.js";
+```
+
+Then in `runAgentCommand` — inside the `dispatch` inner function (around agent.ts:693-710) — add before the `return -1;`:
+
+```ts
+    if (subcommand === "skill") return runAgentSkillCommand(rest);
+```
+
+Then in the help text of `runAgentCommand` (around agent.ts:668-689), add a line grouped with the chat/sessions block:
+
+```
+  skill <verb> ...                   Manage skills attached to an agent (add/remove/list)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd packages/typescript && npm run lint && npm test -- --test-file-pattern=agent-members 2>&1 | tail -30
+```
+
+Expected: all mutateConfigMembers, patchAgentMembers, and cmd tests PASS; lint clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/typescript/src/commands/agent-members.ts packages/typescript/src/commands/agent.ts packages/typescript/test/agent-members-cmd.test.ts
+git commit -m "feat(agent): kweaver agent skill {add,remove,list} for #72
+
+Ships the skill member group end-to-end: argv parsing, dispatch in
+runAgentCommand, help text, and skill-specific fetchById backed by
+getSkill. Replaces the hand-edit-JSON workflow for skill attachment.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Tool Command Handlers
+
+**Files:**
+- Modify: `packages/typescript/src/commands/agent-members.ts` — add `runAgentToolCommand`
+- Modify: `packages/typescript/src/commands/agent.ts` — dispatch
+- Test: extend `packages/typescript/test/agent-members-cmd.test.ts`
+
+Mirrors Task 4 for tools. Exact config path, id-field, and command verb (`tool` vs `toolbox`) come from Task 1's probe.
+
+**Prerequisites from Task 1:**
+- `<TOOL_CONFIG_PATH>` — replace with the path array observed in probe, e.g. `["tools", "tools"]` or `["toolboxes"]`
+- `<TOOL_ID_FIELD>` — replace with observed id-field name, e.g. `"tool_id"` or `"toolbox_id"`
+- `<TOOL_VERB>` — replace with `"tool"` or `"toolbox"` based on probe decision
+
+- [ ] **Step 1: Add TOOL_SPEC and tool `fetchById` adapter**
+
+In `packages/typescript/src/commands/agent-members.ts`, add alongside `SKILL_SPEC`:
+
+```ts
+import { listToolboxes, listTools } from "../api/toolboxes.js";
+
+const TOOL_SPEC: MemberSpec = {
+  memberKind: "<TOOL_VERB>",
+  configPath: [<TOOL_CONFIG_PATH>],
+  idField: "<TOOL_ID_FIELD>",
+};
+```
+
+Write a tool-specific `fetchById`. Toolboxes/tools don't have a pure `getById` endpoint — if the verb is `toolbox`, use `listToolboxes({keyword: id})` and filter; if `tool`, use `listToolboxes` to enumerate boxes then `listTools({boxId})` to find the match. Extract this into a helper:
+
+```ts
+async function fetchToolInfo(
+  ctx: { baseUrl: string; accessToken: string; businessDomain: string },
+  id: string,
+): Promise<MemberFetchResult> {
+  // Implementation depends on Task 1 decision. Pseudo-code for the "toolbox as unit" case:
+  try {
+    const raw = await listToolboxes({ baseUrl: ctx.baseUrl, accessToken: ctx.accessToken, businessDomain: ctx.businessDomain });
+    const parsed = JSON.parse(raw) as { data?: Array<{ box_id?: string; toolbox_id?: string; id?: string; box_name?: string; status?: string }> };
+    const rows = parsed.data ?? [];
+    const match = rows.find((r) => String(r.box_id ?? r.toolbox_id ?? r.id) === id);
+    if (!match) return { exists: false, published: false };
+    return {
+      exists: true,
+      published: match.status === "published",
+      name: match.box_name,
+      status: match.status,
+    };
+  } catch {
+    return { exists: false, published: false };
+  }
+}
+```
+
+For the "individual tool" case, the equivalent is nested: `listToolboxes` → for each box `listTools({boxId})` → match `tool_id`. This is O(N*M); acceptable for now, issue #72 explicitly accepts N round-trips per fetch.
+
+- [ ] **Step 2: Copy the three runners from Task 4 and rename**
+
+In `agent-members.ts`, duplicate `runSkillAdd` / `runSkillRemove` / `runSkillList` as `runToolAdd` / `runToolRemove` / `runToolList`. Differences:
+
+- Use `TOOL_SPEC` instead of `SKILL_SPEC`.
+- `deps.fetchById` uses `fetchToolInfo` (add) or the never-invoked stub (remove).
+- `printReport` second arg becomes `"<TOOL_VERB>"`.
+- `list` output row becomes `{ <TOOL_ID_FIELD>: r.id, name: r.name, status: r.status }`.
+
+Export a dispatcher:
+
+```ts
+export async function runAgentToolCommand(args: string[]): Promise<number> {
+  const [verb, ...rest] = args;
+  if (!verb || verb === "--help" || verb === "-h") {
+    console.log(`kweaver agent <TOOL_VERB>
+  add <agent-id> <id>... [--strict] [-bd <bd>]
+  remove <agent-id> <id>... [-bd <bd>]
+  list <agent-id> [--pretty|--compact] [-bd <bd>]`);
+    return 0;
+  }
+  if (verb === "add") return runToolAdd(rest);
+  if (verb === "remove") return runToolRemove(rest);
+  if (verb === "list") return runToolList(rest);
+  process.stderr.write(`Unknown agent <TOOL_VERB> subcommand: ${verb}\n`);
+  return 1;
+}
+```
+
+- [ ] **Step 3: Wire dispatch in agent.ts**
+
+In the `dispatch` inner of `runAgentCommand`, add:
+
+```ts
+    if (subcommand === "<TOOL_VERB>") return runAgentToolCommand(rest);
+```
+
+And add a line to the help text.
+
+- [ ] **Step 4: Add a happy-path test**
+
+Append to `test/agent-members-cmd.test.ts` one test mirroring "agent skill add — happy path writes and reports" but targeting `["<TOOL_VERB>", "add", "ag_1", "tb_a"]` with mocks for `listToolboxes` / agent get+put.
+
+- [ ] **Step 5: Run lint + full test suite**
+
+```bash
+cd packages/typescript && npm run lint && npm test 2>&1 | tail -20
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/typescript/src/commands/agent-members.ts packages/typescript/src/commands/agent.ts packages/typescript/test/agent-members-cmd.test.ts
+git commit -m "feat(agent): kweaver agent <TOOL_VERB> {add,remove,list} for #72
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: MCP Command Handlers
+
+> **Gated on Task 1 probe.** If the probe determined MCP is not supported on the platform (no config field exists), DELETE this task and note the deferral in Task 8's writeup.
+
+**Files:** same pattern as Task 5.
+
+**Prerequisites from Task 1:**
+- `<MCP_CONFIG_PATH>`, `<MCP_ID_FIELD>` from probe
+- Whether a get-by-id or list endpoint exists on the platform for mcp servers
+
+- [ ] **Step 1: Add `api/mcp-servers.ts` if absent**
+
+If the probe found the platform API endpoints for mcp servers, create a thin wrapper matching the pattern of `api/skills.ts` — exports `getMcpServer` or `listMcpServers` as needed.
+
+If only a list endpoint exists, the `fetchById` adapter uses list-and-filter like Task 5's tool adapter.
+
+- [ ] **Step 2: Add MCP_SPEC + runners + dispatcher**
+
+Same structure as Task 5, targeting `MCP_SPEC` and `runAgentMcpCommand`.
+
+- [ ] **Step 3: Wire dispatch + help**
+
+```ts
+    if (subcommand === "mcp") return runAgentMcpCommand(rest);
+```
+
+- [ ] **Step 4: Add command test**
+
+One happy-path test for `mcp add`.
+
+- [ ] **Step 5: Lint + test**
+
+```bash
+cd packages/typescript && npm run lint && npm test 2>&1 | tail -10
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(agent): kweaver agent mcp {add,remove,list} for #72"
+```
+
+---
+
+## Task 7: E2E Test for Skill Group
+
+**Files:**
+- Create: `packages/typescript/test/e2e/agent-member-skill.test.ts`
+
+Reuse the existing e2e pattern (`test/e2e/*.test.ts`) and `~/.env.secrets` credential source.
+
+- [ ] **Step 1: Find an existing e2e test to pattern-match**
+
+```bash
+ls /Users/xupeng/dev/github/kweaver-sdk/packages/typescript/test/e2e/
+```
+
+Read one (e.g., a bkn or skill e2e) to note the setup/teardown conventions.
+
+- [ ] **Step 2: Write the e2e test**
+
+Create `packages/typescript/test/e2e/agent-member-skill.test.ts`:
+
+```ts
+import test from "node:test";
+import assert from "node:assert/strict";
+// NOTE: follow the setup pattern from whichever sibling e2e test you read above —
+// token loading, platform selection, cleanup helpers.
+
+test("e2e: agent skill add/list/remove round-trip", async () => {
+  // 1. Pre-req: a skill already registered + published on the platform (use a known fixture id).
+  // 2. Pre-req: create a fresh test agent (kweaver agent create ...) and capture its id.
+  // 3. Run: kweaver agent skill add <ag> <sk>  →  assert exit 0, assert list contains it.
+  // 4. Run: kweaver agent skill list <ag>       →  assert sk appears with status "published".
+  // 5. Run: kweaver agent skill remove <ag> <sk> → assert exit 0, assert list is empty.
+  // 6. Cleanup: delete the test agent.
+  //
+  // Invoke via runAgentCommand directly (same pattern as test/agent.test.ts's
+  // "run agent sessions prints conversations" test but without mocking fetch).
+});
+```
+
+Fill in the pseudo-code with real runAgentCommand calls, capturing stdout via a log spy.
+
+- [ ] **Step 3: Run the e2e test**
+
+```bash
+cd packages/typescript && npm run test:e2e -- --test-file-pattern=agent-member-skill 2>&1 | tail -20
+```
+
+Expected: PASS against the real platform.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/typescript/test/e2e/agent-member-skill.test.ts
+git commit -m "test(e2e): agent skill member round-trip for #72
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Manual Verification + Issue Writeup
+
+**Files:**
+- None modified. Artifacts posted to GitHub issue #72.
+
+Hand-verify the UX promise of the spec and post a close-out comment on issue #72.
+
+- [ ] **Step 1: Build the CLI from this branch**
+
+```bash
+cd packages/typescript && npm run build
+```
+
+- [ ] **Step 2: Run the before/after comparison**
+
+Pick a test agent on dip-poc. Record:
+
+- **Before** the change (describe the old flow — copy from issue #72 original);
+- **After** the change — run the new commands and capture actual terminal output:
+
+```bash
+kweaver agent skill list <agent-id> --compact
+kweaver agent skill add <agent-id> <skill-id>
+kweaver agent skill list <agent-id> --compact
+kweaver agent skill remove <agent-id> <skill-id>
+```
+
+Verify:
+1. Before add: skill not in list.
+2. After add: skill in list with correct name + status.
+3. `agent get <agent-id>` afterward: other config fields (llms, system_prompt, data_source) untouched.
+4. After remove: skill gone from list.
+5. Tool group: same round-trip.
+6. MCP group (if shipped): same round-trip.
+
+- [ ] **Step 3: Post a close-out comment on issue #72**
+
+Use `gh issue comment 72 --repo kweaver-ai/kweaver-sdk --body-file <file>` with content:
+
+- Summary of what shipped (9 / 6 / 3 subcommands depending on scope).
+- Before/after terminal transcript from Step 2.
+- What was explicitly deferred and why (llm, knowledge-network, `set` verb, flag form, agent trace fix — each cites its own follow-up rationale).
+- Link to the merged PR when available.
+
+- [ ] **Step 4: Final commit if any docs updated during verification**
+
+```bash
+git status
+# if docs/superpowers/plans/research/2026-04-21-agent-config-probe.md was updated:
+git commit -am "docs: final probe findings for #72 close-out"
+```
+
+---
+
+## Self-Review
+
+Ran a final pass against the spec:
+
+- **Spec coverage:** Every spec section has a task. Section-to-task mapping:
+  - "目标 UX" before/after → Task 8
+  - "CLI 表面" 9 commands → Tasks 4, 5, 6
+  - "底层机制" `patchAgentMembers` + `listAgentMembers` → Tasks 2, 3
+  - "校验与用户可见输出" → Tasks 3 (logic), 4 (printReport)
+  - "测试" 单元 / 集成 / e2e / 手工 → Tasks 2, 3, 4-6 (cmd), 7 (e2e), 8 (manual)
+  - "文件改动清单" → matches File Structure header exactly
+  - "已知 limitation" → surfaced in Task 8's writeup (the "deferred" list)
+
+- **Placeholder scan:** Task 5 and Task 6 intentionally keep `<TOOL_*>` and `<MCP_*>` placeholders because Task 1 supplies those values — this is an explicit substitution step, not an unfilled gap. All other tasks have concrete code and commands.
+
+- **Type consistency:** `MemberSpec`, `MemberFetchResult`, `AgentMembersDeps`, `PatchAgentMembersReport`, `MutationReport`, `mutateConfigMembers`, `patchAgentMembers`, `listAgentMembers` — names and shapes used identically across Tasks 2, 3, 4, 5, 6.

--- a/docs/superpowers/plans/2026-04-21-agent-member-cli.md
+++ b/docs/superpowers/plans/2026-04-21-agent-member-cli.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ship 9 sub-subcommands (`kweaver agent {skill|tool|mcp} {add|remove|list}`) that let users attach / detach / inspect agent members without hand-editing JSON, closing [issue #72](https://github.com/kweaver-ai/kweaver-sdk/issues/72).
+**Goal:** Ship 3 sub-subcommands (`kweaver agent skill {add|remove|list}`) that let users attach / detach / inspect skills without hand-editing JSON, closing the most painful slice of [issue #72](https://github.com/kweaver-ai/kweaver-sdk/issues/72). Tool + MCP groups deferred to follow-up — see `docs/superpowers/plans/research/2026-04-21-agent-config-probe.md` for rationale.
 
-**Architecture:** One pure mutation utility (`mutateConfigMembers`) + one orchestrator (`patchAgentMembers`) + three `MemberSpec` adapters (skill/tool/mcp) that plug into existing `getAgent` / `updateAgent` API calls. A separate `listAgentMembers` orchestrator handles the read path. All new code lives in a new file `packages/typescript/src/commands/agent-members.ts`; `agent.ts` only gains a dispatch branch.
+**Architecture:** One pure mutation utility (`mutateConfigMembers`) + one orchestrator (`patchAgentMembers`) + a `MemberSpec` adapter for skills, plugging into existing `getAgent` / `updateAgent` API calls. A separate `listAgentMembers` orchestrator handles the read path. All new code lives in a new file `packages/typescript/src/commands/agent-members.ts`; `agent.ts` only gains a dispatch branch. The orchestrator is intentionally member-agnostic so the follow-up tool/mcp work can plug in without restructuring.
 
 **Tech Stack:** TypeScript, Node built-in `node:test`, existing `fetchTextOrThrow` / `HttpError` utilities, existing `getAgent` / `updateAgent` / `getSkill` API functions.
 
@@ -18,19 +18,16 @@
 packages/typescript/
   src/
     commands/
-      agent.ts                          — MODIFY: add skill|tool|mcp dispatch in runAgentCommand, update help text
-      agent-members.ts                  — NEW: MemberSpec + mutateConfigMembers + patchAgentMembers + listAgentMembers + three command handlers
-    api/
-      toolboxes.ts                      — MODIFY (only if Task 1 finds no suitable fetch): add getToolboxById helper
-      mcp-servers.ts                    — NEW (only if Task 1 probe shows mcp support): thin API wrapper
+      agent.ts                          — MODIFY: add skill dispatch in runAgentCommand, update help text
+      agent-members.ts                  — NEW: MemberSpec + mutateConfigMembers + patchAgentMembers + listAgentMembers + skill command handler
   test/
     agent-members-mutate.test.ts        — NEW: pure mutation tests
     agent-members-orchestrator.test.ts  — NEW: patchAgentMembers / listAgentMembers with fetch mocks
     agent-members-cmd.test.ts           — NEW: command parsing + help text + router wiring
     e2e/
-      agent-member-skill.test.ts        — NEW: end-to-end on real platform, skill group only
+      agent-member-skill.test.ts        — NEW: end-to-end on real platform
 docs/superpowers/plans/research/
-  2026-04-21-agent-config-probe.md      — NEW: findings from Task 1
+  2026-04-21-agent-config-probe.md      — NEW: findings from Task 1 (already complete)
 ```
 
 ---
@@ -120,13 +117,7 @@ git commit -m "docs(plan): agent config probe findings for #72"
 
 - [ ] **Step 6: Update this plan based on findings**
 
-Edit this plan file in place:
-
-1. In Task 2, replace `SKILL_SPEC.configPath = ["skills", "skills"]` with the actually-observed path.
-2. In Task 7 / 8 / 9, replace the `<TOOL_CONFIG_PATH>` placeholder with the observed path and `<TOOL_ID_FIELD>` with the observed id-field name. Update the command verb if probe chose `toolbox` over `tool`.
-3. If MCP is ABSENT: delete Tasks 10, 11, 12 from this plan entirely, and mark the mcp group as "deferred — tracked in follow-up issue" in Task 14's writeup.
-
-Do NOT commit the plan edits separately — they'll flow in with Task 2.
+This step has already been executed (2026-04-21): probe confirmed `configPath = ["skills", "skills"]` and `idField = "skill_id"` for the skill group, matching the values hard-coded in Task 4. Tool and MCP groups were dropped from this plan based on the probe (see "Decisions for this plan" in the probe report and the follow-up issue stub).
 
 ---
 
@@ -1272,169 +1263,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 
 ---
 
-## Task 5: Tool Command Handlers
-
-**Files:**
-- Modify: `packages/typescript/src/commands/agent-members.ts` — add `runAgentToolCommand`
-- Modify: `packages/typescript/src/commands/agent.ts` — dispatch
-- Test: extend `packages/typescript/test/agent-members-cmd.test.ts`
-
-Mirrors Task 4 for tools. Exact config path, id-field, and command verb (`tool` vs `toolbox`) come from Task 1's probe.
-
-**Prerequisites from Task 1:**
-- `<TOOL_CONFIG_PATH>` — replace with the path array observed in probe, e.g. `["tools", "tools"]` or `["toolboxes"]`
-- `<TOOL_ID_FIELD>` — replace with observed id-field name, e.g. `"tool_id"` or `"toolbox_id"`
-- `<TOOL_VERB>` — replace with `"tool"` or `"toolbox"` based on probe decision
-
-- [ ] **Step 1: Add TOOL_SPEC and tool `fetchById` adapter**
-
-In `packages/typescript/src/commands/agent-members.ts`, add alongside `SKILL_SPEC`:
-
-```ts
-import { listToolboxes, listTools } from "../api/toolboxes.js";
-
-const TOOL_SPEC: MemberSpec = {
-  memberKind: "<TOOL_VERB>",
-  configPath: [<TOOL_CONFIG_PATH>],
-  idField: "<TOOL_ID_FIELD>",
-};
-```
-
-Write a tool-specific `fetchById`. Toolboxes/tools don't have a pure `getById` endpoint — if the verb is `toolbox`, use `listToolboxes({keyword: id})` and filter; if `tool`, use `listToolboxes` to enumerate boxes then `listTools({boxId})` to find the match. Extract this into a helper:
-
-```ts
-async function fetchToolInfo(
-  ctx: { baseUrl: string; accessToken: string; businessDomain: string },
-  id: string,
-): Promise<MemberFetchResult> {
-  // Implementation depends on Task 1 decision. Pseudo-code for the "toolbox as unit" case:
-  try {
-    const raw = await listToolboxes({ baseUrl: ctx.baseUrl, accessToken: ctx.accessToken, businessDomain: ctx.businessDomain });
-    const parsed = JSON.parse(raw) as { data?: Array<{ box_id?: string; toolbox_id?: string; id?: string; box_name?: string; status?: string }> };
-    const rows = parsed.data ?? [];
-    const match = rows.find((r) => String(r.box_id ?? r.toolbox_id ?? r.id) === id);
-    if (!match) return { exists: false, published: false };
-    return {
-      exists: true,
-      published: match.status === "published",
-      name: match.box_name,
-      status: match.status,
-    };
-  } catch {
-    return { exists: false, published: false };
-  }
-}
-```
-
-For the "individual tool" case, the equivalent is nested: `listToolboxes` → for each box `listTools({boxId})` → match `tool_id`. This is O(N*M); acceptable for now, issue #72 explicitly accepts N round-trips per fetch.
-
-- [ ] **Step 2: Copy the three runners from Task 4 and rename**
-
-In `agent-members.ts`, duplicate `runSkillAdd` / `runSkillRemove` / `runSkillList` as `runToolAdd` / `runToolRemove` / `runToolList`. Differences:
-
-- Use `TOOL_SPEC` instead of `SKILL_SPEC`.
-- `deps.fetchById` uses `fetchToolInfo` (add) or the never-invoked stub (remove).
-- `printReport` second arg becomes `"<TOOL_VERB>"`.
-- `list` output row becomes `{ <TOOL_ID_FIELD>: r.id, name: r.name, status: r.status }`.
-
-Export a dispatcher:
-
-```ts
-export async function runAgentToolCommand(args: string[]): Promise<number> {
-  const [verb, ...rest] = args;
-  if (!verb || verb === "--help" || verb === "-h") {
-    console.log(`kweaver agent <TOOL_VERB>
-  add <agent-id> <id>... [--strict] [-bd <bd>]
-  remove <agent-id> <id>... [-bd <bd>]
-  list <agent-id> [--pretty|--compact] [-bd <bd>]`);
-    return 0;
-  }
-  if (verb === "add") return runToolAdd(rest);
-  if (verb === "remove") return runToolRemove(rest);
-  if (verb === "list") return runToolList(rest);
-  process.stderr.write(`Unknown agent <TOOL_VERB> subcommand: ${verb}\n`);
-  return 1;
-}
-```
-
-- [ ] **Step 3: Wire dispatch in agent.ts**
-
-In the `dispatch` inner of `runAgentCommand`, add:
-
-```ts
-    if (subcommand === "<TOOL_VERB>") return runAgentToolCommand(rest);
-```
-
-And add a line to the help text.
-
-- [ ] **Step 4: Add a happy-path test**
-
-Append to `test/agent-members-cmd.test.ts` one test mirroring "agent skill add — happy path writes and reports" but targeting `["<TOOL_VERB>", "add", "ag_1", "tb_a"]` with mocks for `listToolboxes` / agent get+put.
-
-- [ ] **Step 5: Run lint + full test suite**
-
-```bash
-cd packages/typescript && npm run lint && npm test 2>&1 | tail -20
-```
-
-Expected: all tests pass.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add packages/typescript/src/commands/agent-members.ts packages/typescript/src/commands/agent.ts packages/typescript/test/agent-members-cmd.test.ts
-git commit -m "feat(agent): kweaver agent <TOOL_VERB> {add,remove,list} for #72
-
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
-```
-
----
-
-## Task 6: MCP Command Handlers
-
-> **Gated on Task 1 probe.** If the probe determined MCP is not supported on the platform (no config field exists), DELETE this task and note the deferral in Task 8's writeup.
-
-**Files:** same pattern as Task 5.
-
-**Prerequisites from Task 1:**
-- `<MCP_CONFIG_PATH>`, `<MCP_ID_FIELD>` from probe
-- Whether a get-by-id or list endpoint exists on the platform for mcp servers
-
-- [ ] **Step 1: Add `api/mcp-servers.ts` if absent**
-
-If the probe found the platform API endpoints for mcp servers, create a thin wrapper matching the pattern of `api/skills.ts` — exports `getMcpServer` or `listMcpServers` as needed.
-
-If only a list endpoint exists, the `fetchById` adapter uses list-and-filter like Task 5's tool adapter.
-
-- [ ] **Step 2: Add MCP_SPEC + runners + dispatcher**
-
-Same structure as Task 5, targeting `MCP_SPEC` and `runAgentMcpCommand`.
-
-- [ ] **Step 3: Wire dispatch + help**
-
-```ts
-    if (subcommand === "mcp") return runAgentMcpCommand(rest);
-```
-
-- [ ] **Step 4: Add command test**
-
-One happy-path test for `mcp add`.
-
-- [ ] **Step 5: Lint + test**
-
-```bash
-cd packages/typescript && npm run lint && npm test 2>&1 | tail -10
-```
-
-- [ ] **Step 6: Commit**
-
-```bash
-git commit -m "feat(agent): kweaver agent mcp {add,remove,list} for #72"
-```
-
----
-
-## Task 7: E2E Test for Skill Group
+## Task 5: E2E Test for Skill Group
 
 **Files:**
 - Create: `packages/typescript/test/e2e/agent-member-skill.test.ts`
@@ -1493,7 +1322,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 
 ---
 
-## Task 8: Manual Verification + Issue Writeup
+## Task 6: Manual Verification + Issue Writeup
 
 **Files:**
 - None modified. Artifacts posted to GitHub issue #72.
@@ -1523,18 +1352,16 @@ kweaver agent skill remove <agent-id> <skill-id>
 Verify:
 1. Before add: skill not in list.
 2. After add: skill in list with correct name + status.
-3. `agent get <agent-id>` afterward: other config fields (llms, system_prompt, data_source) untouched.
+3. `agent get <agent-id>` afterward: other config fields (llms, system_prompt, data_source, the rest of `config.skills.*`) untouched.
 4. After remove: skill gone from list.
-5. Tool group: same round-trip.
-6. MCP group (if shipped): same round-trip.
 
 - [ ] **Step 3: Post a close-out comment on issue #72**
 
 Use `gh issue comment 72 --repo kweaver-ai/kweaver-sdk --body-file <file>` with content:
 
-- Summary of what shipped (9 / 6 / 3 subcommands depending on scope).
+- Summary of what shipped: 3 subcommands (`agent skill {add,remove,list}`).
 - Before/after terminal transcript from Step 2.
-- What was explicitly deferred and why (llm, knowledge-network, `set` verb, flag form, agent trace fix — each cites its own follow-up rationale).
+- What was explicitly deferred and why: tool + mcp groups (need separate spec — see `docs/superpowers/plans/research/2026-04-21-agent-config-probe.md` for the resolved facts that make a follow-up cheap); also still-deferred from spec: llm, knowledge-network, `set` verb, flag form, agent trace fix.
 - Link to the merged PR when available.
 
 - [ ] **Step 4: Final commit if any docs updated during verification**
@@ -1549,17 +1376,19 @@ git commit -am "docs: final probe findings for #72 close-out"
 
 ## Self-Review
 
-Ran a final pass against the spec:
+Ran a final pass against the spec (after the 2026-04-21 scope shrink to skill-only):
 
-- **Spec coverage:** Every spec section has a task. Section-to-task mapping:
-  - "目标 UX" before/after → Task 8
-  - "CLI 表面" 9 commands → Tasks 4, 5, 6
-  - "底层机制" `patchAgentMembers` + `listAgentMembers` → Tasks 2, 3
+- **Spec coverage (skill slice):** Every spec section that applies to skill has a task:
+  - "目标 UX" before/after → Task 6
+  - "CLI 表面" — skill row of the 9-command table → Task 4
+  - "底层机制" `patchAgentMembers` + `listAgentMembers` → Tasks 2, 3 (member-agnostic, ready for tool/mcp follow-up)
   - "校验与用户可见输出" → Tasks 3 (logic), 4 (printReport)
-  - "测试" 单元 / 集成 / e2e / 手工 → Tasks 2, 3, 4-6 (cmd), 7 (e2e), 8 (manual)
-  - "文件改动清单" → matches File Structure header exactly
-  - "已知 limitation" → surfaced in Task 8's writeup (the "deferred" list)
+  - "测试" 单元 / 集成 / e2e / 手工 → Tasks 2, 3, 4 (cmd), 5 (e2e), 6 (manual)
+  - "文件改动清单" → matches File Structure header
+  - "已知 limitation" → surfaced in Task 6's writeup (deferred list)
 
-- **Placeholder scan:** Task 5 and Task 6 intentionally keep `<TOOL_*>` and `<MCP_*>` placeholders because Task 1 supplies those values — this is an explicit substitution step, not an unfilled gap. All other tasks have concrete code and commands.
+- **Spec coverage (deferred):** "CLI 表面" tool + mcp rows are not in this plan; tracked via the follow-up issue described in the probe report. This is the explicit user-approved scope shrink, not a gap.
 
-- **Type consistency:** `MemberSpec`, `MemberFetchResult`, `AgentMembersDeps`, `PatchAgentMembersReport`, `MutationReport`, `mutateConfigMembers`, `patchAgentMembers`, `listAgentMembers` — names and shapes used identically across Tasks 2, 3, 4, 5, 6.
+- **Placeholder scan:** No `<TOOL_*>` / `<MCP_*>` placeholders remain. Task 1 placeholders that referenced Task 5/6 substitutions were dropped along with those tasks. Task 1 itself is already complete (probe ran 2026-04-21).
+
+- **Type consistency:** `MemberSpec`, `MemberFetchResult`, `AgentMembersDeps`, `PatchAgentMembersReport`, `MutationReport`, `mutateConfigMembers`, `patchAgentMembers`, `listAgentMembers` — names and shapes used identically across Tasks 2, 3, 4.

--- a/docs/superpowers/plans/research/2026-04-21-agent-config-probe.md
+++ b/docs/superpowers/plans/research/2026-04-21-agent-config-probe.md
@@ -1,0 +1,94 @@
+# Agent Config Probe — 2026-04-21
+
+**Source:** `kweaver agent get 01KPQ0SHKYHZKCJ4CB6P93D54M --verbose --save-config` against platform `https://115.190.186.186` (operator account, session 8fac7c79), 2026-04-21 UTC.
+
+Agent: "MySQL恢复Agent" (has 2 skills, 13 tools, 1 mcp already attached → ideal probe target).
+
+## Big finding: `skills` is a composite container, not a top-level sibling
+
+Contrary to issue #72's implied shape (`config.skills.skills`, `config.tools`, `config.mcps` as three siblings), the real layout is **one composite object holding all four member arrays**:
+
+```jsonc
+{
+  "config": {
+    // ... system_prompt, data_source, input, output, etc. ...
+    "skills": {
+      "skills": [ { "skill_id": "..." }, ... ],
+      "tools":  [ { "tool_id": "...", "tool_box_id": "...", "tool_input": [...], ... }, ... ],
+      "mcps":   [ { "mcp_server_id": "..." }, ... ],
+      "agents": []
+    },
+    "llms": [...],
+    // ...
+  }
+}
+```
+
+So the three member types we care about all live under `config.skills.*` — very clean for the `MemberSpec` pattern.
+
+## Per-member findings
+
+### Skill attachment — CLEAN
+
+- **configPath:** `["skills", "skills"]`
+- **idField:** `"skill_id"`
+- **Sample element:** `{"skill_id": "72161175-c913-402c-94d0-7cadae1d4e3e"}`
+- **fetchById endpoint:** `getSkill({skillId})` → returns `{status, name, ...}`. Already exists in `api/skills.ts:242`.
+- **Verdict:** Ship as designed. Plan Task 4 needs no change.
+
+### MCP attachment — CLEAN (route confirmed via server source)
+
+- **configPath:** `["skills", "mcps"]`
+- **idField:** `"mcp_server_id"`
+- **Sample element:** `{"mcp_server_id": "586b8d0e-b5f9-4f73-8735-eadb97f772b9"}` — one field.
+- **fetchById endpoint:** `GET /api/agent-operator-integration/v1/mcp/{mcp_id}` (server handler at `kweaver/adp/execution-factory/operator-integration/server/driveradapters/mcp_handler.go:71`); list at `/api/agent-operator-integration/v1/mcp/list`. Response carries `Name` and `Status` (`published`/`draft`/`offline`). Earlier CLI probe missed it because we guessed `/mcp-server(s)`/`/mcp_servers` instead of the actual `/mcp` segment.
+- **Verdict:** Fully implementable in this iteration if scope allows; needs a thin `api/mcp-servers.ts` wrapper.
+
+### Tool attachment — RICH ELEMENT, REQUIRES CLIENT-SIDE EXPANSION
+
+- **configPath:** `["skills", "tools"]`
+- **idField:** `"tool_id"`
+- **Sample element** (truncated — full element spans ~85 lines per tool):
+
+```jsonc
+{
+  "tool_id": "05275bb1-46e2-4727-9c6f-97d9ea0af94b",
+  "tool_box_id": "e521d454-4a0b-4dc9-8a28-d0986de1cef9",
+  "tool_timeout": 300,
+  "tool_input": [                     // ← per-tool OpenAPI input mapping
+    { "input_name": "x-account-id", "input_type": "string", "map_type": "auto", "map_value": "", "enable": false },
+    { "input_name": "query",        "input_type": "string", "map_type": "auto", "map_value": "", "enable": true  },
+    { "input_name": "options",      "input_type": "object", "children": [ ... nested schema ... ] },
+    // ... one entry per OpenAPI parameter ...
+  ],
+  "intervention": false,
+  "intervention_confirmation_message": "",
+  "result_process_strategies": null
+}
+```
+
+- **Fatal issue:** attaching a tool by `{tool_id: "..."}` alone will NOT work. The LLM-side invocation needs `tool_input` populated with the tool's OpenAPI parameter schema + default mapping. Writing bare `{tool_id: x}` produces a config that looks attached but fails at runtime when the agent tries to call the tool.
+- **No server-side resolve endpoint:** server stores the value object as `{tool_id, tool_box_id}` + an opaque `tool_input` JSON blob set by the caller — see `kweaver/decision-agent/agent-backend/agent-factory/src/domain/valueobject/daconfvalobj/skillvalobj/skill_tool.go:10-18`. There is no "give me default tool element for tool_id" handler.
+- **Client-side path is well-defined:** `GET /api/agent-operator-integration/v1/tool-box/{boxId}/tools/list` (response type `QueryToolListResp` at `kweaver/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go:287-292`) returns each tool's full `APISpec.Parameters` (logics_metadata.go:71-80). Mapping rule: each `Parameter` → `{input_name: name, input_type: schema.type, map_type: "auto", map_value: "", enable: required}`; recurse into `children` for object/array params. Plus a UX gap: user only knows `tool_id` but config element needs `tool_box_id` too — CLI must either accept `--box <id>` or scan all boxes.
+- **Verdict:** Doable but adds ~150 LOC of OpenAPI-to-input expansion + a UX choice for box resolution. Not "drop-in an id" — needs its own spec + plan.
+
+### Agent (sub-agent) attachment — out of scope
+
+- `config.skills.agents[]` exists but is always `[]` on this agent. Not in this plan's scope (issue #72 didn't mention it).
+
+## Decisions for this plan
+
+User direction (2026-04-21): **minimal change — ship skill only**. Both tool and mcp groups defer to a follow-up issue, even though mcp is technically clean.
+
+1. **Scope:** Tasks 1, 2, 3, 4, 7, 8. Drop Tasks 5 (tool) and 6 (mcp) from this plan.
+2. **Spec fidelity:** The spec's "CLI surface" listed 9 commands; this plan ships 3 (skill group). Spec stays correct as a *vision*; implementation lands incrementally.
+3. **Composite-container quirk:** `config.skills` is a legacy-named composite holding 4 sub-arrays (skills/tools/mcps/agents). Our `MemberSpec.configPath` already targets the sub-level (`["skills", "skills"]`), so the naming has zero effect on the implementation.
+
+## Follow-up issue to open after skill ships
+
+Title suggestion: `【CLI】agent tool / mcp 关联子命令（#72 延续）`
+
+Body should cite this probe report and the resolved facts so the follow-up doesn't re-research:
+
+- **MCP** is clean: `GET /api/agent-operator-integration/v1/mcp/list` and `/api/agent-operator-integration/v1/mcp/{mcp_id}` (server: `kweaver/adp/execution-factory/operator-integration/server/driveradapters/mcp_handler.go`). Element shape `{mcp_server_id}`. Add `api/mcp-servers.ts` wrapper + reuse `patchAgentMembers`.
+- **Tool** needs client-side OpenAPI-to-`tool_input` expansion: source-of-truth response is `QueryToolListResp` at `kweaver/adp/execution-factory/operator-integration/server/interfaces/logics_toolbox.go:287-292`. Plus needs box resolution UX (`--box <id>` vs auto-scan).

--- a/docs/superpowers/specs/2026-04-21-agent-member-cli-design.md
+++ b/docs/superpowers/specs/2026-04-21-agent-member-cli-design.md
@@ -1,0 +1,234 @@
+# Agent 成员关联 CLI 设计（skill / tool / mcp）
+
+关联 issue：[#72](https://github.com/kweaver-ai/kweaver-sdk/issues/72)
+
+## 背景
+
+`kweaver agent update` 目前的字段级 patch 只覆盖 `--name / --profile / --system-prompt / --knowledge-network-id`，其他所有 config 字段（skills / tools / mcps / llms / 等）都必须走 `--config-path` 整份替换。结果是：把一个 skill 挂到 agent 上需要用户 `agent get > cfg.json` → 用 python/jq 手改 `config.skills.skills[]` → `agent update --config-path`——既要知道嵌套路径，又有误删 tools/mcps/llms 的风险。
+
+这是整个 agent 成员管理共同的缺口，不是 skill 独有。issue #63 已经给 toolbox/tool 做了"父容器 CRUD + 子成员生命周期"的子子命令模式；这次用同一个模式延伸到 agent 的成员管理。
+
+## 范围
+
+**本次覆盖**：skill / tool / mcp 三类成员，各自 `add / remove / list` 三个动词。
+
+**不在本次范围内**：
+
+- `llm` 子命令（字段结构 `is_default / llm_config / max_tokens / temperature / top_p / top_k` 跟"id 数组"范式不对称，需单独设计）；
+- `knowledge-network add / remove / list`（当前平台只支持单个 KN，且 `--knowledge-network-id` 写入时 `knowledge_network_name` 被留空是独立小 bug）；
+- `set`（全量替换）动词——`remove + add` 组合可达成，YAGNI 至实际需求出现；
+- `kweaver agent update --skill-add / --tool-add / --mcp-add` 这类 flag 形态——子子命令覆盖 95% 日常，跨成员类型的原子批量改先不做；
+- 反向 `kweaver skill attach-to-agent`。
+
+## 目标 UX
+
+**Before**：
+
+```bash
+kweaver agent get ag_xxx --verbose > /tmp/cfg.json
+python3 -c "
+import json
+a = json.load(open('/tmp/cfg.json'))
+a['config']['skills']['skills'] = [{'skill_id':'sk_abc'}, {'skill_id':'sk_def'}]
+json.dump(a['config'], open('/tmp/cfg-out.json','w'))
+"
+kweaver agent update ag_xxx --config-path /tmp/cfg-out.json
+```
+
+**After**：
+
+```bash
+kweaver agent skill add ag_xxx sk_abc sk_def
+```
+
+## CLI 表面
+
+新增 9 个子子命令：
+
+```
+kweaver agent skill add    <agent-id> <skill-id>...       [--strict] [-bd <bd>]
+kweaver agent skill remove <agent-id> <skill-id>...       [-bd <bd>]
+kweaver agent skill list   <agent-id>                     [-bd <bd>] [--pretty|--compact]
+
+kweaver agent tool add     <agent-id> <tool-id>...        [--strict] [-bd <bd>]
+kweaver agent tool remove  <agent-id> <tool-id>...        [-bd <bd>]
+kweaver agent tool list    <agent-id>                     [-bd <bd>] [--pretty|--compact]
+
+kweaver agent mcp add      <agent-id> <mcp-id>...         [--strict] [-bd <bd>]
+kweaver agent mcp remove   <agent-id> <mcp-id>...         [-bd <bd>]
+kweaver agent mcp list     <agent-id>                     [-bd <bd>] [--pretty|--compact]
+```
+
+**待 plan 阶段校准的细节**（读一份真实 agent config 反推平台契约后确定）：
+
+- `tool` 关联单位究竟是 toolbox 容器还是单个 endpoint——决定动词到底叫 `agent tool` 还是 `agent toolbox`，以及 `idField` 是 `tool_id` 还是 `toolbox_id`；
+- `mcp` 关联单位——当前 CLI 无任何 mcp 命令，config 里的字段名（`mcp_server_id` / `mcp_id` / 其他）需从平台契约读出；
+- 三类成员在 `config` 里的嵌套路径，例如 `config.skills.skills[]`（从 issue 观察）对其余两类是否同构。
+
+子子命令的形态（`add / remove / list` 三词一套对称）不受这些细节影响。
+
+## 底层机制
+
+三组命令共享一个 patch 工具，新建文件 `packages/typescript/src/commands/agent-members.ts` 或类似：
+
+```ts
+type MemberSpec = {
+  memberKind: string;          // "skill" | "tool" | "mcp"，用于错误消息
+  configPath: string[];        // 例 ["skills", "skills"]
+  idField: string;             // 例 "skill_id"
+  fetchById: (id: string, ctx: ApiCtx) =>
+    Promise<{ exists: boolean; published: boolean; name?: string }>;
+};
+
+async function patchAgentMembers(opts: {
+  agentId: string;
+  spec: MemberSpec;
+  addIds: string[];
+  removeIds: string[];
+  strict: boolean;
+  ctx: ApiCtx;
+}): Promise<PatchReport>;
+```
+
+### 写路径（add / remove）五阶段
+
+1. **validate**（仅 add）：对每个 addId 调 `spec.fetchById`；
+   - 任一 id 不存在 → 立即终止，**不调用 updateAgent**（零侧改）；
+   - 存在但 `published=false` → warning 累积；`--strict` 时升级为错误中止。
+2. **fetch**：`getAgent(agentId)` 拿当前 `config`。
+3. **mutate**：按 `spec.configPath` 下沉到目标数组（沿途缺失的对象/数组节点自动补齐），按 `spec.idField` 做 dedupe add 或 filter remove。
+4. **write**：`updateAgent(agentId, { ...current, config: mutatedConfig })`——**完全复用 agent.ts:1460 的现有通路**，不新增 API 函数。
+5. **report**：每个 id 的状态（`added / already-attached / removed / not-attached / skipped-unpublished-warn`），打印到 stdout。
+
+### list 路径
+
+1. `getAgent(agentId)` → 按 `spec.configPath` + `spec.idField` 取出 id 列表；
+2. 并行 `spec.fetchById`（用于附带 name / status）；
+3. 按 `--pretty / --compact` JSON 输出（跟 `skill list` 既有约定一致）；
+4. `fetchById` 失败 → 降级为 `{ id, name: null, status: "unknown" }`，不阻塞整条 list。
+
+### 并发
+
+单用户 CLI 场景下，`get → update` 之间不做乐观锁。多并发写同一个 agent 的竞态是已知 limitation，设计文档层面接受。
+
+## 校验与用户可见行为
+
+### add — 全部存在，部分未发布（默认）
+
+```
+$ kweaver agent skill add ag_x sk_a sk_b
+! sk_b  skill is in draft status (use --strict to reject, or publish it first)
+✓ sk_a  added
+✓ sk_b  added (draft)
+• Already attached skills skipped: 0
+Agent ag_x now has 5 skills attached.
+```
+exit 0.
+
+### add — 任一 id 不存在
+
+```
+$ kweaver agent skill add ag_x sk_a sk_b sk_c
+✗ sk_c  not found (aborting, agent not modified)
+```
+exit 1，零侧改。
+
+### add — `--strict` 下 draft
+
+add 时 `--strict` 把 unpublished warning 升级为错误，也零侧改，exit 1。
+
+### add — 重复添加
+
+```
+$ kweaver agent skill add ag_x sk_a
+• sk_a  already attached (skipped)
+Agent ag_x now has 4 skills attached.
+```
+exit 0。
+
+### remove
+
+```
+$ kweaver agent skill remove ag_x sk_a sk_z
+✓ sk_a  removed
+• sk_z  not attached (skipped)
+Agent ag_x now has 3 skills attached.
+```
+exit 0。remove 不调用 `fetchById`——只做数组过滤，悬挂引用被清掉反而是好事。
+
+### list 输出
+
+```json
+[
+  {"skill_id": "sk_a", "name": "mysql-foundation", "status": "published"},
+  {"skill_id": "sk_b", "name": "api-client", "status": "draft"},
+  {"skill_id": "sk_c", "name": null, "status": "unknown"}
+]
+```
+
+### exit code 约定
+
+| 情形 | exit |
+|---|---|
+| agent 不存在（来自 `agent get` HTTP 错误） | 1 |
+| add 时任一 id 不存在 | 1（零侧改） |
+| add 时 `--strict` 下有 draft id | 1（零侧改） |
+| add 时仅 dedupe skip | 0 |
+| remove 时全部 not-attached | 0（skip 不是错误） |
+| 底层 `updateAgent` HTTP 失败 | 1 |
+
+`--strict` 当前只作用于 add；remove 不需要。
+
+## 测试
+
+仓库使用 Node 内置 `node:test`，`test/*.test.ts` 走 mock HTTP，`test/e2e/*.test.ts` 打真实平台。两类都写。
+
+### 单元 — `test/agent-member-patch.test.ts`
+
+验证 `patchAgentMembers` 的纯逻辑，不测 HTTP 细节：
+
+1. config 路径缺失（`config` 里无 `skills` 键）时自动补齐嵌套节点后写入；
+2. 已存在 id 再 add → skip，不出现在 update body 的重复条目里；
+3. remove 过滤保留原有顺序；remove 不在列表里的 id → skip，不报错；
+4. add 有不存在的 id → 根本不调用 `updateAgent`（验证零侧改）；
+5. `--strict` + draft id → 也不调用 `updateAgent`；
+6. 非 `--strict` + draft id → 照常 update，warning 出现在 stderr；
+7. list 路径里 `fetchById` 失败降级为 `status: "unknown"`。
+
+### 集成 — `test/agent-member-cmd.test.ts`
+
+每组 member × `{add, remove, list}` 各一条正向 + 一条反向用例，验证：
+
+- 参数解析、help 文本；
+- `-bd / --pretty / --compact` 继承；
+- 未知子子命令的错误消息；
+- 跟 `test/agent.test.ts` 既有模式对齐。
+
+### e2e — `test/e2e/agent-member.test.ts`
+
+用真实平台 token 跑 "创建测试 agent → skill add → skill list → skill remove → 清理" 的最小闭环。tool / mcp 的 e2e 在 plan 阶段契约定好后再补。遵循仓库 e2e 惯例：从 `~/.env.secrets` 读凭证、测完清理现场。
+
+### 手工验证
+
+在 dip-poc 上跑一次端到端，用 `agent skill add` 替换 issue #72 里那段 python+jq 流程，产出 "before / after" 对比贴回 issue 作为关闭凭证。
+
+## 文件改动清单
+
+新增：
+
+- `packages/typescript/src/commands/agent-members.ts` — `patchAgentMembers` + 三个 MemberSpec 定义 + 三个命令 handler
+- `test/agent-member-patch.test.ts`
+- `test/agent-member-cmd.test.ts`
+- `test/e2e/agent-member.test.ts`
+
+修改：
+
+- `packages/typescript/src/commands/agent.ts` — `runAgentCommand` 路由新增 `skill / tool / mcp` 三个子子命令分支；更新 help 文本
+- （可能）`packages/typescript/src/api/skills.ts` / `toolboxes.ts` / 新建 mcp API 文件 — 仅在现有 `fetchById` 能力不足时补充 get-by-id 函数
+
+## 已知 limitation
+
+1. 多并发 CLI 写同一个 agent 时 `get → update` 有竞态，不做乐观锁；
+2. `agent tool / mcp` 的动词命名与 `idField` 需 plan 阶段读真实 config 校准；
+3. `fetchById` 每个 id 一次请求，批量 add 时 N 个 id 就 N 次 round-trip，不引入批量接口；
+4. 不做 llm / knowledge-network 的对称命令（单独 issue）。

--- a/packages/typescript/src/commands/agent-members.ts
+++ b/packages/typescript/src/commands/agent-members.ts
@@ -340,29 +340,29 @@ function printReport(kind: string, agentId: string, report: PatchAgentMembersRep
 }
 
 async function runSkillAdd(args: string[]): Promise<number> {
-  const parsed = parseWriteArgs(args, "add");
-  const token = await ensureValidToken();
-  const businessDomain = parsed.businessDomain || resolveBusinessDomain();
-
-  const deps: AgentMembersDeps = {
-    getAgent: (id) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
-    updateAgent: (id, body) => updateAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, body: JSON.stringify(body), businessDomain }),
-    fetchById: async (id) => {
-      try {
-        const info = await getSkill({ baseUrl: token.baseUrl, accessToken: token.accessToken, skillId: id, businessDomain });
-        return {
-          exists: true,
-          published: info.status === "published",
-          name: info.name,
-          status: info.status,
-        };
-      } catch {
-        return { exists: false, published: false };
-      }
-    },
-  };
-
   try {
+    const parsed = parseWriteArgs(args, "add");
+    const token = await ensureValidToken();
+    const businessDomain = parsed.businessDomain || resolveBusinessDomain();
+
+    const deps: AgentMembersDeps = {
+      getAgent: (id) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
+      updateAgent: (id, body) => updateAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, body: JSON.stringify(body), businessDomain }),
+      fetchById: async (id) => {
+        try {
+          const info = await getSkill({ baseUrl: token.baseUrl, accessToken: token.accessToken, skillId: id, businessDomain });
+          return {
+            exists: true,
+            published: info.status === "published",
+            name: info.name,
+            status: info.status,
+          };
+        } catch {
+          return { exists: false, published: false };
+        }
+      },
+    };
+
     const report = await patchAgentMembers({
       agentId: parsed.agentId,
       spec: SKILL_SPEC,
@@ -380,17 +380,17 @@ async function runSkillAdd(args: string[]): Promise<number> {
 }
 
 async function runSkillRemove(args: string[]): Promise<number> {
-  const parsed = parseWriteArgs(args, "remove");
-  const token = await ensureValidToken();
-  const businessDomain = parsed.businessDomain || resolveBusinessDomain();
-
-  const deps: AgentMembersDeps = {
-    getAgent: (id) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
-    updateAgent: (id, body) => updateAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, body: JSON.stringify(body), businessDomain }),
-    fetchById: async () => ({ exists: true, published: true }),
-  };
-
   try {
+    const parsed = parseWriteArgs(args, "remove");
+    const token = await ensureValidToken();
+    const businessDomain = parsed.businessDomain || resolveBusinessDomain();
+
+    const deps: AgentMembersDeps = {
+      getAgent: (id) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
+      updateAgent: (id, body) => updateAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, body: JSON.stringify(body), businessDomain }),
+      fetchById: async () => ({ exists: true, published: true }),
+    };
+
     const report = await patchAgentMembers({
       agentId: parsed.agentId,
       spec: SKILL_SPEC,
@@ -421,6 +421,10 @@ async function runSkillList(args: string[]): Promise<number> {
     if (arg === "--compact") { pretty = false; continue; }
     if (arg === "-bd" || arg === "--biz-domain") {
       businessDomain = args[i + 1] ?? "";
+      if (!businessDomain || businessDomain.startsWith("-")) {
+        process.stderr.write("Missing value for biz-domain flag\n");
+        return 1;
+      }
       i += 1;
       continue;
     }

--- a/packages/typescript/src/commands/agent-members.ts
+++ b/packages/typescript/src/commands/agent-members.ts
@@ -123,3 +123,159 @@ export function mutateConfigMembers(input: MutateConfigMembersInput): MutateConf
     },
   };
 }
+
+// ── MemberSpec + orchestrator ───────────────────────────────────────────────
+
+export interface MemberFetchResult {
+  exists: boolean;
+  published: boolean;
+  name?: string;
+  /** Optional free-form status label for `list` output; e.g. "published" | "draft" | "offline". */
+  status?: string;
+}
+
+export interface MemberSpec {
+  /** Human-readable noun used in error/warning messages. */
+  memberKind: string;
+  /** Path inside the agent `config` object where the member array lives. */
+  configPath: string[];
+  /** Key inside each array element that identifies the member. */
+  idField: string;
+}
+
+export interface AgentMembersDeps {
+  getAgent: (agentId: string) => Promise<string>;
+  updateAgent: (agentId: string, body: Record<string, unknown>) => Promise<string>;
+  fetchById: (id: string) => Promise<MemberFetchResult>;
+}
+
+export interface PatchAgentMembersInput {
+  agentId: string;
+  spec: MemberSpec;
+  addIds: string[];
+  removeIds: string[];
+  strict: boolean;
+  deps: AgentMembersDeps;
+}
+
+export interface PatchAgentMembersReport extends MutationReport {
+  warnings: string[];
+}
+
+function mergeAgentBody(current: Record<string, unknown>, newConfig: Record<string, unknown>): Record<string, unknown> {
+  return {
+    name: current.name,
+    profile: current.profile,
+    avatar_type: current.avatar_type,
+    avatar: current.avatar,
+    product_key: current.product_key,
+    config: newConfig,
+  };
+}
+
+export async function patchAgentMembers(input: PatchAgentMembersInput): Promise<PatchAgentMembersReport> {
+  const { agentId, spec, addIds, removeIds, strict, deps } = input;
+
+  const warnings: string[] = [];
+
+  // 1. validate (add only)
+  if (addIds.length > 0) {
+    const results = await Promise.all(
+      addIds.map(async (id) => ({ id, info: await deps.fetchById(id) })),
+    );
+    const missing = results.filter((r) => !r.info.exists).map((r) => r.id);
+    if (missing.length > 0) {
+      throw new Error(
+        `${spec.memberKind}(s) ${missing.join(", ")} not found (aborting, agent not modified)`,
+      );
+    }
+    const drafts = results.filter((r) => r.info.exists && !r.info.published).map((r) => r.id);
+    if (drafts.length > 0) {
+      if (strict) {
+        throw new Error(
+          `${spec.memberKind}(s) ${drafts.join(", ")} are in draft status (aborted by --strict)`,
+        );
+      }
+      for (const id of drafts) {
+        warnings.push(`${spec.memberKind} ${id} is in draft status (use --strict to reject, or publish it first)`);
+      }
+    }
+  }
+
+  // 2. fetch current agent
+  const currentRaw = await deps.getAgent(agentId);
+  const current = JSON.parse(currentRaw) as Record<string, unknown>;
+  const config = (current.config ?? {}) as Record<string, unknown>;
+
+  // 3. mutate
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: spec.configPath,
+    idField: spec.idField,
+    addIds,
+    removeIds,
+  });
+
+  // Short-circuit: no-op (skip the write if neither add nor remove changed anything)
+  const nothingChanged = report.added.length === 0 && report.removed.length === 0;
+  if (nothingChanged) {
+    return { ...report, warnings };
+  }
+
+  // 4. write
+  await deps.updateAgent(agentId, mergeAgentBody(current, newConfig));
+
+  // 5. report
+  return { ...report, warnings };
+}
+
+// ── List orchestrator ────────────────────────────────────────────────────────
+
+export interface ListAgentMembersInput {
+  agentId: string;
+  spec: MemberSpec;
+  deps: Pick<AgentMembersDeps, "getAgent" | "fetchById">;
+}
+
+export interface ListedMember {
+  id: string;
+  name: string | null;
+  status: string;
+}
+
+export async function listAgentMembers(input: ListAgentMembersInput): Promise<ListedMember[]> {
+  const { agentId, spec, deps } = input;
+  const currentRaw = await deps.getAgent(agentId);
+  const current = JSON.parse(currentRaw) as Record<string, unknown>;
+  const config = (current.config ?? {}) as Record<string, unknown>;
+
+  // Read (don't create) the path. If any segment is missing, result is empty.
+  let cursor: unknown = config;
+  for (const key of spec.configPath) {
+    if (cursor && typeof cursor === "object" && !Array.isArray(cursor) && key in (cursor as Record<string, unknown>)) {
+      cursor = (cursor as Record<string, unknown>)[key];
+    } else {
+      return [];
+    }
+  }
+  if (!Array.isArray(cursor)) return [];
+
+  const ids = (cursor as Record<string, unknown>[]).map((el) => String(el[spec.idField] ?? ""));
+
+  const results = await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const info = await deps.fetchById(id);
+        return {
+          id,
+          name: info.name ?? null,
+          status: info.status ?? (info.exists ? (info.published ? "published" : "unpublish") : "unknown"),
+        };
+      } catch {
+        return { id, name: null, status: "unknown" };
+      }
+    }),
+  );
+
+  return results;
+}

--- a/packages/typescript/src/commands/agent-members.ts
+++ b/packages/typescript/src/commands/agent-members.ts
@@ -3,6 +3,11 @@
  * (skills, tools, mcps) via get → mutate(config) → update.
  */
 
+import { getAgent, updateAgent } from "../api/agent-list.js";
+import { getSkill } from "../api/skills.js";
+import { ensureValidToken, formatHttpError } from "../auth/oauth.js";
+import { resolveBusinessDomain } from "../config/store.js";
+
 export interface MutationReport {
   finalIds: string[];
   added: string[];
@@ -278,4 +283,201 @@ export async function listAgentMembers(input: ListAgentMembersInput): Promise<Li
   );
 
   return results;
+}
+
+// ── Skill command handler ────────────────────────────────────────────────────
+
+const SKILL_SPEC: MemberSpec = {
+  memberKind: "skill",
+  configPath: ["skills", "skills"],
+  idField: "skill_id",
+};
+
+interface ParsedWriteArgs {
+  agentId: string;
+  ids: string[];
+  strict: boolean;
+  businessDomain: string;
+}
+
+function parseWriteArgs(args: string[], verb: "add" | "remove"): ParsedWriteArgs {
+  const agentId = args[0];
+  if (!agentId || agentId.startsWith("-")) {
+    throw new Error(`Missing <agent-id> for ${verb}`);
+  }
+  const ids: string[] = [];
+  let strict = false;
+  let businessDomain = "";
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === "--strict") { strict = true; continue; }
+    if (arg === "-bd" || arg === "--biz-domain") {
+      businessDomain = args[i + 1] ?? "";
+      if (!businessDomain || businessDomain.startsWith("-")) {
+        throw new Error("Missing value for biz-domain flag");
+      }
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unsupported flag: ${arg}`);
+    }
+    ids.push(arg);
+  }
+  if (ids.length === 0) {
+    throw new Error(`Missing <member-id> for ${verb}`);
+  }
+  return { agentId, ids, strict, businessDomain };
+}
+
+function printReport(kind: string, agentId: string, report: PatchAgentMembersReport): void {
+  for (const w of report.warnings) process.stderr.write(`! ${w}\n`);
+  for (const id of report.added) console.log(`✓ ${id}  added`);
+  for (const id of report.alreadyAttached) console.log(`• ${id}  already attached (skipped)`);
+  for (const id of report.removed) console.log(`✓ ${id}  removed`);
+  for (const id of report.notAttached) console.log(`• ${id}  not attached (skipped)`);
+  console.log(`Agent ${agentId} now has ${report.finalIds.length} ${kind}(s) attached.`);
+}
+
+async function runSkillAdd(args: string[]): Promise<number> {
+  const parsed = parseWriteArgs(args, "add");
+  const token = await ensureValidToken();
+  const businessDomain = parsed.businessDomain || resolveBusinessDomain();
+
+  const deps: AgentMembersDeps = {
+    getAgent: (id) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
+    updateAgent: (id, body) => updateAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, body: JSON.stringify(body), businessDomain }),
+    fetchById: async (id) => {
+      try {
+        const info = await getSkill({ baseUrl: token.baseUrl, accessToken: token.accessToken, skillId: id, businessDomain });
+        return {
+          exists: true,
+          published: info.status === "published",
+          name: info.name,
+          status: info.status,
+        };
+      } catch {
+        return { exists: false, published: false };
+      }
+    },
+  };
+
+  try {
+    const report = await patchAgentMembers({
+      agentId: parsed.agentId,
+      spec: SKILL_SPEC,
+      addIds: parsed.ids,
+      removeIds: [],
+      strict: parsed.strict,
+      deps,
+    });
+    printReport("skill", parsed.agentId, report);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`✗ ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+async function runSkillRemove(args: string[]): Promise<number> {
+  const parsed = parseWriteArgs(args, "remove");
+  const token = await ensureValidToken();
+  const businessDomain = parsed.businessDomain || resolveBusinessDomain();
+
+  const deps: AgentMembersDeps = {
+    getAgent: (id) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
+    updateAgent: (id, body) => updateAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, body: JSON.stringify(body), businessDomain }),
+    fetchById: async () => ({ exists: true, published: true }),
+  };
+
+  try {
+    const report = await patchAgentMembers({
+      agentId: parsed.agentId,
+      spec: SKILL_SPEC,
+      addIds: [],
+      removeIds: parsed.ids,
+      strict: false,
+      deps,
+    });
+    printReport("skill", parsed.agentId, report);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`✗ ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+async function runSkillList(args: string[]): Promise<number> {
+  const agentId = args[0];
+  if (!agentId || agentId.startsWith("-")) {
+    process.stderr.write("Missing <agent-id> for list\n");
+    return 1;
+  }
+  let pretty = true;
+  let businessDomain = "";
+  for (let i = 1; i < args.length; i += 1) {
+    const arg = args[i]!;
+    if (arg === "--pretty") { pretty = true; continue; }
+    if (arg === "--compact") { pretty = false; continue; }
+    if (arg === "-bd" || arg === "--biz-domain") {
+      businessDomain = args[i + 1] ?? "";
+      i += 1;
+      continue;
+    }
+    process.stderr.write(`Unsupported flag: ${arg}\n`);
+    return 1;
+  }
+
+  const token = await ensureValidToken();
+  businessDomain = businessDomain || resolveBusinessDomain();
+
+  const deps = {
+    getAgent: (id: string) => getAgent({ baseUrl: token.baseUrl, accessToken: token.accessToken, agentId: id, businessDomain }),
+    fetchById: async (id: string): Promise<MemberFetchResult> => {
+      try {
+        const info = await getSkill({ baseUrl: token.baseUrl, accessToken: token.accessToken, skillId: id, businessDomain });
+        return { exists: true, published: info.status === "published", name: info.name, status: info.status };
+      } catch {
+        return { exists: false, published: false };
+      }
+    },
+  };
+
+  try {
+    const rows = await listAgentMembers({ agentId, spec: SKILL_SPEC, deps });
+    const output = rows.map((r) => ({ skill_id: r.id, name: r.name, status: r.status }));
+    console.log(JSON.stringify(output, null, pretty ? 2 : 0));
+    return 0;
+  } catch (error) {
+    process.stderr.write(`✗ ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+export async function runAgentSkillCommand(args: string[]): Promise<number> {
+  const [verb, ...rest] = args;
+  if (!verb || verb === "--help" || verb === "-h") {
+    console.log(`kweaver agent skill
+
+Subcommands:
+  add <agent-id> <skill-id>... [--strict] [-bd <bd>]      Attach skills to an agent
+  remove <agent-id> <skill-id>... [-bd <bd>]              Detach skills from an agent
+  list <agent-id> [--pretty|--compact] [-bd <bd>]         List skills attached to an agent
+
+Notes:
+  --strict         On add, reject skills that exist but are not in 'published' status.
+                   Default behaviour: warn and continue.
+  Dedupe is automatic for add; remove silently skips not-attached ids.`);
+    return 0;
+  }
+  try {
+    if (verb === "add") return await runSkillAdd(rest);
+    if (verb === "remove") return await runSkillRemove(rest);
+    if (verb === "list") return await runSkillList(rest);
+    process.stderr.write(`Unknown agent skill subcommand: ${verb}\n`);
+    return 1;
+  } catch (error) {
+    process.stderr.write(`${formatHttpError(error)}\n`);
+    return 1;
+  }
 }

--- a/packages/typescript/src/commands/agent-members.ts
+++ b/packages/typescript/src/commands/agent-members.ts
@@ -4,7 +4,7 @@
  */
 
 export interface MutationReport {
-  currentIds: string[];
+  finalIds: string[];
   added: string[];
   alreadyAttached: string[];
   removed: string[];
@@ -22,7 +22,7 @@ export interface MutateConfigMembersInput {
 export interface MutateConfigMembersResult {
   newConfig: Record<string, unknown>;
   report: MutationReport;
-  currentIds: string[];
+  finalIds: string[];
 }
 
 /** Deep-clone a JSON-serializable object so mutations don't leak to callers. */
@@ -64,11 +64,14 @@ function ensureArrayAtPath(
 }
 
 export function mutateConfigMembers(input: MutateConfigMembersInput): MutateConfigMembersResult {
+  if (input.path.length === 0) {
+    throw new Error("mutateConfigMembers: path must have at least one segment");
+  }
   const newConfig = clone(input.config);
   const arr = ensureArrayAtPath(newConfig, input.path);
 
-  const currentIds: string[] = arr.map((el) => String(el[input.idField] ?? ""));
-  const currentSet = new Set(currentIds);
+  const existingIds: string[] = arr.map((el) => String(el[input.idField] ?? ""));
+  const currentSet = new Set(existingIds);
 
   const added: string[] = [];
   const alreadyAttached: string[] = [];
@@ -110,9 +113,9 @@ export function mutateConfigMembers(input: MutateConfigMembersInput): MutateConf
 
   return {
     newConfig,
-    currentIds: finalIds,
+    finalIds,
     report: {
-      currentIds: finalIds,
+      finalIds,
       added,
       alreadyAttached,
       removed,

--- a/packages/typescript/src/commands/agent-members.ts
+++ b/packages/typescript/src/commands/agent-members.ts
@@ -1,0 +1,122 @@
+/**
+ * Pure helpers and orchestrators for managing agent member associations
+ * (skills, tools, mcps) via get → mutate(config) → update.
+ */
+
+export interface MutationReport {
+  currentIds: string[];
+  added: string[];
+  alreadyAttached: string[];
+  removed: string[];
+  notAttached: string[];
+}
+
+export interface MutateConfigMembersInput {
+  config: Record<string, unknown>;
+  path: string[];
+  idField: string;
+  addIds: string[];
+  removeIds: string[];
+}
+
+export interface MutateConfigMembersResult {
+  newConfig: Record<string, unknown>;
+  report: MutationReport;
+  currentIds: string[];
+}
+
+/** Deep-clone a JSON-serializable object so mutations don't leak to callers. */
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Descend into `config` along `path`, creating empty objects and a terminal
+ * empty array along the way if any node is missing. Returns the terminal array.
+ */
+function ensureArrayAtPath(
+  root: Record<string, unknown>,
+  path: string[],
+): Record<string, unknown>[] {
+  let cursor: Record<string, unknown> = root;
+  for (let i = 0; i < path.length - 1; i += 1) {
+    const key = path[i]!;
+    const next = cursor[key];
+    if (next === undefined || next === null) {
+      cursor[key] = {};
+    } else if (typeof next !== "object" || Array.isArray(next)) {
+      throw new Error(
+        `Config path conflict at ${path.slice(0, i + 1).join(".")}: expected object, got ${Array.isArray(next) ? "array" : typeof next}`,
+      );
+    }
+    cursor = cursor[key] as Record<string, unknown>;
+  }
+  const terminalKey = path[path.length - 1]!;
+  const terminal = cursor[terminalKey];
+  if (terminal === undefined || terminal === null) {
+    cursor[terminalKey] = [];
+  } else if (!Array.isArray(terminal)) {
+    throw new Error(
+      `Config path conflict at ${path.join(".")}: expected array, got ${typeof terminal}`,
+    );
+  }
+  return cursor[terminalKey] as Record<string, unknown>[];
+}
+
+export function mutateConfigMembers(input: MutateConfigMembersInput): MutateConfigMembersResult {
+  const newConfig = clone(input.config);
+  const arr = ensureArrayAtPath(newConfig, input.path);
+
+  const currentIds: string[] = arr.map((el) => String(el[input.idField] ?? ""));
+  const currentSet = new Set(currentIds);
+
+  const added: string[] = [];
+  const alreadyAttached: string[] = [];
+  for (const id of input.addIds) {
+    if (currentSet.has(id)) {
+      alreadyAttached.push(id);
+    } else {
+      arr.push({ [input.idField]: id });
+      currentSet.add(id);
+      added.push(id);
+    }
+  }
+
+  const removeSet = new Set(input.removeIds);
+  const removed: string[] = [];
+  const notAttached: string[] = [];
+  if (removeSet.size > 0) {
+    const survivors: Record<string, unknown>[] = [];
+    const survivingIdSet = new Set<string>();
+    for (const el of arr) {
+      const id = String(el[input.idField] ?? "");
+      if (removeSet.has(id)) {
+        if (!removed.includes(id)) removed.push(id);
+        continue;
+      }
+      survivors.push(el);
+      survivingIdSet.add(id);
+    }
+    for (const id of input.removeIds) {
+      if (!removed.includes(id) && !survivingIdSet.has(id)) {
+        notAttached.push(id);
+      }
+    }
+    arr.length = 0;
+    arr.push(...survivors);
+  }
+
+  const finalIds = arr.map((el) => String(el[input.idField] ?? ""));
+
+  return {
+    newConfig,
+    currentIds: finalIds,
+    report: {
+      currentIds: finalIds,
+      added,
+      alreadyAttached,
+      removed,
+      notAttached,
+    },
+  };
+}

--- a/packages/typescript/src/commands/agent.ts
+++ b/packages/typescript/src/commands/agent.ts
@@ -1,5 +1,6 @@
 import { ensureValidToken, formatHttpError, with401RefreshRetry } from "../auth/oauth.js";
 import { runAgentChatCommand } from "./agent-chat.js";
+import { runAgentSkillCommand } from "./agent-members.js";
 import {
   listAgents, getAgent, getAgentByKey,
   createAgent, updateAgent, deleteAgent,
@@ -684,6 +685,7 @@ Subcommands:
   unpublish <agent_id>               Unpublish an agent
   chat <agent_id>                    Start interactive chat with an agent
   chat <agent_id> -m "message"       Send a single message (non-interactive)
+  skill <verb> ...                   Manage skills attached to an agent (add/remove/list)
   sessions <agent_id>                List all conversations for an agent
   history <agent_id> <conversation_id> Show message history for a conversation
   trace <agent_id> <conversation_id>  Get trace data for a conversation`);
@@ -707,6 +709,7 @@ Subcommands:
     if (subcommand === "delete") return runAgentDeleteCommand(rest);
     if (subcommand === "publish") return runAgentPublishCommand(rest);
     if (subcommand === "unpublish") return runAgentUnpublishCommand(rest);
+    if (subcommand === "skill") return runAgentSkillCommand(rest);
     return -1;
   };
 

--- a/packages/typescript/test/agent-members-cmd.test.ts
+++ b/packages/typescript/test/agent-members-cmd.test.ts
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { runAgentCommand } from "../src/commands/agent.js";
+
+const originalFetch = globalThis.fetch;
+
+function createConfigDir(): string {
+  return mkdtempSync(join(tmpdir(), "kweaver-agent-members-"));
+}
+
+async function importStoreModule(configDir: string) {
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const moduleUrl = pathToFileURL(join(process.cwd(), "src/config/store.ts")).href;
+  return import(`${moduleUrl}?t=${Date.now()}-${Math.random()}`);
+}
+
+async function primeToken() {
+  const configDir = createConfigDir();
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  const store = await importStoreModule(configDir);
+  store.saveTokenConfig({
+    baseUrl: "https://dip.aishu.cn",
+    accessToken: "token-test",
+    tokenType: "bearer",
+    scope: "openid",
+    obtainedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  });
+  store.setCurrentPlatform("https://dip.aishu.cn");
+}
+
+test("agent help lists skill subcommand", async () => {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(" ")); };
+  try {
+    await runAgentCommand([]);
+    assert.ok(lines.join("\n").includes("skill"), "help should mention skill");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+test("agent skill help lists add/remove/list", async () => {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => { lines.push(args.map(String).join(" ")); };
+  try {
+    await runAgentCommand(["skill", "--help"]);
+    const help = lines.join("\n");
+    assert.ok(help.includes("add"), "help should list add");
+    assert.ok(help.includes("remove"), "help should list remove");
+    assert.ok(help.includes("list"), "help should list list");
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+test("agent skill rejects unknown subverb", { concurrency: false }, async () => {
+  await primeToken();
+  const errors: string[] = [];
+  const originalErr = console.error;
+  const originalStderr = process.stderr.write.bind(process.stderr);
+  console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+  (process.stderr as any).write = (chunk: any) => { errors.push(String(chunk)); return true; };
+  try {
+    const code = await runAgentCommand(["skill", "foobar", "ag_1"]);
+    assert.equal(code, 1);
+    assert.ok(errors.join("\n").toLowerCase().includes("unknown"), `expected 'unknown' in stderr, got: ${errors.join("\n")}`);
+  } finally {
+    console.error = originalErr;
+    (process.stderr as any).write = originalStderr;
+  }
+});
+
+test("agent skill add — rejects missing id", { concurrency: false }, async () => {
+  await primeToken();
+
+  globalThis.fetch = async (urlInput: string | URL | Request) => {
+    const urlStr = typeof urlInput === "string" ? urlInput : urlInput instanceof URL ? urlInput.href : urlInput.url;
+    if (urlStr.includes("/skills/sk_missing")) {
+      return new Response("not found", { status: 404 });
+    }
+    if (urlStr.includes("/agent-factory/v3/agent/")) {
+      throw new Error("agent get called despite missing skill id");
+    }
+    return new Response("{}", { status: 200 });
+  };
+
+  const errors: string[] = [];
+  const originalErr = console.error;
+  const originalStderr = process.stderr.write.bind(process.stderr);
+  console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+  (process.stderr as any).write = (chunk: any) => { errors.push(String(chunk)); return true; };
+  try {
+    const code = await runAgentCommand(["skill", "add", "ag_1", "sk_missing"]);
+    assert.equal(code, 1);
+    assert.match(errors.join("\n"), /sk_missing/);
+  } finally {
+    console.error = originalErr;
+    (process.stderr as any).write = originalStderr;
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("agent skill add — happy path writes and reports", { concurrency: false }, async () => {
+  await primeToken();
+
+  const updateBodies: string[] = [];
+  globalThis.fetch = async (urlInput: string | URL | Request, init?: RequestInit) => {
+    const urlStr = typeof urlInput === "string" ? urlInput : urlInput instanceof URL ? urlInput.href : urlInput.url;
+    const method = (init?.method ?? "GET").toUpperCase();
+
+    if (urlStr.includes("/skills/sk_a") && method === "GET") {
+      return new Response(JSON.stringify({ data: { id: "sk_a", name: "alpha", status: "published" } }), {
+        status: 200, headers: { "content-type": "application/json" },
+      });
+    }
+    if (urlStr.includes("/agent-factory/v3/agent/ag_1") && method === "GET") {
+      return new Response(JSON.stringify({ id: "ag_1", name: "A", profile: "P", config: {} }), {
+        status: 200, headers: { "content-type": "application/json" },
+      });
+    }
+    if (urlStr.includes("/agent-factory/v3/agent/ag_1") && method === "PUT") {
+      updateBodies.push(String(init?.body ?? ""));
+      return new Response("ok", { status: 200 });
+    }
+    throw new Error(`unexpected fetch ${method} ${urlStr}`);
+  };
+
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => { logs.push(args.map(String).join(" ")); };
+  try {
+    const code = await runAgentCommand(["skill", "add", "ag_1", "sk_a"]);
+    assert.equal(code, 0);
+    assert.equal(updateBodies.length, 1);
+    const body = JSON.parse(updateBodies[0]!) as { config: { skills: { skills: { skill_id: string }[] } } };
+    assert.deepEqual(body.config.skills.skills, [{ skill_id: "sk_a" }]);
+    assert.ok(logs.join("\n").includes("sk_a"));
+  } finally {
+    console.log = originalLog;
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/typescript/test/agent-members-cmd.test.ts
+++ b/packages/typescript/test/agent-members-cmd.test.ts
@@ -108,6 +108,26 @@ test("agent skill add — rejects missing id", { concurrency: false }, async () 
   }
 });
 
+test("agent skill add — arg parse error uses ✗ prefix", { concurrency: false }, async () => {
+  await primeToken();
+  const errors: string[] = [];
+  const originalErr = console.error;
+  const originalStderr = process.stderr.write.bind(process.stderr);
+  console.error = (...args: unknown[]) => { errors.push(args.map(String).join(" ")); };
+  (process.stderr as any).write = (chunk: any) => { errors.push(String(chunk)); return true; };
+  try {
+    // No agent id, no skill id — triggers parseWriteArgs throw
+    const code = await runAgentCommand(["skill", "add"]);
+    assert.equal(code, 1);
+    const out = errors.join("");
+    assert.match(out, /✗/, `expected ✗ prefix, got: ${out}`);
+    assert.match(out, /Missing <agent-id>/);
+  } finally {
+    console.error = originalErr;
+    (process.stderr as any).write = originalStderr;
+  }
+});
+
 test("agent skill add — happy path writes and reports", { concurrency: false }, async () => {
   await primeToken();
 

--- a/packages/typescript/test/agent-members-mutate.test.ts
+++ b/packages/typescript/test/agent-members-mutate.test.ts
@@ -1,0 +1,114 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mutateConfigMembers } from "../src/commands/agent-members.js";
+
+test("mutateConfigMembers adds ids to existing array", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }] } };
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: ["sk_b", "sk_c"],
+    removeIds: [],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills.map((x) => x.skill_id),
+    ["sk_a", "sk_b", "sk_c"],
+  );
+  assert.deepEqual(report.added, ["sk_b", "sk_c"]);
+  assert.deepEqual(report.alreadyAttached, []);
+});
+
+test("mutateConfigMembers dedupes already-attached ids", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }] } };
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: ["sk_a", "sk_b"],
+    removeIds: [],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills.map((x) => x.skill_id),
+    ["sk_a", "sk_b"],
+  );
+  assert.deepEqual(report.added, ["sk_b"]);
+  assert.deepEqual(report.alreadyAttached, ["sk_a"]);
+});
+
+test("mutateConfigMembers creates missing path nodes", () => {
+  const config: Record<string, unknown> = {};
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: ["sk_a"],
+    removeIds: [],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills,
+    [{ skill_id: "sk_a" }],
+  );
+  assert.deepEqual(report.added, ["sk_a"]);
+});
+
+test("mutateConfigMembers removes ids and preserves order", () => {
+  const config = {
+    skills: { skills: [{ skill_id: "sk_a" }, { skill_id: "sk_b" }, { skill_id: "sk_c" }] },
+  };
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: [],
+    removeIds: ["sk_b"],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills.map((x) => x.skill_id),
+    ["sk_a", "sk_c"],
+  );
+  assert.deepEqual(report.removed, ["sk_b"]);
+  assert.deepEqual(report.notAttached, []);
+});
+
+test("mutateConfigMembers reports not-attached on remove miss", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }] } };
+  const { newConfig, report } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: [],
+    removeIds: ["sk_a", "sk_missing"],
+  });
+  assert.deepEqual(
+    (newConfig as { skills: { skills: { skill_id: string }[] } }).skills.skills,
+    [],
+  );
+  assert.deepEqual(report.removed, ["sk_a"]);
+  assert.deepEqual(report.notAttached, ["sk_missing"]);
+});
+
+test("mutateConfigMembers does not mutate input config", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }] } };
+  const original = JSON.parse(JSON.stringify(config));
+  mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: ["sk_b"],
+    removeIds: [],
+  });
+  assert.deepEqual(config, original);
+});
+
+test("mutateConfigMembers lists current ids", () => {
+  const config = { skills: { skills: [{ skill_id: "sk_a" }, { skill_id: "sk_b" }] } };
+  const { currentIds } = mutateConfigMembers({
+    config,
+    path: ["skills", "skills"],
+    idField: "skill_id",
+    addIds: [],
+    removeIds: [],
+  });
+  assert.deepEqual(currentIds, ["sk_a", "sk_b"]);
+});

--- a/packages/typescript/test/agent-members-mutate.test.ts
+++ b/packages/typescript/test/agent-members-mutate.test.ts
@@ -101,14 +101,28 @@ test("mutateConfigMembers does not mutate input config", () => {
   assert.deepEqual(config, original);
 });
 
-test("mutateConfigMembers lists current ids", () => {
+test("mutateConfigMembers exposes finalIds list", () => {
   const config = { skills: { skills: [{ skill_id: "sk_a" }, { skill_id: "sk_b" }] } };
-  const { currentIds } = mutateConfigMembers({
+  const { finalIds } = mutateConfigMembers({
     config,
     path: ["skills", "skills"],
     idField: "skill_id",
     addIds: [],
     removeIds: [],
   });
-  assert.deepEqual(currentIds, ["sk_a", "sk_b"]);
+  assert.deepEqual(finalIds, ["sk_a", "sk_b"]);
+});
+
+test("mutateConfigMembers throws on empty path", () => {
+  assert.throws(
+    () =>
+      mutateConfigMembers({
+        config: {},
+        path: [],
+        idField: "skill_id",
+        addIds: ["sk_a"],
+        removeIds: [],
+      }),
+    /path must have at least one segment/i,
+  );
 });

--- a/packages/typescript/test/agent-members-orchestrator.test.ts
+++ b/packages/typescript/test/agent-members-orchestrator.test.ts
@@ -1,0 +1,206 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  patchAgentMembers,
+  type MemberSpec,
+  type MemberFetchResult,
+} from "../src/commands/agent-members.js";
+
+interface MockAgentStore {
+  agent: Record<string, unknown>;
+  updateCalls: Record<string, unknown>[];
+}
+
+function makeDeps(store: MockAgentStore, members: Record<string, MemberFetchResult>) {
+  return {
+    getAgent: async (id: string) => {
+      if (id !== "ag_1") throw new Error(`agent ${id} not found`);
+      return JSON.stringify(store.agent);
+    },
+    updateAgent: async (id: string, body: Record<string, unknown>) => {
+      store.updateCalls.push(body);
+      return "ok";
+    },
+    fetchById: async (id: string): Promise<MemberFetchResult> => {
+      if (!(id in members)) return { exists: false, published: false };
+      return members[id]!;
+    },
+  };
+}
+
+function skillSpec(): MemberSpec {
+  return {
+    memberKind: "skill",
+    configPath: ["skills", "skills"],
+    idField: "skill_id",
+  };
+}
+
+test("patchAgentMembers add happy path", async () => {
+  const store: MockAgentStore = {
+    agent: { id: "ag_1", name: "a", profile: "p", config: {} },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, {
+    sk_a: { exists: true, published: true, name: "alpha" },
+  });
+
+  const report = await patchAgentMembers({
+    agentId: "ag_1",
+    spec: skillSpec(),
+    addIds: ["sk_a"],
+    removeIds: [],
+    strict: false,
+    deps,
+  });
+
+  assert.equal(store.updateCalls.length, 1);
+  const config = store.updateCalls[0]!.config as { skills: { skills: { skill_id: string }[] } };
+  assert.deepEqual(config.skills.skills, [{ skill_id: "sk_a" }]);
+  assert.deepEqual(report.added, ["sk_a"]);
+  assert.deepEqual(report.warnings, []);
+});
+
+test("patchAgentMembers add aborts when any id does not exist", async () => {
+  const store: MockAgentStore = {
+    agent: { id: "ag_1", name: "a", profile: "p", config: {} },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, {
+    sk_a: { exists: true, published: true },
+  });
+
+  await assert.rejects(
+    () =>
+      patchAgentMembers({
+        agentId: "ag_1",
+        spec: skillSpec(),
+        addIds: ["sk_a", "sk_missing"],
+        removeIds: [],
+        strict: false,
+        deps,
+      }),
+    (err: Error) => /sk_missing.*not found/.test(err.message),
+  );
+
+  assert.equal(store.updateCalls.length, 0, "updateAgent must not be called when any id is missing");
+});
+
+test("patchAgentMembers add warns on draft in non-strict mode and still writes", async () => {
+  const store: MockAgentStore = {
+    agent: { id: "ag_1", name: "a", profile: "p", config: {} },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, {
+    sk_draft: { exists: true, published: false, name: "draft-one" },
+  });
+
+  const report = await patchAgentMembers({
+    agentId: "ag_1",
+    spec: skillSpec(),
+    addIds: ["sk_draft"],
+    removeIds: [],
+    strict: false,
+    deps,
+  });
+
+  assert.equal(store.updateCalls.length, 1);
+  assert.deepEqual(report.added, ["sk_draft"]);
+  assert.equal(report.warnings.length, 1);
+  assert.match(report.warnings[0]!, /sk_draft.*draft/);
+});
+
+test("patchAgentMembers add errors on draft in strict mode and does not write", async () => {
+  const store: MockAgentStore = {
+    agent: { id: "ag_1", name: "a", profile: "p", config: {} },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, {
+    sk_draft: { exists: true, published: false },
+  });
+
+  await assert.rejects(
+    () =>
+      patchAgentMembers({
+        agentId: "ag_1",
+        spec: skillSpec(),
+        addIds: ["sk_draft"],
+        removeIds: [],
+        strict: true,
+        deps,
+      }),
+    (err: Error) => /sk_draft.*draft/.test(err.message),
+  );
+
+  assert.equal(store.updateCalls.length, 0);
+});
+
+test("patchAgentMembers remove does not call fetchById", async () => {
+  const store: MockAgentStore = {
+    agent: {
+      id: "ag_1",
+      name: "a",
+      profile: "p",
+      config: { skills: { skills: [{ skill_id: "sk_a" }, { skill_id: "sk_b" }] } },
+    },
+    updateCalls: [],
+  };
+  let fetchCalls = 0;
+  const deps = {
+    getAgent: async () => JSON.stringify(store.agent),
+    updateAgent: async (_id: string, body: Record<string, unknown>) => {
+      store.updateCalls.push(body);
+      return "ok";
+    },
+    fetchById: async () => {
+      fetchCalls += 1;
+      return { exists: true, published: true };
+    },
+  };
+
+  const report = await patchAgentMembers({
+    agentId: "ag_1",
+    spec: skillSpec(),
+    addIds: [],
+    removeIds: ["sk_a", "sk_missing"],
+    strict: false,
+    deps,
+  });
+
+  assert.equal(fetchCalls, 0, "fetchById must not be invoked for remove");
+  assert.equal(store.updateCalls.length, 1);
+  assert.deepEqual(report.removed, ["sk_a"]);
+  assert.deepEqual(report.notAttached, ["sk_missing"]);
+});
+
+test("patchAgentMembers preserves sibling config fields", async () => {
+  const store: MockAgentStore = {
+    agent: {
+      id: "ag_1",
+      name: "a",
+      profile: "p",
+      config: {
+        system_prompt: "keep me",
+        llms: [{ is_default: true, llm_config: { id: "m1", name: "n", max_tokens: 1 } }],
+        data_source: { knowledge_network: [{ knowledge_network_id: "kn_x", knowledge_network_name: "" }] },
+      },
+    },
+    updateCalls: [],
+  };
+  const deps = makeDeps(store, { sk_a: { exists: true, published: true } });
+
+  await patchAgentMembers({
+    agentId: "ag_1",
+    spec: skillSpec(),
+    addIds: ["sk_a"],
+    removeIds: [],
+    strict: false,
+    deps,
+  });
+
+  const written = store.updateCalls[0]!.config as Record<string, unknown>;
+  assert.equal(written.system_prompt, "keep me");
+  assert.ok(Array.isArray(written.llms));
+  assert.ok((written.data_source as Record<string, unknown>).knowledge_network);
+  assert.ok((written.skills as Record<string, unknown>).skills);
+});

--- a/packages/typescript/test/e2e/agent-member-skill.test.ts
+++ b/packages/typescript/test/e2e/agent-member-skill.test.ts
@@ -1,0 +1,121 @@
+/**
+ * E2E smoke test for `kweaver agent skill {add,remove,list}` against a live platform.
+ *
+ * Requires a KWeaver instance with OAuth credentials configured:
+ *   kweaver auth login   # or equivalent to populate ~/.kweaver/
+ *   export KWEAVER_E2E=1
+ *
+ * The test is gated on KWEAVER_E2E=1 — skipped by default so `npm test` stays hermetic.
+ *
+ * Run from `packages/typescript`:
+ *   KWEAVER_E2E=1 npm run test:e2e -- --test-name-pattern "agent skill"
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { runAgentCommand } from "../../src/commands/agent.js";
+import { ensureValidToken } from "../../src/auth/oauth.js";
+import { createAgent, deleteAgent } from "../../src/api/agent-list.js";
+import { listSkills } from "../../src/api/skills.js";
+
+const e2eEnabled = process.env.KWEAVER_E2E === "1";
+
+async function captureRun(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const originalLog = console.log;
+  const originalErr = console.error;
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  console.log = (...a: unknown[]) => { stdout.push(a.map(String).join(" ") + "\n"); };
+  console.error = (...a: unknown[]) => { stderr.push(a.map(String).join(" ") + "\n"); };
+  (process.stderr as unknown as { write: (c: unknown) => boolean }).write = (c: unknown) => {
+    stderr.push(String(c));
+    return true;
+  };
+  try {
+    const code = await runAgentCommand(args);
+    return { code, stdout: stdout.join(""), stderr: stderr.join("") };
+  } finally {
+    console.log = originalLog;
+    console.error = originalErr;
+    (process.stderr as unknown as { write: typeof originalStderrWrite }).write = originalStderrWrite;
+  }
+}
+
+test("agent skill add/list/remove round-trip (e2e)", { skip: !e2eEnabled }, async () => {
+  const token = await ensureValidToken();
+  const base = { baseUrl: token.baseUrl, accessToken: token.accessToken };
+
+  // 1. Find at least one published skill to use as the attachment target.
+  const skillsPage = await listSkills({ ...base, status: "published", pageSize: 1 });
+  const skillRow = (skillsPage.data ?? [])[0];
+  if (!skillRow?.id) {
+    throw new Error("e2e pre-req failed: no published skill found on platform; register one first");
+  }
+  const skillId = skillRow.id;
+
+  // 2. Create a fresh test agent.
+  const ts = Date.now();
+  const createBody = JSON.stringify({
+    name: `e2e_skill_member_${ts}`,
+    profile: "e2e test agent for skill membership",
+    avatar_type: 1,
+    avatar: "icon-dip-agent-default",
+    product_key: "dip",
+    product_name: "DIP",
+    config: {
+      input: { fields: [{ name: "user_input", type: "string", desc: "" }] },
+      output: { default_format: "markdown" },
+      system_prompt: "",
+    },
+  });
+  const created = JSON.parse(await createAgent({ ...base, body: createBody })) as { id?: string; data?: { id?: string } };
+  const agentId = created.id ?? created.data?.id;
+  assert.ok(agentId, `create returned an id (got: ${JSON.stringify(created)})`);
+
+  try {
+    // 3. list — empty to start
+    {
+      const { code, stdout } = await captureRun(["skill", "list", agentId!, "--compact"]);
+      assert.equal(code, 0, `list exit 0, got stdout=${stdout}`);
+      const rows = JSON.parse(stdout.trim()) as unknown[];
+      assert.deepEqual(rows, [], "freshly created agent has no skills");
+    }
+
+    // 4. add
+    {
+      const { code, stdout, stderr } = await captureRun(["skill", "add", agentId!, skillId]);
+      assert.equal(code, 0, `add exit 0; stdout=${stdout} stderr=${stderr}`);
+      assert.match(stdout, new RegExp(`✓ ${skillId}\\s+added`));
+    }
+
+    // 5. list — contains the skill
+    {
+      const { code, stdout } = await captureRun(["skill", "list", agentId!, "--compact"]);
+      assert.equal(code, 0);
+      const rows = JSON.parse(stdout.trim()) as Array<{ skill_id: string; name: string | null; status: string }>;
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0]!.skill_id, skillId);
+      assert.equal(rows[0]!.status, "published");
+    }
+
+    // 6. remove
+    {
+      const { code, stdout, stderr } = await captureRun(["skill", "remove", agentId!, skillId]);
+      assert.equal(code, 0, `remove exit 0; stdout=${stdout} stderr=${stderr}`);
+      assert.match(stdout, new RegExp(`✓ ${skillId}\\s+removed`));
+    }
+
+    // 7. list — empty again
+    {
+      const { code, stdout } = await captureRun(["skill", "list", agentId!, "--compact"]);
+      assert.equal(code, 0);
+      const rows = JSON.parse(stdout.trim()) as unknown[];
+      assert.deepEqual(rows, [], "skill removed cleanly");
+    }
+  } finally {
+    // 8. cleanup — runs even if inner steps throw
+    await deleteAgent({ ...base, agentId: agentId! }).catch(() => undefined);
+  }
+});


### PR DESCRIPTION
## Summary

- Ships `kweaver agent skill add / remove / list` — three sub-subcommands that replace the `agent get → hand-edit JSON → agent update` workflow called out as the top CLI-UX gap in #72.
- Keeps sibling `config.*` fields (llms / system_prompt / data_source / the rest of `config.skills.*`) untouched through the get → mutate → update pipeline.
- Scope is deliberately skill-only; tool + mcp were deferred after a probe of the live platform revealed tool attachment needs OpenAPI-to-`tool_input` expansion (non-trivial, separate issue). Full probe findings: `docs/superpowers/plans/research/2026-04-21-agent-config-probe.md`.

## Design / architecture

- `mutateConfigMembers` — pure, dependency-free config helper (dedupe, missing-path creation, clone, report).
- `patchAgentMembers` — orchestrator wrapping validate → fetch → mutate → update, parameterized by a `MemberSpec` so the deferred tool/mcp groups can plug in without restructuring.
- `listAgentMembers` — read-only path decorating each id with name/status, graceful degradation if fetch-by-id fails.
- `runAgentSkillCommand` — CLI handler wiring argv + help + the skill-specific `fetchById` (backed by `getSkill`).

Documents:
- Spec: `docs/superpowers/specs/2026-04-21-agent-member-cli-design.md`
- Plan: `docs/superpowers/plans/2026-04-21-agent-member-cli.md`
- Probe report: `docs/superpowers/plans/research/2026-04-21-agent-config-probe.md`

## UX change

Before (from #72):
```bash
kweaver agent get ag_xxx --verbose > /tmp/cfg.json
python3 -c "...edit config.skills.skills..."
kweaver agent update ag_xxx --config-path /tmp/cfg-out.json
```

After:
```bash
kweaver agent skill add <agent-id> <skill-id>...   [--strict]
kweaver agent skill remove <agent-id> <skill-id>...
kweaver agent skill list <agent-id> [--pretty|--compact]
```

## Validation behaviour

- Add: each `skill-id` is validated via `getSkill` before any write; missing id → exit 1, zero side effects. Draft skills → warning by default, `--strict` upgrades to abort.
- Add dedupe: already-attached ids print `• already attached (skipped)`, no write call if nothing actually changes.
- Remove: never calls `fetchById` (lets you clear dangling references); ids not in the list print `• not attached (skipped)`, exit 0.

## Test plan

- [x] TDD: 8 unit tests for `mutateConfigMembers` (pure logic).
- [x] TDD: 6 unit tests for `patchAgentMembers` (mocked deps — validate/abort/warn/strict/remove/sibling-preserve).
- [x] TDD: 6 command tests for `runAgentSkillCommand` (help, unknown verb, missing-id abort, happy-path write, ✗-prefix consistency).
- [x] Full TS suite green locally (696/696 passing, lint clean).
- [x] e2e test added, gated on `KWEAVER_E2E=1`.
- [x] Manual round-trip on live platform (`https://115.190.186.186`): create test agent → list (empty) → add two skills → add duplicate (dedupe) → list (names + statuses) → add missing id (zero-side-effect abort, exit 1) → confirm sibling config (llms / 15 other config keys) untouched → remove mixed (real + not-attached) → list → remove last → list empty → delete agent. Every step matched the expected UX.

## Deferred (tracked follow-ups)

- **Tool group** (`agent tool add/remove/list`) — `config.skills.tools[]` elements need `tool_input` resolved from the tool's OpenAPI spec; bare `{tool_id}` would fail at runtime. Separate spec + plan; probe report has the groundwork.
- **MCP group** (`agent mcp add/remove/list`) — API route confirmed (`/api/agent-operator-integration/v1/mcp{,/list,/<id>}`); shape is simple. Bundled with the tool follow-up for uniform delivery.
- LLM / knowledge-network add/remove/set, `set` verb, `agent update --skill-add` flag form, `agent trace` 500 fix — all deferred from the original spec; they're independent and best shipped separately.

Closes a major piece of #72 (the agent↔skill association gap); remaining items tracked via a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)