### PR TITLE
fix(cli): context-loader respects KWEAVER_BASE_URL env (v0.6.9)

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kweaver-sdk"
-version = "0.6.8"
+version = "0.6.9"
 description = "KWeaver Python SDK — client library for knowledge network construction and querying"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "kweaver-sdk"
-version = "0.6.8"
+version = "0.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },

--- a/packages/typescript/package-lock.json
+++ b/packages/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kweaver-ai/kweaver-sdk",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kweaver-ai/kweaver-sdk",
-      "version": "0.6.8",
+      "version": "0.6.9",
       "license": "MIT",
       "dependencies": {
         "@kweaver-ai/bkn": "^0.1.0",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kweaver-ai/kweaver-sdk",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "KWeaver TypeScript SDK — CLI tool and programmatic API for knowledge networks and Decision Agents.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/typescript/src/commands/context-loader.ts
+++ b/packages/typescript/src/commands/context-loader.ts
@@ -1,4 +1,4 @@
-import { ensureValidToken, formatHttpError, with401RefreshRetry } from "../auth/oauth.js";
+import { ensureValidToken, formatHttpError, resolveActivePlatform, with401RefreshRetry } from "../auth/oauth.js";
 import type { ConditionSpec, RelationTypePath } from "../api/context-loader.js";
 import {
   knSearch,
@@ -17,7 +17,6 @@ import {
 import {
   addContextLoaderEntry,
   getCurrentContextLoaderKn,
-  getCurrentPlatform,
   loadContextLoaderConfig,
   removeContextLoaderEntry,
   setCurrentContextLoader,
@@ -31,9 +30,11 @@ function ensureContextLoaderConfig(): {
   knId: string;
   accessToken: string;
 } {
-  const platform = getCurrentPlatform();
-  if (!platform) {
-    throw new Error("No platform selected. Run: kweaver auth <platform-url>");
+  const active = resolveActivePlatform();
+  if (!active) {
+    throw new Error(
+      "No platform selected. Set KWEAVER_BASE_URL or run: kweaver auth <platform-url>",
+    );
   }
 
   const kn = getCurrentContextLoaderKn();
@@ -146,11 +147,14 @@ Subcommands:
     return 0;
   }
 
-  const platform = getCurrentPlatform();
-  if (!platform) {
-    console.error("No platform selected. Run: kweaver auth <platform-url>");
+  const active = resolveActivePlatform();
+  if (!active) {
+    console.error(
+      "No platform selected. Set KWEAVER_BASE_URL or run: kweaver auth <platform-url>",
+    );
     return 1;
   }
+  const platform = active.url;
 
   if (action === "show") {
     const kn = getCurrentContextLoaderKn();


### PR DESCRIPTION
## Summary

Two platform checks in [\`packages/typescript/src/commands/context-loader.ts\`](packages/typescript/src/commands/context-loader.ts) called \`getCurrentPlatform()\` directly, so users who authenticated only via \`KWEAVER_BASE_URL\` + \`KWEAVER_TOKEN\` (no \`kweaver auth login\`) hit a misleading \`No platform selected. Run: kweaver auth <platform-url>\` error — even though every other command group (\`bkn\`, \`agent\`, \`ds\`, \`dataflow\`, \`vega\`, ...) worked fine in the same shell.

Both call sites now use the existing [\`resolveActivePlatform()\`](packages/typescript/src/auth/oauth.ts) helper (precedence: positional > env > saved), aligning context-loader with the precedence already used by \`auth status/whoami\`, \`config show|set-bd|list-bd\`, and \`ensureValidToken()\`.

### Background

- Bug present since \`90b9eb4\` (2026-03-16, initial context-loader implementation).
- PR #78 introduced \`resolveActivePlatform\` and fixed the \`auth\` / \`config\` command groups but did not touch \`context-loader\`.
- Confirmed by user: \`kweaver context-loader config set --kn-id ...\` failed with env-only auth, while other commands using the same env vars succeeded.

### Audit of remaining \`getCurrentPlatform()\` callers

I went through every direct \`getCurrentPlatform()\` use; the rest are either already env-aware (going through \`ensureValidToken\` / \`client.ts\` env-first precedence) or intentionally saved-only (TLS flag, refresh, login/delete/switch). Only context-loader was wrong.

## Changes

- [\`packages/typescript/src/commands/context-loader.ts\`](packages/typescript/src/commands/context-loader.ts): replace two \`getCurrentPlatform()\` checks with \`resolveActivePlatform()\`; sharpen the error hint to mention \`KWEAVER_BASE_URL\`.
- Version bump 0.6.8 → 0.6.9 across \`packages/typescript/package.json\`, \`package-lock.json\`, \`packages/python/pyproject.toml\`, \`packages/python/uv.lock\`.

## Test plan

- [x] \`npm run build\` (TS)
- [x] \`npm run lint\` (TS)
- [x] \`npm test\` — 716/716 passing
- [x] Manual: with \`KWEAVER_BASE_URL\` + \`KWEAVER_TOKEN\` set and no \`~/.kweaver/\` session, \`kweaver context-loader config set --kn-id <id>\` writes config without the \"No platform selected\" error.


Made with [Cursor](https://cursor.com)