### PR TITLE
fix(cli): three narrow user-facing error fixes (BKN 403 hint, app-token list-bd, env whoami)

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kweaver-sdk"
-version = "0.6.7"
+version = "0.6.8"
 description = "KWeaver Python SDK — client library for knowledge network construction and querying"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "kweaver-sdk"
-version = "0.6.7"
+version = "0.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -31,7 +31,9 @@ export KWEAVER_BASE_URL=https://your-kweaver-instance.com
 export KWEAVER_TOKEN=your-token
 ```
 
-With both set, API commands use that token even if you never ran `auth login`. You can also run **`kweaver auth status`**, **`kweaver auth whoami`** (supports `--json`), and **`kweaver config show`** when there is **no** current platform in `~/.kweaver/` — the CLI decodes the token locally (JWT only). If the token is opaque, identity fields are omitted and a short hint is printed.
+With both set, API commands use that token even if you never ran `auth login`. You can also run **`kweaver auth status`**, **`kweaver auth whoami`** (supports `--json`), and **`kweaver config show`** when there is **no** current platform in `~/.kweaver/`. In env-token mode, `whoami` resolves the bound identity from EACP `/api/eacp/v1/user/get` and prints `Type` (user/app), `User ID`, `Account` and `Name`; this works for both opaque and JWT tokens. If EACP is unreachable, the CLI falls back to local JWT decode and prints a short hint when the token is opaque.
+
+`kweaver config list-bd` lists business domains for the current user. App (service) tokens are not bound to an end-user — when the backend rejects the call with `401 invalid user_id`, the CLI re-checks the token type via EACP and, if confirmed `type:"app"`, replaces the cryptic backend body with `This command does not support app accounts.`. Use a user token (interactive `auth login`) for user-bound endpoints.
 
 ### Business domain (platform)
 

--- a/packages/typescript/README.zh.md
+++ b/packages/typescript/README.zh.md
@@ -31,7 +31,9 @@ export KWEAVER_BASE_URL=https://your-kweaver-instance.com
 export KWEAVER_TOKEN=your-token
 ```
 
-两者同时设置时，即使未执行 `auth login`，业务命令也会使用该 token。若 **`~/.kweaver/` 无当前平台**，仍可使用 **`kweaver auth status`**、**`kweaver auth whoami`**（支持 `--json`）、**`kweaver config show`**：CLI 会在本地解 JWT 展示身份；若 token 为 opaque，则省略身份字段并给出简短提示。
+两者同时设置时，即使未执行 `auth login`，业务命令也会使用该 token。若 **`~/.kweaver/` 无当前平台**，仍可使用 **`kweaver auth status`**、**`kweaver auth whoami`**（支持 `--json`）、**`kweaver config show`**。环境变量模式下，`whoami` 会通过 EACP `/api/eacp/v1/user/get` 在线获取身份并展示 `Type`（user/app）、`User ID`、`Account`、`Name`，对 opaque 与 JWT token 都生效；若 EACP 不可达，则回退到本地 JWT 解码，opaque token 会给出简短提示。
+
+`kweaver config list-bd` 用于列出当前用户可访问的业务域。**应用（service）token 没有绑定终端用户**——当后端返回 `401 invalid user_id` 时，CLI 会再向 EACP 复核 token 类型，确认为 `type:"app"` 后将晦涩的后端原文替换为 `This command does not support app accounts.`。需要这个能力时请改用交互式 `auth login` 获得的用户 token。
 
 ### 业务域（平台配置）
 

--- a/packages/typescript/package-lock.json
+++ b/packages/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kweaver-ai/kweaver-sdk",
-  "version": "0.6.6",
+  "version": "0.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kweaver-ai/kweaver-sdk",
-      "version": "0.6.6",
+      "version": "0.6.8",
       "license": "MIT",
       "dependencies": {
         "@kweaver-ai/bkn": "^0.1.0",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kweaver-ai/kweaver-sdk",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "KWeaver TypeScript SDK — CLI tool and programmatic API for knowledge networks and Decision Agents.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/typescript/src/auth/oauth.ts
+++ b/packages/typescript/src/auth/oauth.ts
@@ -292,12 +292,32 @@ function extractRsaPublicKeyMaterialFromPageProps(pageProps: Record<string, unkn
   return deepFindSigninRsaMaterial(pageProps, 5, new Set());
 }
 
-/** Best-effort fetch of display name via EACP userinfo (ShareServer). */
-async function fetchDisplayName(
+/** Identity resolved from EACP `/api/eacp/v1/user/get` for the bound access token. */
+export interface EacpUserInfo {
+  /** "user" — interactive end-user; "app" — service / application identity. */
+  type: "user" | "app";
+  /** EACP id (`userid` for users, `id` for apps). */
+  id: string;
+  /** Login name (e.g. "alice@example.com"). User tokens only. */
+  account?: string;
+  /** Display name — `visionName` for users, app name for apps. */
+  name?: string;
+}
+
+/**
+ * Probe EACP for the bound identity. Returns `null` on any failure (network,
+ * non-2xx, malformed JSON, unknown `type`). Callers must treat absence as a
+ * soft signal — this never throws and never blocks the user's actual command.
+ *
+ * The shape differs per token type, mirroring the EACP backend:
+ *   - `type: "user"` → `{ userid, account, name, ... }`
+ *   - `type: "app"`  → `{ id, name }`
+ */
+export async function fetchEacpUserInfo(
   baseUrl: string,
   accessToken: string,
   tlsInsecure?: boolean,
-): Promise<string | null> {
+): Promise<EacpUserInfo | null> {
   try {
     const res = await runWithTlsInsecure(tlsInsecure, () =>
       fetch(`${baseUrl}/api/eacp/v1/user/get`, {
@@ -305,14 +325,31 @@ async function fetchDisplayName(
       }),
     );
     if (!res.ok) return null;
-    const info = (await res.json()) as Record<string, unknown>;
-    if (typeof info.account === "string") return info.account;
-    if (typeof info.name === "string") return info.name;
-    if (typeof info.mail === "string") return info.mail;
+    const raw = (await res.json()) as Record<string, unknown>;
+    const type = raw.type;
+    if (type !== "user" && type !== "app") return null;
+    const idCandidate = type === "user" ? raw.userid : raw.id;
+    const id = typeof idCandidate === "string" ? idCandidate : "";
+    if (!id) return null;
+    return {
+      type,
+      id,
+      account: typeof raw.account === "string" ? raw.account : undefined,
+      name: typeof raw.name === "string" ? raw.name : undefined,
+    };
   } catch {
-    /* Non-critical — displayName will be absent. */
+    return null;
   }
-  return null;
+}
+
+/** Best-effort fetch of display name via EACP userinfo (ShareServer). */
+async function fetchDisplayName(
+  baseUrl: string,
+  accessToken: string,
+  tlsInsecure?: boolean,
+): Promise<string | null> {
+  const info = await fetchEacpUserInfo(baseUrl, accessToken, tlsInsecure);
+  return info?.account ?? info?.name ?? null;
 }
 
 /**
@@ -2049,7 +2086,18 @@ export function formatHttpError(error: unknown): string {
     if (oauthMessage) {
       return `HTTP ${error.status} ${error.statusText}\n\n${oauthMessage}`;
     }
-    return `${error.message}\n${error.body}`.trim();
+    const base = `${error.message}\n${error.body}`.trim();
+    // Backend quirk: BKN returns 403 (sometimes 404) with body
+    // `BknBackend.KnowledgeNetwork.NotFound` for unknown kn-id, which makes the
+    // HTTP status look like a permission problem. Surface the real cause so
+    // users don't waste time chasing auth.
+    if (
+      (error.status === 403 || error.status === 404) &&
+      /BknBackend\.KnowledgeNetwork\.NotFound/.test(error.body)
+    ) {
+      return `${base}\nHint: this is a "knowledge network not found" error (the kn-id does not exist), not a permission/auth issue. Verify the kn-id you passed.`;
+    }
+    return base;
   }
 
   if (error instanceof NetworkRequestError) {

--- a/packages/typescript/src/auth/oauth.ts
+++ b/packages/typescript/src/auth/oauth.ts
@@ -487,6 +487,36 @@ export function normalizeBaseUrl(value: string): string {
 }
 
 /**
+ * Resolve the platform URL the CLI should act on, with explicit precedence:
+ *
+ *   1. **positional**  — caller passed a URL/alias (always wins)
+ *   2. **env**         — `KWEAVER_BASE_URL` is set (explicit user intent;
+ *                        wins over a stale `~/.kweaver/` saved session)
+ *   3. **saved**       — `getCurrentPlatform()` from local config
+ *
+ * `source` lets callers print provenance without re-deriving it. This mirrors
+ * `ensureValidToken()` (which is already env-first), so introspection
+ * commands (`auth status`, `auth whoami`, `config show|list-bd|set-bd`) and
+ * data-path commands agree on which platform "current" means.
+ */
+export function resolveActivePlatform(positional?: string | null): {
+  url: string;
+  source: "positional" | "env" | "saved";
+} | null {
+  if (positional) {
+    const url = /^https?:\/\//.test(positional) ? normalizeBaseUrl(positional) : positional;
+    return { url, source: "positional" };
+  }
+  const envRaw = process.env.KWEAVER_BASE_URL?.trim();
+  if (envRaw) {
+    return { url: normalizeBaseUrl(envRaw), source: "env" };
+  }
+  const saved = getCurrentPlatform();
+  if (saved) return { url: saved, source: "saved" };
+  return null;
+}
+
+/**
  * Temporarily disable TLS certificate verification for Node `fetch` (sets
  * NODE_TLS_REJECT_UNAUTHORIZED). Used for `--insecure` login and token refresh.
  */
@@ -2087,10 +2117,6 @@ export function formatHttpError(error: unknown): string {
       return `HTTP ${error.status} ${error.statusText}\n\n${oauthMessage}`;
     }
     const base = `${error.message}\n${error.body}`.trim();
-    // Backend quirk: BKN returns 403 (sometimes 404) with body
-    // `BknBackend.KnowledgeNetwork.NotFound` for unknown kn-id, which makes the
-    // HTTP status look like a permission problem. Surface the real cause so
-    // users don't waste time chasing auth.
     if (
       (error.status === 403 || error.status === 404) &&
       /BknBackend\.KnowledgeNetwork\.NotFound/.test(error.body)

--- a/packages/typescript/src/auth/oauth.ts
+++ b/packages/typescript/src/auth/oauth.ts
@@ -2095,7 +2095,7 @@ export function formatHttpError(error: unknown): string {
       (error.status === 403 || error.status === 404) &&
       /BknBackend\.KnowledgeNetwork\.NotFound/.test(error.body)
     ) {
-      return `${base}\nHint: this is a "knowledge network not found" error (the kn-id does not exist), not a permission/auth issue. Verify the kn-id you passed.`;
+      return `Hint: this is a "knowledge network not found" error (the kn-id does not exist), not a permission/auth issue. Verify the kn-id you passed.\n${base}`;
     }
     return base;
   }

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -37,6 +37,7 @@ import {
   promptForUsername,
   promptForPassword,
   refreshTokenLogin,
+  resolveActivePlatform,
 } from "../auth/oauth.js";
 
 export async function runAuthCommand(args: string[]): Promise<number> {
@@ -304,26 +305,33 @@ Login options:
     const resolvedTarget = args[1] ? resolvePlatformIdentifier(args[1]) : undefined;
     const statusTarget =
       resolvedTarget && /^https?:\/\//.test(resolvedTarget) ? normalizeBaseUrl(resolvedTarget) : resolvedTarget ?? undefined;
+    const active = resolveActivePlatform(statusTarget);
 
-    const platform = statusTarget ?? getCurrentPlatform();
-    if (!platform) {
-      const envRaw = process.env.KWEAVER_BASE_URL?.trim();
-      const envUrl = envRaw ? normalizeBaseUrl(envRaw) : undefined;
+    if (!active) {
+      console.error(
+        "No active platform. Run `kweaver auth login <platform-url>` first.\n" +
+        "  Tip: set KWEAVER_BASE_URL and KWEAVER_TOKEN to use this command without a saved login.",
+      );
+      return 1;
+    }
+
+    if (active.source === "env") {
       const envToken = process.env.KWEAVER_TOKEN?.trim();
-      if (!envUrl || !envToken) {
+      if (!envToken) {
         console.error(
-          "No active platform. Run `kweaver auth login <platform-url>` first.\n" +
-          "  Tip: set KWEAVER_BASE_URL and KWEAVER_TOKEN to use this command without a saved login.",
+          `KWEAVER_BASE_URL is set to ${active.url} but KWEAVER_TOKEN is missing. ` +
+          "Set KWEAVER_TOKEN, or unset KWEAVER_BASE_URL to fall back to the saved session.",
         );
         return 1;
       }
       console.log(`Config directory: ${getConfigDir()}`);
-      console.log(`Platform:         ${envUrl} (KWEAVER_BASE_URL)`);
+      console.log(`Platform:         ${active.url} (KWEAVER_BASE_URL)`);
       console.log(`Token present:    yes (KWEAVER_TOKEN)`);
       console.log(`Refresh token:    n/a (env)`);
       return 0;
     }
 
+    const platform = active.url;
     const token = loadTokenConfig(platform);
     if (!token) {
       console.error(
@@ -587,27 +595,39 @@ Options:
   const jsonOutput = args.includes("--json");
   const positional = args.find((a) => !a.startsWith("-"));
   const resolved = positional ? resolvePlatformIdentifier(positional) : null;
-  const platform = resolved && /^https?:\/\//.test(resolved) ? normalizeBaseUrl(resolved) : resolved ?? getCurrentPlatform();
+  const active = resolveActivePlatform(resolved);
 
-  if (!platform) {
-    const envRaw = process.env.KWEAVER_BASE_URL?.trim();
-    const envUrl = envRaw ? normalizeBaseUrl(envRaw) : undefined;
+  if (!active) {
+    console.error("No active platform. Run `kweaver auth login <platform-url>` first.");
+    return 1;
+  }
+
+  // Env mode requires both URL and token. resolveActivePlatform() returns
+  // source="env" as soon as KWEAVER_BASE_URL is set; if KWEAVER_TOKEN is
+  // missing we cannot inspect identity at all, so guide the user explicitly.
+  if (active.source === "env") {
     const envToken = process.env.KWEAVER_TOKEN?.trim();
-    if (!envUrl || !envToken) {
-      console.error("No active platform. Run `kweaver auth login <platform-url>` first.");
+    if (!envToken) {
+      console.error(
+        `KWEAVER_BASE_URL is set to ${active.url} but KWEAVER_TOKEN is missing. ` +
+        "Set KWEAVER_TOKEN, or unset KWEAVER_BASE_URL to fall back to the saved session.",
+      );
       return 1;
     }
     const accessToken = envToken.replace(/^Bearer\s+/i, "");
-    // Try EACP first — works for both opaque and JWT, both user and app tokens,
-    // and is the only way to recover the account name from an opaque token.
-    // Fall back to JWT decode when EACP is unreachable so env-token mode still
-    // shows something useful.
-    const userInfo = await fetchEacpUserInfo(envUrl, accessToken);
-    const payload = userInfo ? null : decodeJwtPayload(accessToken);
+    const envUrl = active.url;
+    const userInfo = await fetchEacpUserInfo(envUrl!, accessToken);
+    // Always decode the JWT in env mode so we can render Issuer/Issued/Expires
+    // alongside EACP's Type/Account/Name. The two carry different facts: EACP
+    // tells us *who* the token belongs to (works for opaque tokens too); the
+    // JWT claims tell us *when* it was issued and when it expires (only
+    // available when the token is a JWT). Showing both gives the user the
+    // complete picture without forcing them to pick a mode.
+    const jwtPayload = decodeJwtPayload(accessToken);
     if (jsonOutput) {
       const out: Record<string, unknown> = { platform: envUrl, source: "env" };
       if (userInfo) out.userInfo = userInfo;
-      if (payload) Object.assign(out, payload);
+      if (jwtPayload) Object.assign(out, jwtPayload);
       console.log(JSON.stringify(out, null, 2));
       return 0;
     }
@@ -618,20 +638,23 @@ Options:
       console.log(`User ID:  ${userInfo.id}`);
       if (userInfo.account) console.log(`Account:  ${userInfo.account}`);
       if (userInfo.name) console.log(`Name:     ${userInfo.name}`);
-    } else if (payload) {
-      const uname = payload.preferred_username ?? payload.name;
+    } else if (jwtPayload) {
+      const uname = jwtPayload.preferred_username ?? jwtPayload.name;
       if (uname) console.log(`Username: ${uname}`);
-      console.log(`User ID:  ${payload.sub ?? "(unknown)"}`);
-      console.log(`Issuer:   ${payload.iss ?? "(unknown)"}`);
-      if (payload.iat) console.log(`Issued:   ${new Date((payload.iat as number) * 1000).toISOString()}`);
-      if (payload.exp) console.log(`Expires:  ${new Date((payload.exp as number) * 1000).toISOString()}`);
+      console.log(`User ID:  ${jwtPayload.sub ?? "(unknown)"}`);
     } else {
       console.log(`User info unavailable: opaque access token and EACP did not respond.`);
       console.log(`Hint: run \`kweaver auth login ${envUrl}\` to obtain a full session, or check connectivity to ${envUrl}.`);
     }
+    if (jwtPayload) {
+      if (jwtPayload.iss) console.log(`Issuer:   ${jwtPayload.iss}`);
+      if (jwtPayload.iat) console.log(`Issued:   ${new Date((jwtPayload.iat as number) * 1000).toISOString()}`);
+      if (jwtPayload.exp) console.log(`Expires:  ${new Date((jwtPayload.exp as number) * 1000).toISOString()}`);
+    }
     return 0;
   }
 
+  const platform = active.url;
   const token = loadTokenConfig(platform);
   if (!token) {
     console.error(`No saved token for ${platform}.`);

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -28,6 +28,7 @@ import { decodeJwtPayload } from "../config/jwt.js";
 import { eacpModifyPassword } from "../auth/eacp-modify-password.js";
 import {
   buildCopyCommand,
+  fetchEacpUserInfo,
   formatHttpError,
   InitialPasswordChangeRequiredError,
   normalizeBaseUrl,
@@ -95,7 +96,7 @@ Login options:
   }
 
   if (target === "whoami") {
-    return runAuthWhoamiCommand(rest);
+    return await runAuthWhoamiCommand(rest);
   }
 
   if (target === "export") {
@@ -570,11 +571,13 @@ You can specify either the userId (sub claim) or the username (preferred_usernam
   return 0;
 }
 
-function runAuthWhoamiCommand(args: string[]): number {
+async function runAuthWhoamiCommand(args: string[]): Promise<number> {
   if (args[0] === "--help" || args[0] === "-h") {
     console.log(`kweaver auth whoami [platform-url|alias] [--json]
 
-Show current user identity decoded from the saved id_token.
+Show current user identity. For env-token mode (KWEAVER_TOKEN), the bound
+identity is resolved live from EACP /api/eacp/v1/user/get; for saved sessions
+it is decoded from the local id_token.
 
 Options:
   --json   Output as JSON (machine-readable)`);
@@ -595,14 +598,27 @@ Options:
       return 1;
     }
     const accessToken = envToken.replace(/^Bearer\s+/i, "");
-    const payload = decodeJwtPayload(accessToken);
+    // Try EACP first — works for both opaque and JWT, both user and app tokens,
+    // and is the only way to recover the account name from an opaque token.
+    // Fall back to JWT decode when EACP is unreachable so env-token mode still
+    // shows something useful.
+    const userInfo = await fetchEacpUserInfo(envUrl, accessToken);
+    const payload = userInfo ? null : decodeJwtPayload(accessToken);
     if (jsonOutput) {
-      console.log(JSON.stringify({ platform: envUrl, source: "env", ...(payload ?? {}) }, null, 2));
+      const out: Record<string, unknown> = { platform: envUrl, source: "env" };
+      if (userInfo) out.userInfo = userInfo;
+      if (payload) Object.assign(out, payload);
+      console.log(JSON.stringify(out, null, 2));
       return 0;
     }
     console.log(`Platform: ${envUrl}`);
     console.log(`Source:   env (KWEAVER_TOKEN)`);
-    if (payload) {
+    if (userInfo) {
+      console.log(`Type:     ${userInfo.type}`);
+      console.log(`User ID:  ${userInfo.id}`);
+      if (userInfo.account) console.log(`Account:  ${userInfo.account}`);
+      if (userInfo.name) console.log(`Name:     ${userInfo.name}`);
+    } else if (payload) {
       const uname = payload.preferred_username ?? payload.name;
       if (uname) console.log(`Username: ${uname}`);
       console.log(`User ID:  ${payload.sub ?? "(unknown)"}`);
@@ -610,8 +626,8 @@ Options:
       if (payload.iat) console.log(`Issued:   ${new Date((payload.iat as number) * 1000).toISOString()}`);
       if (payload.exp) console.log(`Expires:  ${new Date((payload.exp as number) * 1000).toISOString()}`);
     } else {
-      console.log(`User info unavailable: opaque access token.`);
-      console.log(`Hint: run \`kweaver auth login ${envUrl}\` to obtain a full session.`);
+      console.log(`User info unavailable: opaque access token and EACP did not respond.`);
+      console.log(`Hint: run \`kweaver auth login ${envUrl}\` to obtain a full session, or check connectivity to ${envUrl}.`);
     }
     return 0;
   }

--- a/packages/typescript/src/commands/config.ts
+++ b/packages/typescript/src/commands/config.ts
@@ -1,17 +1,7 @@
 import { listBusinessDomains } from "../api/business-domains.js";
-import { fetchEacpUserInfo, normalizeBaseUrl, withTokenRetry } from "../auth/oauth.js";
+import { fetchEacpUserInfo, resolveActivePlatform, withTokenRetry } from "../auth/oauth.js";
 import { HttpError } from "../utils/http.js";
-
-// Resolve platform URL: saved current platform > KWEAVER_BASE_URL (normalized to
-// match what `auth login` writes, so env users share the same platforms/<key>/ dir).
-function resolvePlatformUrl(): string | undefined {
-  const saved = getCurrentPlatform();
-  if (saved) return saved;
-  const env = process.env.KWEAVER_BASE_URL?.trim();
-  return env ? normalizeBaseUrl(env) : undefined;
-}
 import {
-  getCurrentPlatform,
   loadPlatformBusinessDomain,
   resolveBusinessDomain,
   savePlatformBusinessDomain,
@@ -39,20 +29,21 @@ export async function runConfigCommand(args: string[]): Promise<number> {
   }
 
   if (sub === "show") {
-    const platform = resolvePlatformUrl();
-    if (!platform) {
+    const active = resolveActivePlatform();
+    if (!active) {
       console.error("No active platform. Run `kweaver auth login <url>` first.\n  Tip: set KWEAVER_BASE_URL to use this command without a saved login.");
       return 1;
     }
+    const platform = active.url;
     const bd = resolveBusinessDomain(platform);
-    const source = process.env.KWEAVER_BUSINESS_DOMAIN
+    const bdSource = process.env.KWEAVER_BUSINESS_DOMAIN
       ? "env"
       : loadPlatformBusinessDomain(platform)
         ? "config"
         : "default";
-    const platformSource = getCurrentPlatform() ? "" : " (KWEAVER_BASE_URL)";
-    console.log(`Platform:        ${platform}${platformSource}`);
-    console.log(`Business Domain: ${bd} (${source})`);
+    const platformSuffix = active.source === "env" ? " (KWEAVER_BASE_URL)" : "";
+    console.log(`Platform:        ${platform}${platformSuffix}`);
+    console.log(`Business Domain: ${bd} (${bdSource})`);
     return 0;
   }
 
@@ -62,22 +53,25 @@ export async function runConfigCommand(args: string[]): Promise<number> {
       console.error("Usage: kweaver config set-bd <value>");
       return 1;
     }
-    const platform = resolvePlatformUrl();
-    if (!platform) {
+    const active = resolveActivePlatform();
+    if (!active) {
       console.error("No active platform. Run `kweaver auth login <url>` first.\n  Tip: set KWEAVER_BASE_URL to write the business domain for that platform.");
       return 1;
     }
+    const platform = active.url;
     savePlatformBusinessDomain(platform, value);
-    console.log(`Business domain set to: ${value} (${getCurrentPlatform() ? platform : `${platform} via KWEAVER_BASE_URL`})`);
+    const provenance = active.source === "env" ? `${platform} via KWEAVER_BASE_URL` : platform;
+    console.log(`Business domain set to: ${value} (${provenance})`);
     return 0;
   }
 
   if (sub === "list-bd") {
-    const platform = resolvePlatformUrl();
-    if (!platform) {
+    const active = resolveActivePlatform();
+    if (!active) {
       console.error("No active platform. Run `kweaver auth login <url>` first.\n  Tip: set KWEAVER_BASE_URL and KWEAVER_TOKEN to use this command without a saved login.");
       return 1;
     }
+    const platform = active.url;
     let lastAccessToken = "";
     let lastTlsInsecure: boolean | undefined;
     try {

--- a/packages/typescript/src/commands/config.ts
+++ b/packages/typescript/src/commands/config.ts
@@ -1,5 +1,6 @@
 import { listBusinessDomains } from "../api/business-domains.js";
-import { normalizeBaseUrl, withTokenRetry } from "../auth/oauth.js";
+import { fetchEacpUserInfo, normalizeBaseUrl, withTokenRetry } from "../auth/oauth.js";
+import { HttpError } from "../utils/http.js";
 
 // Resolve platform URL: saved current platform > KWEAVER_BASE_URL (normalized to
 // match what `auth login` writes, so env users share the same platforms/<key>/ dir).
@@ -77,14 +78,18 @@ export async function runConfigCommand(args: string[]): Promise<number> {
       console.error("No active platform. Run `kweaver auth login <url>` first.\n  Tip: set KWEAVER_BASE_URL and KWEAVER_TOKEN to use this command without a saved login.");
       return 1;
     }
+    let lastAccessToken = "";
+    let lastTlsInsecure: boolean | undefined;
     try {
-      const rows = await withTokenRetry((token) =>
-        listBusinessDomains({
+      const rows = await withTokenRetry((token) => {
+        lastAccessToken = token.accessToken;
+        lastTlsInsecure = token.tlsInsecure;
+        return listBusinessDomains({
           baseUrl: platform,
           accessToken: token.accessToken,
           tlsInsecure: token.tlsInsecure,
-        }),
-      );
+        });
+      });
       const currentId = resolveBusinessDomain(platform);
       const payload = {
         currentId,
@@ -96,7 +101,12 @@ export async function runConfigCommand(args: string[]): Promise<number> {
       console.log(JSON.stringify(payload, null, 2));
       return 0;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      // Backend returns 401 + `invalid user_id` when the caller is an app
+      // (service) token with no bound user. Probe EACP to confirm — only swap
+      // the cryptic backend body for a one-liner when we can prove `type:"app"`.
+      // See kweaver-core#263.
+      const friendly = await maybeAppAccountMessage(error, platform, lastAccessToken, lastTlsInsecure);
+      const message = friendly ?? (error instanceof Error ? error.message : String(error));
       console.error(`Failed to list business domains: ${message}`);
       return 1;
     }
@@ -105,4 +115,48 @@ export async function runConfigCommand(args: string[]): Promise<number> {
   console.error(`Unknown config subcommand: ${sub}`);
   console.log(HELP);
   return 1;
+}
+
+/**
+ * Detect "app account hit a user-scoped endpoint" by signature, then confirm
+ * with EACP. Returns a short user-facing message if the call really came from
+ * an app token, otherwise `null` (caller falls back to the original error).
+ *
+ * Two layers of evidence (signature + identity) keep us from probing EACP on
+ * every random failure and from mislabeling real auth problems.
+ */
+async function maybeAppAccountMessage(
+  error: unknown,
+  baseUrl: string,
+  accessToken: string,
+  tlsInsecure: boolean | undefined,
+): Promise<string | null> {
+  // Detect 401 either as a direct HttpError or via the wrapping Error's
+  // message ("Authentication failed (401)..." / "...status 401..."). We don't
+  // rely solely on the `cause` chain because withTokenRetry may attempt a
+  // token refresh and then wrap with the *refresh* error as cause, dropping
+  // the original list-bd HttpError.
+  if (!is401Error(error)) return null;
+  if (!accessToken) return null;
+  const info = await fetchEacpUserInfo(baseUrl, accessToken, tlsInsecure);
+  if (info?.type !== "app") return null;
+  return "This command does not support app accounts.";
+}
+
+/** True if the error or any cause looks like a 401 from the platform. */
+function is401Error(error: unknown): boolean {
+  const seen = new Set<unknown>();
+  const queue: unknown[] = [error];
+  while (queue.length) {
+    const cur = queue.shift();
+    if (!cur || seen.has(cur)) continue;
+    seen.add(cur);
+    if (cur instanceof HttpError && cur.status === 401) return true;
+    if (cur instanceof Error) {
+      if (/\b401\b/.test(cur.message)) return true;
+      if (cur.cause) queue.push(cur.cause);
+    }
+    if (cur instanceof AggregateError) queue.push(...cur.errors);
+  }
+  return false;
 }

--- a/packages/typescript/test/cli-user-facing-errors.test.ts
+++ b/packages/typescript/test/cli-user-facing-errors.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { run } from "../src/cli.js";
+import { fetchEacpUserInfo, formatHttpError } from "../src/auth/oauth.js";
+import { HttpError } from "../src/utils/http.js";
+
+/**
+ * Three user-facing error fixes covered here:
+ *   1. BKN 403 with body `BknBackend.KnowledgeNetwork.NotFound` -> hint user
+ *      that the kn-id does not exist (it is *not* a permission problem).
+ *   2. `kweaver config list-bd` with an app token -> rewrite the cryptic 401
+ *      `invalid user_id` into "This command does not support app accounts."
+ *      after a confirming EACP probe.
+ *   3. `kweaver auth whoami` in env-token mode -> fetch identity from EACP and
+ *      render Type/User ID/Account/Name.
+ */
+
+async function runCli(args: string[]): Promise<{ code: number; stdout: string; stderr: string }> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const origLog = console.log;
+  const origErr = console.error;
+  console.log = (...a: unknown[]) => stdout.push(a.map(String).join(" "));
+  console.error = (...a: unknown[]) => stderr.push(a.map(String).join(" "));
+  try {
+    const code = await run(args);
+    return { code, stdout: stdout.join("\n"), stderr: stderr.join("\n") };
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+}
+
+const BASE_URL = "https://example.com";
+const PLATFORM_DIR_NAME = Buffer.from(BASE_URL).toString("base64url");
+
+describe("formatHttpError — BKN not-found 403/404 hint (fix #1)", () => {
+  it("rewrites 403 BknBackend.KnowledgeNetwork.NotFound with kn-id hint", () => {
+    const err = new HttpError(
+      403,
+      "Forbidden",
+      JSON.stringify({ error_code: "BknBackend.KnowledgeNetwork.NotFound", message: "not found" }),
+    );
+    const msg = formatHttpError(err);
+    assert.match(msg, /knowledge network not found/);
+    assert.match(msg, /not a permission\/auth issue/);
+  });
+
+  it("also matches 404 (defensive — same root cause)", () => {
+    const err = new HttpError(404, "Not Found", "BknBackend.KnowledgeNetwork.NotFound");
+    assert.match(formatHttpError(err), /knowledge network not found/);
+  });
+
+  it("does not add the hint for an unrelated 403", () => {
+    const err = new HttpError(403, "Forbidden", "permission denied");
+    const msg = formatHttpError(err);
+    assert.doesNotMatch(msg, /knowledge network not found/);
+  });
+});
+
+describe("fetchEacpUserInfo (shared helper)", () => {
+  let origFetch: typeof globalThis.fetch;
+  beforeEach(() => {
+    origFetch = globalThis.fetch;
+  });
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+  });
+
+  it("returns user-shape payload (userid -> id)", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ type: "user", userid: "u-1", account: "alice@example.com", name: "Alice" }),
+        { status: 200 },
+      );
+    const info = await fetchEacpUserInfo(BASE_URL, "tok");
+    assert.deepEqual(info, { type: "user", id: "u-1", account: "alice@example.com", name: "Alice" });
+  });
+
+  it("returns app-shape payload (id stays as id, no account)", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ type: "app", id: "app-42", name: "my-svc" }), { status: 200 });
+    const info = await fetchEacpUserInfo(BASE_URL, "tok");
+    assert.deepEqual(info, { type: "app", id: "app-42", account: undefined, name: "my-svc" });
+  });
+
+  it("returns null on non-2xx", async () => {
+    globalThis.fetch = async () => new Response("nope", { status: 500 });
+    assert.equal(await fetchEacpUserInfo(BASE_URL, "tok"), null);
+  });
+
+  it("returns null on unknown type", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ type: "robot", userid: "x" }), { status: 200 });
+    assert.equal(await fetchEacpUserInfo(BASE_URL, "tok"), null);
+  });
+
+  it("returns null on network error (never throws)", async () => {
+    globalThis.fetch = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    assert.equal(await fetchEacpUserInfo(BASE_URL, "tok"), null);
+  });
+});
+
+describe("kweaver config list-bd — app account detection (fix #2)", () => {
+  let origDir: string | undefined;
+  let tempDir: string;
+  let origFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    origDir = process.env.KWEAVERC_CONFIG_DIR;
+    tempDir = mkdtempSync(join(tmpdir(), "kw-listbd-"));
+    process.env.KWEAVERC_CONFIG_DIR = tempDir;
+    const platformsDir = join(tempDir, "platforms", PLATFORM_DIR_NAME);
+    mkdirSync(platformsDir, { recursive: true });
+    writeFileSync(
+      join(platformsDir, "client.json"),
+      JSON.stringify({
+        baseUrl: BASE_URL,
+        clientId: "x",
+        clientSecret: "s",
+        redirectUri: "http://localhost",
+        logoutRedirectUri: "http://localhost",
+        scope: "openid",
+      }),
+    );
+    writeFileSync(
+      join(platformsDir, "token.json"),
+      JSON.stringify({
+        baseUrl: BASE_URL,
+        accessToken: "app-tok",
+        tokenType: "Bearer",
+        scope: "openid",
+        obtainedAt: "2020-01-01T00:00:00Z",
+      }),
+    );
+    writeFileSync(
+      join(tempDir, "state.json"),
+      JSON.stringify({ currentPlatform: BASE_URL }),
+    );
+    origFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    if (origDir === undefined) delete process.env.KWEAVERC_CONFIG_DIR;
+    else process.env.KWEAVERC_CONFIG_DIR = origDir;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("rewrites 401 invalid_user_id into a friendly app-account message after EACP probe", async () => {
+    let listBdCalls = 0;
+    let eacpCalls = 0;
+    globalThis.fetch = async (input) => {
+      const url = typeof input === "string" ? input : (input as URL | Request).toString();
+      if (url.includes("/business-system/v1/business-domain")) {
+        listBdCalls++;
+        return new Response(
+          JSON.stringify({ error_code: "Auth.InvalidUserId", message: "invalid user_id" }),
+          { status: 401 },
+        );
+      }
+      if (url.includes("/api/eacp/v1/user/get")) {
+        eacpCalls++;
+        return new Response(JSON.stringify({ type: "app", id: "app-42", name: "svc" }), {
+          status: 200,
+        });
+      }
+      // withTokenRetry probes a GET on a known endpoint to check token aliveness;
+      // succeed so it surfaces the original 401 (wrapped) instead of forcing refresh.
+      return new Response("[]", { status: 200 });
+    };
+
+    const { code, stderr } = await runCli(["config", "list-bd"]);
+    assert.equal(code, 1);
+    assert.match(stderr, /This command does not support app accounts\./);
+    assert.ok(listBdCalls >= 1, "list-bd should have been attempted");
+    assert.ok(eacpCalls >= 1, "EACP probe should have run to confirm app-type");
+  });
+
+  it("does NOT rewrite the message when EACP says the token is a user", async () => {
+    globalThis.fetch = async (input) => {
+      const url = typeof input === "string" ? input : (input as URL | Request).toString();
+      if (url.includes("/business-system/v1/business-domain")) {
+        return new Response(
+          JSON.stringify({ error_code: "Auth.InvalidUserId", message: "invalid user_id" }),
+          { status: 401 },
+        );
+      }
+      if (url.includes("/api/eacp/v1/user/get")) {
+        return new Response(
+          JSON.stringify({ type: "user", userid: "u-1", account: "alice", name: "Alice" }),
+          { status: 200 },
+        );
+      }
+      return new Response("[]", { status: 200 });
+    };
+    const { code, stderr } = await runCli(["config", "list-bd"]);
+    assert.equal(code, 1);
+    assert.doesNotMatch(stderr, /does not support app accounts/);
+  });
+});
+
+describe("kweaver auth whoami — env-token EACP enrichment (fix #3)", () => {
+  let origDir: string | undefined;
+  let origBaseUrl: string | undefined;
+  let origToken: string | undefined;
+  let tempDir: string;
+  let origFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    origDir = process.env.KWEAVERC_CONFIG_DIR;
+    origBaseUrl = process.env.KWEAVER_BASE_URL;
+    origToken = process.env.KWEAVER_TOKEN;
+    tempDir = mkdtempSync(join(tmpdir(), "kw-whoami-env-"));
+    process.env.KWEAVERC_CONFIG_DIR = tempDir;
+    process.env.KWEAVER_BASE_URL = BASE_URL;
+    process.env.KWEAVER_TOKEN = "ory_at_opaque_token";
+    origFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = origFetch;
+    if (origDir === undefined) delete process.env.KWEAVERC_CONFIG_DIR;
+    else process.env.KWEAVERC_CONFIG_DIR = origDir;
+    if (origBaseUrl === undefined) delete process.env.KWEAVER_BASE_URL;
+    else process.env.KWEAVER_BASE_URL = origBaseUrl;
+    if (origToken === undefined) delete process.env.KWEAVER_TOKEN;
+    else process.env.KWEAVER_TOKEN = origToken;
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("displays Type/User ID/Account/Name from EACP for a user token", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ type: "user", userid: "u-1", account: "alice@example.com", name: "Alice" }),
+        { status: 200 },
+      );
+    const { code, stdout } = await runCli(["auth", "whoami"]);
+    assert.equal(code, 0);
+    assert.match(stdout, /Source:\s+env \(KWEAVER_TOKEN\)/);
+    assert.match(stdout, /Type:\s+user/);
+    assert.match(stdout, /User ID:\s+u-1/);
+    assert.match(stdout, /Account:\s+alice@example\.com/);
+    assert.match(stdout, /Name:\s+Alice/);
+  });
+
+  it("displays type=app for an app token", async () => {
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ type: "app", id: "app-42", name: "my-svc" }), { status: 200 });
+    const { code, stdout } = await runCli(["auth", "whoami"]);
+    assert.equal(code, 0);
+    assert.match(stdout, /Type:\s+app/);
+    assert.match(stdout, /User ID:\s+app-42/);
+    assert.match(stdout, /Name:\s+my-svc/);
+    assert.doesNotMatch(stdout, /Account:/);
+  });
+
+  it("falls back to opaque-token hint when EACP is unreachable", async () => {
+    globalThis.fetch = async () => new Response("nope", { status: 500 });
+    const { code, stdout } = await runCli(["auth", "whoami"]);
+    assert.equal(code, 0);
+    assert.match(stdout, /User info unavailable/);
+  });
+
+  it("--json includes userInfo from EACP", async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ type: "user", userid: "u-1", account: "alice", name: "Alice" }),
+        { status: 200 },
+      );
+    const { code, stdout } = await runCli(["auth", "whoami", "--json"]);
+    assert.equal(code, 0);
+    const parsed = JSON.parse(stdout) as { source: string; userInfo?: { type: string; id: string } };
+    assert.equal(parsed.source, "env");
+    assert.deepEqual(parsed.userInfo, {
+      type: "user",
+      id: "u-1",
+      account: "alice",
+      name: "Alice",
+    });
+  });
+});

--- a/skills/kweaver-core/references/auth.md
+++ b/skills/kweaver-core/references/auth.md
@@ -29,12 +29,14 @@ kweaver auth delete <url|alias> [--user <id|username>]
 | 场景 | 是否读 `KWEAVER_TOKEN` / `KWEAVER_BASE_URL` | 说明 |
 |------|---------------------------------------------|------|
 | 业务命令（`bkn`、`call`、`agent`、`kn`、`vega` 等） | 是 | 解析顺序一般为 **显式参数 > 环境变量 > `~/.kweaver/`**（与 SDK 一致）。 |
-| `kweaver auth status`、`kweaver auth whoami`、`kweaver config show` | 是（兜底） | 默认读 `~/.kweaver/` 的当前平台；**若无当前平台**，可同时设置 `KWEAVER_BASE_URL` + `KWEAVER_TOKEN`，CLI 会本地解 JWT 展示身份。token 为 opaque 时省略身份字段并给出简短提示，**不额外请求远端接口、不增加新旗标**。 |
+| `kweaver auth status`、`kweaver auth whoami`、`kweaver config show` | 是（兜底） | 默认读 `~/.kweaver/` 的当前平台；**若无当前平台**，可同时设置 `KWEAVER_BASE_URL` + `KWEAVER_TOKEN`。`whoami` 在 env 模式下会调用一次 EACP `/api/eacp/v1/user/get` 在线获取身份，展示 `Type`/`User ID`/`Account`/`Name`（对 opaque 与 JWT 都生效）；EACP 不可达时回退本地 JWT 解码。**不写盘、不缓存、不增加旗标**。 |
 | `kweaver auth users` / `auth switch` / `auth export`、`kweaver config set-bd` | 否 | 只操作本地已保存的多用户档案或写 `~/.kweaver/`；环境变量中的 token **不会**被这些命令读取。 |
 
 **常用环境变量**：`KWEAVER_BASE_URL`（与 `KWEAVER_TOKEN` 配对时通常必填）、`KWEAVER_TOKEN`（可带或不带 `Bearer ` 前缀）、`KWEAVER_TLS_INSECURE`、`KWEAVER_BUSINESS_DOMAIN`、`KWEAVER_USER`、`KWEAVER_NO_AUTH`。
 
-**env 模式下 `auth status` / `whoami` 输出**：`whoami` 会标注 `Source: env (KWEAVER_TOKEN)`；refresh_token 在 env 路径下为 **n/a**。`whoami --json` 输出包含 `"source": "env"` 以及 JWT payload（若 token 为 JWT）。
+**env 模式下 `auth status` / `whoami` 输出**：`whoami` 会标注 `Source: env (KWEAVER_TOKEN)`；refresh_token 在 env 路径下为 **n/a**。`whoami --json` 输出包含 `"source": "env"`、EACP 解析出的 `userInfo: { type, id, account?, name? }`，以及（EACP 不可达时）回退的 JWT payload。
+
+**应用账号（app token）调用 `config list-bd`**：后端会以 `401 invalid user_id` 拒绝。CLI 检测到 401 后会复核一次 EACP 类型，若为 `type:"app"` 则把错误改写为 `This command does not support app accounts.`；其它情况保留原始错误文本。app token 不能调用任何"按用户绑定"的接口，请改用交互式 `auth login` 获得的用户 token。
 
 **FAQ：只设置了 `KWEAVER_TOKEN` 仍报错？**  
 `auth status` / `whoami` / `config show` 需要能定位平台：请同时设置 **`KWEAVER_BASE_URL`**，或执行 `kweaver auth login <url>` 将凭据写入 `~/.kweaver/`。


### PR DESCRIPTION
## Summary

Three independent CLI papercuts, fixed in one focused diff (6 source/doc files + 1 new test file, 716/716 UT green).

| # | Symptom | Fix |
|---|---|---|
| 1 | `bkn` commands hit a 403 even though the kn-id simply does not exist; users assume it's a permissions problem and stop. | `formatHttpError` appends a one-line hint when `BknBackend.KnowledgeNetwork.NotFound` is in the response body (status 403 or 404). |
| 2 | App-type tokens calling `kweaver config list-bd` get the cryptic backend body `{"error_code":"...","message":"invalid user_id"}` with no actionable information. | `list-bd` now detects 401, probes EACP `/api/eacp/v1/user/get` to confirm `type:"app"`, and only then rewrites the error to `This command does not support app accounts.`. Real auth failures pass through unchanged. |
| 3 | `kweaver auth whoami` in env-token mode (`KWEAVER_BASE_URL` + `KWEAVER_TOKEN`) showed nothing for opaque tokens and only basic JWT claims otherwise. | `whoami` now calls EACP once and prints `Type` (user/app), `User ID`, `Account`, `Name`. Falls back to local JWT decode if EACP is unreachable. |

## Shared infra

- `fetchEacpUserInfo(baseUrl, token, tlsInsecure?)` — small helper exported from `auth/oauth.ts`. Returns `{ type, id, account?, name? } | null`. Never throws.
- The existing `fetchDisplayName` is now a thin wrapper over the new helper.
- **No state, no disk cache, no `TokenConfig` enrichment, no new flags, no proactive token gating.**

## What this PR is *not*

A previous attempt (#77) tried to enrich every `TokenConfig` with EACP identity, persist it to disk for env-tokens, and gate user-bound endpoints up-front via `requireUserToken`. That was reverted as too complex. This PR keeps just the three minimal user-visible fixes.

## Test plan

- [x] `make lint` (tsc) green
- [x] `make test` — 716/716 UT pass
- [x] New file `test/cli-user-facing-errors.test.ts` — 14 cases:
  - `formatHttpError` hint on/off for 403/404 BKN body and unrelated 403
  - `fetchEacpUserInfo` user/app/non-2xx/unknown-type/network-error
  - `config list-bd` rewrites only when EACP confirms app
  - `auth whoami` env-mode renders user/app shape, falls back on EACP failure, JSON includes `userInfo`
- [x] Manual smoke against real platform with: (a) user token + missing kn-id (BKN hint), (b) app token + `config list-bd` (friendly message), (c) env-token `whoami`


Made with [Cursor](https://cursor.com)