### PR TITLE
feat(cli/sdk): tool execute/debug + bkn action-type inputs/flag-form execute (0.6.10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ kweaver bkn create-from-csv <ds_id> --files <glob> --name <name> [--build]
 kweaver bkn validate/push/pull
 kweaver bkn object-type list/get/create/update/delete/query/properties
 kweaver bkn relation-type list/get/create/update/delete
-kweaver bkn action-type list/query/execute
+kweaver bkn action-type list/query/inputs/execute
 kweaver bkn subgraph / search
 kweaver bkn action-execution get
 kweaver bkn action-log list/get/cancel

--- a/README.zh.md
+++ b/README.zh.md
@@ -265,7 +265,7 @@ kweaver bkn create-from-csv <ds_id> --files <glob> --name <name> [--build]
 kweaver bkn validate/push/pull
 kweaver bkn object-type list/get/create/update/delete/query/properties
 kweaver bkn relation-type list/get/create/update/delete
-kweaver bkn action-type list/query/execute
+kweaver bkn action-type list/query/inputs/execute
 kweaver bkn subgraph / search
 kweaver bkn action-execution get
 kweaver bkn action-log list/get/cancel

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "kweaver-sdk"
-version = "0.6.9"
+version = "0.6.10"
 description = "KWeaver Python SDK — client library for knowledge network construction and querying"
 requires-python = ">=3.10"
 dependencies = [

--- a/packages/python/src/kweaver/_client.py
+++ b/packages/python/src/kweaver/_client.py
@@ -25,6 +25,7 @@ from kweaver.resources.query import QueryResource
 from kweaver.resources.jobs import JobsResource
 from kweaver.resources.relation_types import RelationTypesResource
 from kweaver.resources.skills import SkillsResource
+from kweaver.resources.toolboxes import ToolboxesResource
 from kweaver.resources.vega import VegaNamespace
 
 
@@ -111,6 +112,7 @@ class KWeaverClient:
         self.jobs = JobsResource(self._http)
         self.concept_groups = ConceptGroupsResource(self._http)
         self.skills = SkillsResource(self._http)
+        self.toolboxes = ToolboxesResource(self._http)
 
     @property
     def vega(self) -> VegaNamespace:

--- a/packages/python/src/kweaver/resources/__init__.py
+++ b/packages/python/src/kweaver/resources/__init__.py
@@ -6,6 +6,7 @@ from kweaver.resources.knowledge_networks import KnowledgeNetworksResource
 from kweaver.resources.object_types import ObjectTypesResource
 from kweaver.resources.query import QueryResource
 from kweaver.resources.relation_types import RelationTypesResource
+from kweaver.resources.toolboxes import ToolboxesResource
 
 __all__ = [
     "DataflowsResource",
@@ -16,4 +17,5 @@ __all__ = [
     "ObjectTypesResource",
     "QueryResource",
     "RelationTypesResource",
+    "ToolboxesResource",
 ]

--- a/packages/python/src/kweaver/resources/action_types.py
+++ b/packages/python/src/kweaver/resources/action_types.py
@@ -38,19 +38,101 @@ class ActionTypesResource:
         )
         return data or {}
 
-    def execute(self, kn_id: str, action_type_id: str, params: dict[str, Any] | None = None) -> ActionExecution:
+    def inputs(self, kn_id: str, action_type_id: str) -> list[dict[str, Any]]:
+        """Return ActionType parameters with ``value_from == "input"``.
+
+        These are exactly the parameters the caller MUST supply via
+        ``dynamic_params`` when calling :meth:`execute`. Each returned dict
+        keeps the original parameter fields (``name``, ``type``, ``source``,
+        ``required``, ``description``, ...) so callers can build their own
+        validation or template logic on top.
+        """
+        raw = self._http.get(
+            f"{_OM_PREFIX}/{kn_id}/action-types/{action_type_id}",
+        )
+        params = _collect_input_parameters(raw)
+        return params
+
+    def execute(
+        self,
+        kn_id: str,
+        action_type_id: str,
+        params: dict[str, Any] | None = None,
+        *,
+        dynamic_params: dict[str, Any] | None = None,
+        instances: list[dict[str, Any]] | None = None,
+        trigger_type: str = "manual",
+    ) -> ActionExecution:
         """Execute an Action Type, returns an async execution object.
 
         Args:
             kn_id: Knowledge network ID.
             action_type_id: Action type ID.
-            params: Request body. Must include ``_instance_identities`` — a list
-                of dicts identifying the instances to act on, e.g.
-                ``{"_instance_identities": [{"pod_ip": "1.2.3.4"}]}``.
+            params: Pre-assembled envelope body. Mutually exclusive with the
+                ``dynamic_params`` / ``instances`` / ``trigger_type`` kwargs;
+                use this only when you already have a full envelope JSON.
+            dynamic_params: Mapping of input parameters (the ones with
+                ``value_from == "input"``). Includes any header-source params
+                like ``Authorization`` that the ActionType declares as inputs.
+            instances: List of identity objects appended to
+                ``_instance_identities``. Empty list (default) is correct for
+                "create"-style actions that don't target an existing instance.
+            trigger_type: Envelope ``trigger_type`` field, defaults to ``manual``.
+
+            When the kwargs are used, the SDK assembles the envelope below.
+            **Must use the envelope shape** below — top-
+                level fields other than ``trigger_type`` / ``_instance_identities``
+                are silently dropped by the backend, leaving ``dynamic_params``
+                empty and downstream tools receiving ``null`` parameters
+                (typically surfacing as 401 token expired or 500 type errors).
+
+                ::
+
+                    {
+                      "trigger_type": "manual",
+                      "_instance_identities": [{"<primary_key>": "<value>"}],
+                      "dynamic_params": {
+                        "<param>": "<value>",
+                        "Authorization": "Bearer <token>",
+                      },
+                    }
+
+                - ``_instance_identities`` may be ``[]`` for "create"-style actions.
+                - Each ActionType parameter has a ``value_from`` discriminator:
+
+                    * ``input``    — caller MUST supply via ``dynamic_params``.
+                      Includes ``source: header`` params (e.g.
+                      ``Authorization``/``token``), which are usually
+                      credentials for the DOWNSTREAM system the action calls —
+                      NOT the platform session token. The SDK never
+                      auto-forwards its session token.
+                    * ``const``    — frozen in the ActionType snapshot; values
+                      in body are silently ignored. Edit the ActionType
+                      definition to ``input`` first if caller override is needed.
+                    * ``property`` — auto-populated from the resolved instance's
+                      property; do not (and cannot) supply via body.
+
+                Practical recipe: query the ActionType, filter parameters where
+                ``value_from == "input"``, put exactly those names into
+                ``dynamic_params``.
+
+                See ``skills/kweaver-core/references/bkn.md`` for the full contract.
         """
+        using_kwargs = dynamic_params is not None or instances is not None
+        if params is not None and using_kwargs:
+            raise ValueError(
+                "execute(): `params` (envelope) and `dynamic_params`/`instances` "
+                "are mutually exclusive — pick one form."
+            )
+        if params is None:
+            params = {
+                "trigger_type": trigger_type,
+                "_instance_identities": list(instances or []),
+                "dynamic_params": dict(dynamic_params or {}),
+            }
         data = self._http.post(
             f"{_PREFIX}/{kn_id}/action-types/{action_type_id}/execute",
-            json=params or {},
+            json=params,
             timeout=120.0,
         )
         execution_id = data.get("execution_id") or data.get("id") or ""
@@ -114,3 +196,38 @@ class ActionTypesResource:
     def cancel(self, kn_id: str, log_id: str) -> None:
         """Cancel a running Action execution."""
         self._http.post(f"{_PREFIX}/{kn_id}/action-logs/{log_id}/cancel")
+
+
+def _collect_input_parameters(node: Any) -> list[dict[str, Any]]:
+    """Walk an ActionType response and pull every parameter with
+    ``value_from == "input"``. The exact response envelope varies between
+    endpoints (root, ``data.action_type``, ``entries[*]`` ...), so we walk all
+    nested dicts/lists and de-dup by parameter name.
+    """
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+
+    def walk(n: Any) -> None:
+        if isinstance(n, list):
+            for item in n:
+                walk(item)
+            return
+        if not isinstance(n, dict):
+            return
+        params = n.get("parameters")
+        if isinstance(params, list):
+            for p in params:
+                if not isinstance(p, dict):
+                    continue
+                if p.get("value_from") != "input":
+                    continue
+                name = p.get("name")
+                if not isinstance(name, str) or name in seen:
+                    continue
+                seen.add(name)
+                out.append(p)
+        for v in n.values():
+            walk(v)
+
+    walk(node)
+    return out

--- a/packages/python/src/kweaver/resources/toolboxes.py
+++ b/packages/python/src/kweaver/resources/toolboxes.py
@@ -1,0 +1,191 @@
+"""SDK resource: toolboxes and tools (agent-operator-integration).
+
+Mirrors ``packages/typescript/src/api/toolboxes.ts``. The execute/debug
+endpoints expect an *envelope* JSON body — flat payloads cause the forwarder
+to drop downstream Authorization headers and the underlying tool answers with
+401 "token expired".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterable, Literal
+
+if TYPE_CHECKING:
+    from kweaver._http import HttpClient
+
+
+_PREFIX = "/api/agent-operator-integration/v1/tool-box"
+
+ToolStatus = Literal["enabled", "disabled"]
+ToolboxStatus = Literal["draft", "published"]
+
+
+def _unwrap_data(payload: Any) -> Any:
+    if isinstance(payload, dict) and "data" in payload:
+        return payload["data"]
+    return payload
+
+
+def _build_envelope(
+    *,
+    body: Any,
+    header: dict[str, Any] | None,
+    query: dict[str, Any] | None,
+    timeout: float | None,
+) -> dict[str, Any]:
+    envelope: dict[str, Any] = {}
+    if timeout is not None:
+        envelope["timeout"] = timeout
+    envelope["header"] = header or {}
+    envelope["query"] = query or {}
+    envelope["body"] = body if body is not None else {}
+    return envelope
+
+
+class ToolboxesResource:
+    """Toolbox + tool management on the agent-operator-integration service."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    # ── toolbox lifecycle ────────────────────────────────────────────────────
+
+    def list(self, *, keyword: str | None = None, limit: int = 30, offset: int = 0) -> Any:
+        """List toolboxes. Returns the parsed backend payload as-is."""
+        params: dict[str, Any] = {"limit": limit, "offset": offset}
+        if keyword:
+            params["keyword"] = keyword
+        return _unwrap_data(self._http.get(f"{_PREFIX}/list", params=params))
+
+    def create(self, body: dict[str, Any]) -> Any:
+        return _unwrap_data(self._http.post(_PREFIX, json=body))
+
+    def delete(self, box_id: str) -> None:
+        self._http.delete(f"{_PREFIX}/{box_id}")
+
+    def set_status(self, box_id: str, status: ToolboxStatus) -> None:
+        self._http.post(f"{_PREFIX}/{box_id}/status", json={"status": status})
+
+    # ── tool lifecycle ───────────────────────────────────────────────────────
+
+    def list_tools(self, box_id: str) -> Any:
+        return _unwrap_data(self._http.get(f"{_PREFIX}/{box_id}/tools/list"))
+
+    def upload_tool(
+        self,
+        box_id: str,
+        spec_path: str | Path,
+        *,
+        metadata_type: str = "openapi",
+    ) -> Any:
+        """Upload an OpenAPI spec file as a tool (multipart form)."""
+        path = Path(spec_path)
+        data = path.read_bytes()
+        # The backend expects the field name "file"; mime is not enforced.
+        files = {"file": (path.name, data, "application/octet-stream")}
+        status, content = self._http.post_multipart(
+            f"{_PREFIX}/{box_id}/tool",
+            files=files,
+            params={"metadata_type": metadata_type},
+        )
+        if status >= 400:
+            from kweaver._errors import raise_for_status_parts
+
+            raise_for_status_parts(status, content)
+        try:
+            import json as _json
+
+            return _unwrap_data(_json.loads(content) if content else None)
+        except Exception:
+            return content.decode("utf-8", errors="replace") if content else None
+
+    def set_tool_statuses(
+        self,
+        box_id: str,
+        updates: Iterable[tuple[str, ToolStatus]] | list[dict[str, str]],
+    ) -> None:
+        """Batch enable/disable tools.
+
+        ``updates`` accepts either ``[(tool_id, "enabled"), ...]`` or the raw
+        ``[{"tool_id": ..., "status": ...}, ...]`` shape.
+        """
+        normalised: list[dict[str, str]] = []
+        for item in updates:
+            if isinstance(item, dict):
+                normalised.append({"tool_id": item["tool_id"], "status": item["status"]})
+            else:
+                tool_id, status = item
+                normalised.append({"tool_id": tool_id, "status": status})
+        self._http.post(f"{_PREFIX}/{box_id}/tools/status", json={"updates": normalised})
+
+    # ── execute / debug ──────────────────────────────────────────────────────
+
+    def execute(
+        self,
+        box_id: str,
+        tool_id: str,
+        *,
+        body: Any = None,
+        header: dict[str, Any] | None = None,
+        query: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        forward_auth: bool = True,
+    ) -> Any:
+        """Invoke a published+enabled tool through the toolbox proxy.
+
+        ``forward_auth`` (default True) auto-injects the active client's
+        Authorization header into the envelope when the caller did not set
+        one — most published tools declare an Authorization parameter and
+        otherwise reach the downstream service with no token.
+        """
+        return self._invoke(
+            f"{_PREFIX}/{box_id}/proxy/{tool_id}",
+            body=body,
+            header=header,
+            query=query,
+            timeout=timeout,
+            forward_auth=forward_auth,
+        )
+
+    def debug(
+        self,
+        box_id: str,
+        tool_id: str,
+        *,
+        body: Any = None,
+        header: dict[str, Any] | None = None,
+        query: dict[str, Any] | None = None,
+        timeout: float | None = None,
+        forward_auth: bool = True,
+    ) -> Any:
+        """Invoke a tool through the debug endpoint (works on draft/disabled tools)."""
+        return self._invoke(
+            f"{_PREFIX}/{box_id}/tool/{tool_id}/debug",
+            body=body,
+            header=header,
+            query=query,
+            timeout=timeout,
+            forward_auth=forward_auth,
+        )
+
+    # ── internals ────────────────────────────────────────────────────────────
+
+    def _invoke(
+        self,
+        path: str,
+        *,
+        body: Any,
+        header: dict[str, Any] | None,
+        query: dict[str, Any] | None,
+        timeout: float | None,
+        forward_auth: bool,
+    ) -> Any:
+        merged_header = dict(header or {})
+        if forward_auth and not any(k.lower() == "authorization" for k in merged_header):
+            auth_headers = self._http._auth.auth_headers()
+            bearer = auth_headers.get("Authorization") or auth_headers.get("authorization")
+            if bearer:
+                merged_header["Authorization"] = bearer
+        envelope = _build_envelope(body=body, header=merged_header, query=query, timeout=timeout)
+        return _unwrap_data(self._http.post(path, json=envelope, timeout=timeout))

--- a/packages/python/tests/unit/test_action_types.py
+++ b/packages/python/tests/unit/test_action_types.py
@@ -1,7 +1,11 @@
 """Tests for ActionTypesResource."""
 
-import httpx
+import json
 
+import httpx
+import pytest
+
+from kweaver.resources.action_types import _collect_input_parameters
 from tests.conftest import RequestCapture, make_client
 
 
@@ -61,6 +65,78 @@ def test_list_logs(capture: RequestCapture):
     assert "offset=10" in url
     assert "limit=5" in url
     assert capture.requests[-1].method == "GET"
+
+
+def test_execute_assembles_envelope_from_kwargs(capture: RequestCapture):
+    """execute(dynamic_params=..., instances=...) wraps into the envelope shape."""
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"execution_id": "exec_1", "status": "running"})
+
+    client = make_client(handler, capture)
+    client.action_types.execute(
+        "kn_1", "at_1",
+        dynamic_params={"task_id": "x", "qty": 3},
+        instances=[{"task_id": "x"}],
+    )
+    sent = json.loads(capture.requests[-1].content)
+    assert sent == {
+        "trigger_type": "manual",
+        "_instance_identities": [{"task_id": "x"}],
+        "dynamic_params": {"task_id": "x", "qty": 3},
+    }
+
+
+def test_execute_kwargs_default_to_empty_lists(capture: RequestCapture):
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"execution_id": "exec_1", "status": "running"})
+
+    client = make_client(handler, capture)
+    client.action_types.execute("kn_1", "at_1", dynamic_params={"a": 1})
+    sent = json.loads(capture.requests[-1].content)
+    assert sent["_instance_identities"] == []
+    assert sent["trigger_type"] == "manual"
+
+
+def test_execute_rejects_params_and_kwargs_together(capture: RequestCapture):
+    def handler(req: httpx.Request) -> httpx.Response:  # not reached
+        return httpx.Response(200, json={})
+
+    client = make_client(handler, capture)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        client.action_types.execute(
+            "kn_1", "at_1",
+            params={"trigger_type": "manual"},
+            dynamic_params={"a": 1},
+        )
+
+
+def test_inputs_filters_value_from_input(capture: RequestCapture):
+    def handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "id": "at_1",
+            "parameters": [
+                {"name": "task_id", "value_from": "input", "type": "string", "required": True},
+                {"name": "Authorization", "value_from": "input", "type": "string", "source": "header"},
+                {"name": "tenant", "value_from": "const"},
+                {"name": "name", "value_from": "property"},
+            ],
+        })
+
+    client = make_client(handler, capture)
+    inputs = client.action_types.inputs("kn_1", "at_1")
+    names = sorted(p["name"] for p in inputs)
+    assert names == ["Authorization", "task_id"]
+    assert capture.requests[-1].method == "GET"
+    assert "/kn_1/action-types/at_1" in capture.last_url()
+
+
+def test_collect_input_parameters_walks_nested_response():
+    raw = {"data": {"action_type": {"parameters": [
+        {"name": "x", "value_from": "input"},
+        {"name": "y", "value_from": "const"},
+    ]}}}
+    out = _collect_input_parameters(raw)
+    assert [p["name"] for p in out] == ["x"]
 
 
 def test_cancel(capture: RequestCapture):

--- a/packages/python/tests/unit/test_toolboxes.py
+++ b/packages/python/tests/unit/test_toolboxes.py
@@ -1,0 +1,167 @@
+"""Unit tests for the toolboxes resource (envelope shape, routing, auto-auth)."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from kweaver import KWeaverClient
+
+
+_PREFIX = "/api/agent-operator-integration/v1/tool-box"
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+def _client(handler):
+    return KWeaverClient(base_url="https://mock", token="tok-py", transport=_transport(handler))
+
+
+def test_list_toolboxes_uses_list_endpoint_and_unwraps_data():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        return httpx.Response(200, json={"code": 0, "data": {"entries": [{"box_id": "b1"}]}})
+
+    client = _client(handler)
+    try:
+        result = client.toolboxes.list(keyword="foo", limit=10, offset=0)
+        assert result == {"entries": [{"box_id": "b1"}]}
+        assert "/tool-box/list" in captured["url"]  # type: ignore[index]
+        assert "keyword=foo" in captured["url"]  # type: ignore[operator]
+    finally:
+        client.close()
+
+
+def test_list_tools_in_toolbox():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == f"{_PREFIX}/b1/tools/list"
+        return httpx.Response(200, json={"data": [{"tool_id": "t1"}]})
+
+    client = _client(handler)
+    try:
+        result = client.toolboxes.list_tools("b1")
+        assert result == [{"tool_id": "t1"}]
+    finally:
+        client.close()
+
+
+def test_set_tool_statuses_normalises_tuple_input():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"code": 0})
+
+    client = _client(handler)
+    try:
+        client.toolboxes.set_tool_statuses("b1", [("t1", "enabled"), ("t2", "disabled")])
+        assert captured["body"] == {
+            "updates": [
+                {"tool_id": "t1", "status": "enabled"},
+                {"tool_id": "t2", "status": "disabled"},
+            ]
+        }
+    finally:
+        client.close()
+
+
+def test_execute_posts_envelope_to_proxy_endpoint():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"code": 0, "data": {"ok": True}})
+
+    client = _client(handler)
+    try:
+        client.toolboxes.execute(
+            "b1",
+            "t1",
+            body={"task_id": "x"},
+            header={"Authorization": "Bearer override"},
+            query={"dry": "true"},
+            timeout=42,
+        )
+        assert captured["path"] == f"{_PREFIX}/b1/proxy/t1"
+        assert captured["body"] == {
+            "timeout": 42,
+            "header": {"Authorization": "Bearer override"},
+            "query": {"dry": "true"},
+            "body": {"task_id": "x"},
+        }
+    finally:
+        client.close()
+
+
+def test_debug_posts_envelope_to_debug_endpoint():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        return httpx.Response(200, json={})
+
+    client = _client(handler)
+    try:
+        client.toolboxes.debug("b1", "t1")
+        assert captured["path"] == f"{_PREFIX}/b1/tool/t1/debug"
+    finally:
+        client.close()
+
+
+def test_execute_auto_injects_authorization_header_from_session_token():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={})
+
+    # NB: TokenAuth emits the raw token as the Authorization value (no "Bearer "
+    # prefix is added). The forwarder relays it verbatim to the downstream tool;
+    # callers who need the prefix should pass token="Bearer ..." explicitly.
+    client = _client(handler)
+    try:
+        client.toolboxes.execute("b1", "t1", body={"k": 1})
+        envelope = captured["body"]
+        assert envelope["header"] == {"Authorization": "tok-py"}  # type: ignore[index]
+        assert envelope["body"] == {"k": 1}  # type: ignore[index]
+        assert envelope["query"] == {}  # type: ignore[index]
+        assert "timeout" not in envelope  # type: ignore[operator]
+    finally:
+        client.close()
+
+
+def test_execute_forward_auth_false_omits_authorization():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={})
+
+    client = _client(handler)
+    try:
+        client.toolboxes.execute("b1", "t1", body={}, forward_auth=False)
+        assert captured["body"]["header"] == {}  # type: ignore[index]
+    finally:
+        client.close()
+
+
+def test_execute_caller_provided_authorization_is_preserved():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={})
+
+    client = _client(handler)
+    try:
+        client.toolboxes.execute("b1", "t1", header={"authorization": "Bearer override"})
+        # Case-insensitive: caller's lowercase key wins, no auto-injection above it.
+        assert captured["body"]["header"] == {"authorization": "Bearer override"}  # type: ignore[index]
+    finally:
+        client.close()

--- a/packages/python/uv.lock
+++ b/packages/python/uv.lock
@@ -421,66 +421,6 @@ wheels = [
 ]
 
 [[package]]
-name = "greenlet"
-version = "3.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a3/51/1664f6b78fc6ebbd98019a1fd730e83fa78f2db7058f72b1463d3612b8db/greenlet-3.3.2.tar.gz", hash = "sha256:2eaf067fc6d886931c7962e8c6bede15d2f01965560f3359b27c80bde2d151f2", size = 188267, upload-time = "2026-02-20T20:54:15.531Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/3f/9859f655d11901e7b2996c6e3d33e0caa9a1d4572c3bc61ed0faa64b2f4c/greenlet-3.3.2-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:9bc885b89709d901859cf95179ec9f6bb67a3d2bb1f0e88456461bd4b7f8fd0d", size = 277747, upload-time = "2026-02-20T20:16:21.325Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/07/cb284a8b5c6498dbd7cba35d31380bb123d7dceaa7907f606c8ff5993cbf/greenlet-3.3.2-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b568183cf65b94919be4438dc28416b234b678c608cafac8874dfeeb2a9bbe13", size = 579202, upload-time = "2026-02-20T20:47:28.955Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/45/67922992b3a152f726163b19f890a85129a992f39607a2a53155de3448b8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:527fec58dc9f90efd594b9b700662ed3fb2493c2122067ac9c740d98080a620e", size = 590620, upload-time = "2026-02-20T20:55:55.581Z" },
-    { url = "https://files.pythonhosted.org/packages/03/5f/6e2a7d80c353587751ef3d44bb947f0565ec008a2e0927821c007e96d3a7/greenlet-3.3.2-cp310-cp310-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508c7f01f1791fbc8e011bd508f6794cb95397fdb198a46cb6635eb5b78d85a7", size = 602132, upload-time = "2026-02-20T21:02:43.261Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/55/9f1ebb5a825215fadcc0f7d5073f6e79e3007e3282b14b22d6aba7ca6cb8/greenlet-3.3.2-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ad0c8917dd42a819fe77e6bdfcb84e3379c0de956469301d9fd36427a1ca501f", size = 591729, upload-time = "2026-02-20T20:20:58.395Z" },
-    { url = "https://files.pythonhosted.org/packages/24/b4/21f5455773d37f94b866eb3cf5caed88d6cea6dd2c6e1f9c34f463cba3ec/greenlet-3.3.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:97245cc10e5515dbc8c3104b2928f7f02b6813002770cfaffaf9a6e0fc2b94ef", size = 1551946, upload-time = "2026-02-20T20:49:31.102Z" },
-    { url = "https://files.pythonhosted.org/packages/00/68/91f061a926abead128fe1a87f0b453ccf07368666bd59ffa46016627a930/greenlet-3.3.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8c1fdd7d1b309ff0da81d60a9688a8bd044ac4e18b250320a96fc68d31c209ca", size = 1618494, upload-time = "2026-02-20T20:21:06.541Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/78/f93e840cbaef8becaf6adafbaf1319682a6c2d8c1c20224267a5c6c8c891/greenlet-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:5d0e35379f93a6d0222de929a25ab47b5eb35b5ef4721c2b9cbcc4036129ff1f", size = 230092, upload-time = "2026-02-20T20:17:09.379Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
-    { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
-    { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/3a/efb2cf697fbccdf75b24e2c18025e7dfa54c4f31fab75c51d0fe79942cef/greenlet-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:1e692b2dae4cc7077cbb11b47d258533b48c8fde69a33d0d8a82e2fe8d8531d5", size = 230389, upload-time = "2026-02-20T20:17:18.772Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/a1/65bbc059a43a7e2143ec4fc1f9e3f673e04f9c7b371a494a101422ac4fd5/greenlet-3.3.2-cp311-cp311-win_arm64.whl", hash = "sha256:02b0a8682aecd4d3c6c18edf52bc8e51eacdd75c8eac52a790a210b06aa295fd", size = 229645, upload-time = "2026-02-20T20:18:18.695Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
-    { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/40/cc802e067d02af8b60b6771cea7d57e21ef5e6659912814babb42b864713/greenlet-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:34308836d8370bddadb41f5a7ce96879b72e2fdfb4e87729330c6ab52376409f", size = 231081, upload-time = "2026-02-20T20:17:28.121Z" },
-    { url = "https://files.pythonhosted.org/packages/58/2e/fe7f36ff1982d6b10a60d5e0740c759259a7d6d2e1dc41da6d96de32fff6/greenlet-3.3.2-cp312-cp312-win_arm64.whl", hash = "sha256:d3a62fa76a32b462a97198e4c9e99afb9ab375115e74e9a83ce180e7a496f643", size = 230331, upload-time = "2026-02-20T20:17:23.34Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
-    { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
-    { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
-    { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
-    { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
-    { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/ca/2101ca3d9223a1dc125140dbc063644dca76df6ff356531eb27bc267b446/greenlet-3.3.2-cp314-cp314-win_amd64.whl", hash = "sha256:8c4dd0f3997cf2512f7601563cc90dfb8957c0cff1e3a1b23991d4ea1776c492", size = 232034, upload-time = "2026-02-20T20:20:08.186Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/4a/ecf894e962a59dea60f04877eea0fd5724618da89f1867b28ee8b91e811f/greenlet-3.3.2-cp314-cp314-win_arm64.whl", hash = "sha256:cd6f9e2bbd46321ba3bbb4c8a15794d32960e3b0ae2cc4d49a1a53d314805d71", size = 231437, upload-time = "2026-02-20T20:18:59.722Z" },
-    { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
-    { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -549,7 +489,7 @@ wheels = [
 
 [[package]]
 name = "kweaver-sdk"
-version = "0.6.9"
+version = "0.6.10"
 source = { editable = "." }
 dependencies = [
     { name = "charset-normalizer" },
@@ -563,11 +503,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "playwright" },
+    { name = "respx" },
 ]
 
 [package.metadata]
@@ -579,11 +515,12 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "respx", marker = "extra == 'dev'", specifier = ">=0.21" },
 ]
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "playwright", specifier = ">=1.58.0" }]
+dev = []
 
 [[package]]
 name = "packaging"
@@ -592,25 +529,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
-]
-
-[[package]]
-name = "playwright"
-version = "1.58.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "greenlet" },
-    { name = "pyee" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/c9/9c6061d5703267f1baae6a4647bfd1862e386fbfdb97d889f6f6ae9e3f64/playwright-1.58.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:96e3204aac292ee639edbfdef6298b4be2ea0a55a16b7068df91adac077cc606", size = 42251098, upload-time = "2026-01-30T15:09:24.028Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/40/59d34a756e02f8c670f0fee987d46f7ee53d05447d43cd114ca015cb168c/playwright-1.58.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:70c763694739d28df71ed578b9c8202bb83e8fe8fb9268c04dd13afe36301f71", size = 41039625, upload-time = "2026-01-30T15:09:27.558Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/ee/3ce6209c9c74a650aac9028c621f357a34ea5cd4d950700f8e2c4b7fe2c4/playwright-1.58.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:185e0132578733d02802dfddfbbc35f42be23a45ff49ccae5081f25952238117", size = 42251098, upload-time = "2026-01-30T15:09:30.461Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/af/009958cbf23fac551a940d34e3206e6c7eed2b8c940d0c3afd1feb0b0589/playwright-1.58.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:c95568ba1eda83812598c1dc9be60b4406dffd60b149bc1536180ad108723d6b", size = 46235268, upload-time = "2026-01-30T15:09:33.787Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/a6/0e66ad04b6d3440dae73efb39540c5685c5fc95b17c8b29340b62abbd952/playwright-1.58.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f9999948f1ab541d98812de25e3a8c410776aa516d948807140aff797b4bffa", size = 45964214, upload-time = "2026-01-30T15:09:36.751Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/4b/236e60ab9f6d62ed0fd32150d61f1f494cefbf02304c0061e78ed80c1c32/playwright-1.58.0-py3-none-win32.whl", hash = "sha256:1e03be090e75a0fabbdaeab65ce17c308c425d879fa48bb1d7986f96bfad0b99", size = 36815998, upload-time = "2026-01-30T15:09:39.627Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f8/5ec599c5e59d2f2f336a05b4f318e733077cd5044f24adb6f86900c3e6a7/playwright-1.58.0-py3-none-win_amd64.whl", hash = "sha256:a2bf639d0ce33b3ba38de777e08697b0d8f3dc07ab6802e4ac53fb65e3907af8", size = 36816005, upload-time = "2026-01-30T15:09:42.449Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c4/cc0229fea55c87d6c9c67fe44a21e2cd28d1d558a5478ed4d617e9fb0c93/playwright-1.58.0-py3-none-win_arm64.whl", hash = "sha256:32ffe5c303901a13a0ecab91d1c3f74baf73b84f4bedbb6b935f5bc11cc98e1b", size = 33085919, upload-time = "2026-01-30T15:09:45.71Z" },
 ]
 
 [[package]]
@@ -765,18 +683,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyee"
-version = "13.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -879,6 +785,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]

--- a/packages/typescript/package-lock.json
+++ b/packages/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kweaver-ai/kweaver-sdk",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kweaver-ai/kweaver-sdk",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "MIT",
       "dependencies": {
         "@kweaver-ai/bkn": "^0.1.0",

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kweaver-ai/kweaver-sdk",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "KWeaver TypeScript SDK — CLI tool and programmatic API for knowledge networks and Decision Agents.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/typescript/src/api/ontology-query.ts
+++ b/packages/typescript/src/api/ontology-query.ts
@@ -243,11 +243,40 @@ export async function actionTypeQuery(options: ActionTypeQueryOptions): Promise<
 /**
  * Action-type execute: POST (has side effects).
  *
- * The request body must include `_instance_identities` — an array of objects
- * identifying which instances the action operates on:
+ * The request body must use the envelope shape below — top-level scalar fields
+ * (other than `trigger_type` and `_instance_identities`) are silently dropped
+ * by the backend, which causes downstream tools to receive `null` parameters
+ * (and typically respond with 401 token expired or 500 type errors).
+ *
  * ```json
- * {"_instance_identities": [{"<primary_key>": "<value>"}], ...otherParams}
+ * {
+ *   "trigger_type": "manual",
+ *   "_instance_identities": [{"<primary_key>": "<value>"}],
+ *   "dynamic_params": {
+ *     "<param_name>": "<value>",
+ *     "Authorization": "Bearer <token>"
+ *   }
+ * }
  * ```
+ *
+ * - `_instance_identities` may be `[]` for "create"-style actions.
+ * - Each ActionType parameter has a `value_from` discriminator:
+ *     • `input`    — caller MUST supply via `dynamic_params`. Includes
+ *                    `source: header` params (e.g. `Authorization`/`token`),
+ *                    which are usually credentials for the DOWNSTREAM system
+ *                    the action calls — NOT the platform session token. The
+ *                    SDK never auto-forwards its session token.
+ *     • `const`    — frozen in the ActionType snapshot; values in body are
+ *                    silently ignored. Edit the ActionType definition to
+ *                    `input` first if you need caller override.
+ *     • `property` — auto-populated from the resolved instance's property;
+ *                    do not (and cannot) supply via body.
+ *
+ * Practical recipe: query the ActionType, filter parameters where
+ * `value_from == "input"`, put exactly those names into `dynamic_params`.
+ *
+ * See `skills/kweaver-core/references/bkn.md` ("action-type execute 请求体契约")
+ * for the full contract and troubleshooting table.
  */
 export interface ActionTypeExecuteOptions extends OntologyQueryBaseOptions {
   atId: string;

--- a/packages/typescript/src/api/toolboxes.ts
+++ b/packages/typescript/src/api/toolboxes.ts
@@ -6,15 +6,24 @@ import { buildHeaders } from "./headers.js";
 // Backend endpoints under /api/agent-operator-integration/v1/tool-box.
 //
 // Verified against kweaver/examples/03-action-lifecycle/run.sh (lines 78–197):
-//   POST   /tool-box                   create
-//   DELETE /tool-box/{id}              delete
-//   POST   /tool-box/{id}/status       publish/draft
-//   POST   /tool-box/{id}/tool         upload tool (multipart)
-//   POST   /tool-box/{id}/tools/status enable/disable (batch)
+//   POST   /tool-box                       create
+//   DELETE /tool-box/{id}                  delete
+//   POST   /tool-box/{id}/status           publish/draft
+//   POST   /tool-box/{id}/tool             upload tool (multipart)
+//   POST   /tool-box/{id}/tools/status     enable/disable (batch)
 //
 // Verified during Task 8 e2e against the live backend (2026-04-18):
 //   GET    /tool-box/list?keyword=&limit=&offset=  list toolboxes
 //   GET    /tool-box/{id}/tools/list               list tools
+//
+// Verified live on 2026-04-23 against dip-poc.aishu.cn:
+//   POST   /tool-box/{box}/proxy/{tool}            execute tool (envelope JSON)
+//   POST   /tool-box/{box}/tool/{tool}/debug       debug tool (envelope JSON)
+//
+// Envelope shape required by /proxy and /debug:
+//   { "timeout": <s>, "header": {...}, "query": {...}, "body": {...} }
+// Flat-shape requests cause the forwarder to drop downstream Authorization
+// headers, which manifests as 401 "token expired" from the underlying tool.
 
 const PATH = "/api/agent-operator-integration/v1/tool-box";
 
@@ -138,4 +147,52 @@ export async function listTools(opts: ListToolsOptions): Promise<string> {
     headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
   });
   return body;
+}
+
+// ── execute / debug ──────────────────────────────────────────────────────────
+//
+// Both endpoints share the same envelope payload and forwarder; the only
+// observable differences are:
+//   - debug bypasses the "tool must be enabled" gate (dev-time invocation),
+//   - audit log records DebugTool vs ExecuteTool.
+
+export interface InvokeToolOptions extends BaseOpts {
+  boxId: string;
+  toolId: string;
+  /** Optional headers to forward to the downstream tool (e.g. Authorization). */
+  header?: Record<string, unknown>;
+  /** Optional query params to forward. */
+  query?: Record<string, unknown>;
+  /** JSON body forwarded to the downstream tool. */
+  body?: unknown;
+  /** Per-call timeout in seconds; backend default applies when omitted. */
+  timeout?: number;
+}
+
+function buildEnvelope(opts: InvokeToolOptions): string {
+  const envelope: Record<string, unknown> = {};
+  if (opts.timeout !== undefined) envelope.timeout = opts.timeout;
+  envelope.header = opts.header ?? {};
+  envelope.query = opts.query ?? {};
+  envelope.body = opts.body ?? {};
+  return JSON.stringify(envelope);
+}
+
+async function invokeTool(opts: InvokeToolOptions, suffix: string): Promise<string> {
+  const { body } = await fetchTextOrThrow(url(opts.baseUrl, suffix), {
+    method: "POST",
+    headers: { ...buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"), "content-type": "application/json" },
+    body: buildEnvelope(opts),
+  });
+  return body;
+}
+
+/** Execute a published+enabled tool through the toolbox proxy. */
+export async function executeTool(opts: InvokeToolOptions): Promise<string> {
+  return invokeTool(opts, `/${encodeURIComponent(opts.boxId)}/proxy/${encodeURIComponent(opts.toolId)}`);
+}
+
+/** Debug a tool through the toolbox proxy (works on draft/disabled tools too). */
+export async function debugTool(opts: InvokeToolOptions): Promise<string> {
+  return invokeTool(opts, `/${encodeURIComponent(opts.boxId)}/tool/${encodeURIComponent(opts.toolId)}/debug`);
 }

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -89,7 +89,8 @@ Usage:
   kweaver bkn object-type list|get|create|update|delete|query|properties <kn-id> ...
   kweaver bkn relation-type list|get|create|update|delete <kn-id> ...
   kweaver bkn subgraph <kn-id> <body-json>
-  kweaver bkn action-type list|query|execute <kn-id> ... [--wait] [--no-wait] [--timeout N]
+  kweaver bkn action-type list|query|inputs|execute <kn-id> ... [--wait] [--no-wait] [--timeout N]
+  kweaver bkn action-type execute <kn-id> <at-id> [<envelope-json>|--dynamic-params '<json>' --instance '<json>' --trigger-type <v>]
   kweaver bkn action-execution get <kn-id> <execution-id>
   kweaver bkn action-log list|get|cancel <kn-id> ...
 
@@ -111,6 +112,9 @@ Usage:
   kweaver tool upload --toolbox <box-id> <openapi-spec-path> [--metadata-type openapi]
   kweaver tool list --toolbox <box-id> [-bd value]
   kweaver tool enable|disable --toolbox <box-id> <tool-id>... [-bd value]
+  kweaver tool execute|debug --toolbox <box-id> <tool-id>
+                             [--body '<json>'|--body-file <path>]
+                             [--header '<json>'] [--query '<json>'] [--timeout <s>]
 
   kweaver vega health|stats|inspect
   kweaver vega catalog list|get|health|test-connection|discover|resources [options]

--- a/packages/typescript/src/client.ts
+++ b/packages/typescript/src/client.ts
@@ -15,6 +15,7 @@ import { DataViewsResource } from "./resources/dataviews.js";
 import { KnowledgeNetworksResource } from "./resources/knowledge-networks.js";
 import { BknResource } from "./resources/bkn.js";
 import { SkillsResource } from "./resources/skills.js";
+import { ToolboxesResource } from "./resources/toolboxes.js";
 import { VegaResource } from "./resources/vega.js";
 
 // ── ClientContext ─────────────────────────────────────────────────────────────
@@ -129,6 +130,9 @@ export class KWeaverClient implements ClientContext {
   /** ADP/KWeaver skill registry, market, progressive read, and install helpers. */
   readonly skills: SkillsResource;
 
+  /** Toolbox / tool management plus execute & debug invocation. */
+  readonly toolboxes: ToolboxesResource;
+
   constructor(opts: KWeaverClientOptions = {}) {
     const envDomain = process.env.KWEAVER_BUSINESS_DOMAIN;
 
@@ -168,6 +172,7 @@ export class KWeaverClient implements ClientContext {
       this.dataviews = new DataViewsResource(this);
       this.vega = new VegaResource(this);
       this.skills = new SkillsResource(this);
+      this.toolboxes = new ToolboxesResource(this);
       return;
     }
 
@@ -228,6 +233,7 @@ export class KWeaverClient implements ClientContext {
     this.dataviews = new DataViewsResource(this);
     this.vega = new VegaResource(this);
     this.skills = new SkillsResource(this);
+    this.toolboxes = new ToolboxesResource(this);
   }
 
   /**

--- a/packages/typescript/src/commands/bkn-schema.ts
+++ b/packages/typescript/src/commands/bkn-schema.ts
@@ -735,6 +735,9 @@ export function parseKnActionTypeExecuteArgs(args: string[]): KnActionTypeExecut
   let businessDomain = "";
   let wait = true;
   let timeout = 300;
+  let dynamicParamsJson: string | undefined;
+  let triggerType: string | undefined;
+  const instanceJsons: string[] = [];
   const positional: string[] = [];
 
   for (let i = 0; i < args.length; i += 1) {
@@ -765,12 +768,42 @@ export function parseKnActionTypeExecuteArgs(args: string[]): KnActionTypeExecut
       i += 1;
       continue;
     }
+    if (arg === "--dynamic-params" && args[i + 1]) {
+      dynamicParamsJson = args[++i];
+      continue;
+    }
+    if (arg === "--instance" && args[i + 1]) {
+      instanceJsons.push(args[++i]);
+      continue;
+    }
+    if (arg === "--trigger-type" && args[i + 1]) {
+      triggerType = args[++i];
+      continue;
+    }
     positional.push(arg);
   }
 
-  const [knId, atId, body] = positional;
-  if (!knId || !atId || !body) {
-    throw new Error("Missing kn-id, at-id, or body. Usage: kweaver bkn action-type execute <kn-id> <at-id> '<json>' [options]");
+  const usingFlags = dynamicParamsJson !== undefined || instanceJsons.length > 0 || triggerType !== undefined;
+  const [knId, atId, positionalBody] = positional;
+  if (!knId || !atId) {
+    throw new Error("Missing kn-id or at-id. Usage: kweaver bkn action-type execute <kn-id> <at-id> [<json>|--dynamic-params '<json>' --instance '<json>'] [options]");
+  }
+  if (positionalBody && usingFlags) {
+    throw new Error("Positional body and --dynamic-params/--instance/--trigger-type are mutually exclusive. Use one form.");
+  }
+  if (!positionalBody && !usingFlags) {
+    throw new Error("Missing body. Provide a positional JSON envelope, or use --dynamic-params / --instance / --trigger-type.");
+  }
+
+  let body: string;
+  if (positionalBody) {
+    body = positionalBody;
+  } else {
+    body = buildExecuteEnvelope({
+      triggerType: triggerType ?? "manual",
+      dynamicParamsJson,
+      instanceJsons,
+    });
   }
 
   if (!businessDomain) businessDomain = resolveBusinessDomain();
@@ -783,6 +816,148 @@ export function parseKnActionTypeExecuteArgs(args: string[]): KnActionTypeExecut
     wait,
     timeout,
   };
+}
+
+/**
+ * Assemble the action-type execute envelope from CLI flags. Each flag is
+ * parsed as JSON; instance entries must be JSON objects; dynamic_params must
+ * be a JSON object. The shape produced is the contract documented in
+ * skills/kweaver-core/references/bkn.md.
+ */
+export function buildExecuteEnvelope(opts: {
+  triggerType: string;
+  dynamicParamsJson?: string;
+  instanceJsons: string[];
+}): string {
+  const envelope: Record<string, unknown> = {
+    trigger_type: opts.triggerType,
+    _instance_identities: opts.instanceJsons.map((s, idx) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(s);
+      } catch (e) {
+        throw new Error(`--instance #${idx + 1} is not valid JSON: ${(e as Error).message}`);
+      }
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        throw new Error(`--instance #${idx + 1} must be a JSON object, got ${Array.isArray(parsed) ? "array" : typeof parsed}`);
+      }
+      return parsed;
+    }),
+  };
+  if (opts.dynamicParamsJson !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(opts.dynamicParamsJson);
+    } catch (e) {
+      throw new Error(`--dynamic-params is not valid JSON: ${(e as Error).message}`);
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error(`--dynamic-params must be a JSON object, got ${Array.isArray(parsed) ? "array" : typeof parsed}`);
+    }
+    envelope.dynamic_params = parsed;
+  } else {
+    envelope.dynamic_params = {};
+  }
+  return JSON.stringify(envelope);
+}
+
+// ── Action-type inputs helpers ────────────────────────────────────────────────
+
+export interface InputParameterSummary {
+  name: string;
+  type?: string;
+  source?: string;
+  required?: boolean;
+  description?: string;
+}
+
+/**
+ * Walk a getActionType response and collect parameters where
+ * `value_from === "input"`. The exact response shape varies (sometimes the
+ * action-type is at the root, sometimes nested under data/result/...), so we
+ * search a few likely locations.
+ */
+export function extractInputParameters(rawJson: string): InputParameterSummary[] {
+  let root: unknown;
+  try {
+    root = JSON.parse(rawJson);
+  } catch {
+    return [];
+  }
+  const candidates = collectParameterArrays(root);
+  const seen = new Set<string>();
+  const out: InputParameterSummary[] = [];
+  for (const params of candidates) {
+    for (const p of params) {
+      if (!p || typeof p !== "object") continue;
+      const obj = p as Record<string, unknown>;
+      if (obj.value_from !== "input") continue;
+      const name = typeof obj.name === "string" ? obj.name : "";
+      if (!name || seen.has(name)) continue;
+      seen.add(name);
+      out.push({
+        name,
+        type: typeof obj.type === "string" ? obj.type : undefined,
+        source: typeof obj.source === "string" ? obj.source : undefined,
+        required: typeof obj.required === "boolean" ? obj.required : undefined,
+        description: typeof obj.description === "string" ? obj.description : undefined,
+      });
+    }
+  }
+  return out;
+}
+
+function collectParameterArrays(node: unknown, acc: unknown[][] = []): unknown[][] {
+  if (!node) return acc;
+  if (Array.isArray(node)) {
+    for (const item of node) collectParameterArrays(item, acc);
+    return acc;
+  }
+  if (typeof node !== "object") return acc;
+  const obj = node as Record<string, unknown>;
+  if (Array.isArray(obj.parameters)) acc.push(obj.parameters);
+  for (const v of Object.values(obj)) collectParameterArrays(v, acc);
+  return acc;
+}
+
+export function buildDynamicParamsTemplate(inputs: InputParameterSummary[]): Record<string, unknown> {
+  const tpl: Record<string, unknown> = {};
+  for (const p of inputs) {
+    tpl[p.name] = placeholderForType(p);
+  }
+  return tpl;
+}
+
+function placeholderForType(p: InputParameterSummary): unknown {
+  const hint = p.description ? ` (${p.description})` : "";
+  const t = (p.type ?? "").toLowerCase();
+  if (t === "int" || t === "integer" || t === "long" || t === "number" || t === "float" || t === "double") return 0;
+  if (t === "bool" || t === "boolean") return false;
+  if (t === "array" || t === "list") return [];
+  if (t === "object" || t === "dict" || t === "map") return {};
+  return `<${p.type ?? "string"}${p.required === false ? "?" : ""}>${hint}`;
+}
+
+export function renderInputsTable(atId: string, inputs: InputParameterSummary[]): string {
+  if (inputs.length === 0) {
+    return `Action type ${atId} has no parameters with value_from=input. dynamic_params can be {}.`;
+  }
+  const rows = inputs.map(p => [
+    p.name,
+    p.type ?? "-",
+    p.source ?? "-",
+    p.required === undefined ? "-" : p.required ? "yes" : "no",
+    truncate(p.description ?? "", 60),
+  ]);
+  const header = ["NAME", "TYPE", "SOURCE", "REQUIRED", "DESCRIPTION"];
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map(r => r[i].length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  const lines = [fmt(header), fmt(widths.map(w => "-".repeat(w))), ...rows.map(fmt)];
+  return `Action type ${atId} input parameters (value_from=input):\n${lines.join("\n")}`;
+}
+
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : s.slice(0, n - 1) + "…";
 }
 
 // ── Action-type execute helpers ────────────────────────────────────────────────
@@ -1335,17 +1510,30 @@ kweaver bkn action-type create <kn-id> '<json>' [--pretty] [-bd value]
 kweaver bkn action-type update <kn-id> <at-id> '<json>' [--pretty] [-bd value]
 kweaver bkn action-type delete <kn-id> <at-ids> [-y] [--pretty] [-bd value]
 kweaver bkn action-type query <kn-id> <at-id> '<json>' [--pretty] [-bd value]
-kweaver bkn action-type execute <kn-id> <at-id> '<json>' [--pretty] [-bd value] [--wait|--no-wait] [--timeout n]
+kweaver bkn action-type inputs <kn-id> <at-id> [--json|--template] [-bd value]
+kweaver bkn action-type execute <kn-id> <at-id> [<json>|--dynamic-params '<json>' --instance '<json>' --trigger-type <v>] [--pretty] [-bd value] [--wait|--no-wait] [--timeout n]
 
 list: List action types (schema) from ontology-manager.
 get: Get a single action type by ID.
 create: Create action type(s) (POST JSON body).
 update: Update an action type (PUT JSON body).
 delete: Delete action type(s) by ID(s).
-query/execute: Query or execute actions. execute has side effects - only use when explicitly requested.
+query: Query actions backing this action type.
+inputs: List parameters with value_from=input that the caller MUST supply.
+        Default prints a table + a starter dynamic_params template.
+        --json     dump filtered parameters as raw JSON
+        --template print only the dynamic_params template object
+execute: Run an action (has side effects - only use when explicitly requested).
+  Body forms (mutually exclusive):
+    1. Positional envelope JSON: '{"trigger_type":"manual","_instance_identities":[],"dynamic_params":{...}}'
+    2. Flag form (CLI assembles the envelope):
+         --dynamic-params '<json object>'   parameters with value_from=input
+         --instance '<json object>'         repeatable; one per identity
+         --trigger-type <value>             defaults to "manual"
   --wait (default)    Poll until execution completes
   --no-wait           Return immediately after starting execution
-  --timeout <seconds> Max wait time when --wait (default: 300)`);
+  --timeout <seconds> Max wait time when --wait (default: 300)
+See skills/kweaver-core/references/bkn.md for the full payload contract.`);
     return 0;
   }
 
@@ -1494,6 +1682,48 @@ query/execute: Query or execute actions. execute has side effects - only use whe
     }
   }
 
+  if (action === "inputs") {
+    const parsed = parseOntologyQueryFlags(rest);
+    const flags = new Set(parsed.filteredArgs.filter(a => a.startsWith("--")));
+    const positional = parsed.filteredArgs.filter(a => !a.startsWith("--"));
+    const [knId, atId] = positional;
+    if (!knId || !atId) {
+      console.error("Usage: kweaver bkn action-type inputs <kn-id> <at-id> [--json|--template]");
+      return 1;
+    }
+    if (flags.has("--json") && flags.has("--template")) {
+      console.error("--json and --template are mutually exclusive.");
+      return 1;
+    }
+    try {
+      const token = await ensureValidToken();
+      const raw = await getActionType({
+        baseUrl: token.baseUrl,
+        accessToken: token.accessToken,
+        knId,
+        atId,
+        businessDomain: parsed.businessDomain,
+      });
+      const inputs = extractInputParameters(raw);
+      if (flags.has("--json")) {
+        console.log(formatCallOutput(JSON.stringify(inputs), parsed.pretty));
+        return 0;
+      }
+      const template = buildDynamicParamsTemplate(inputs);
+      if (flags.has("--template")) {
+        console.log(JSON.stringify(template, null, 2));
+        return 0;
+      }
+      console.log(renderInputsTable(atId, inputs));
+      console.log("\n# Starter dynamic_params (fill in real values, then pass via --dynamic-params):");
+      console.log(JSON.stringify(template, null, 2));
+      return 0;
+    } catch (error) {
+      console.error(formatHttpError(error));
+      return 1;
+    }
+  }
+
   if (action === "execute") {
     let options: KnActionTypeExecuteOptions;
     try {
@@ -1557,7 +1787,7 @@ query/execute: Query or execute actions. execute has side effects - only use whe
     }
   }
 
-  console.error(`Unknown action-type action: ${action}. Use list, get, create, update, delete, query, or execute.`);
+  console.error(`Unknown action-type action: ${action}. Use list, get, create, update, delete, query, inputs, or execute.`);
   return 1;
 }
 

--- a/packages/typescript/src/commands/bkn.ts
+++ b/packages/typescript/src/commands/bkn.ts
@@ -562,7 +562,8 @@ Subcommands:
   action-type update <kn-id> <at-id> '<json>'   Update action type
   action-type delete <kn-id> <at-ids> [-y]   Delete action type(s)
   action-type query <kn-id> <at-id> '<json>'   Query action info
-  action-type execute <kn-id> <at-id> '<json>'   Execute action (has side effects)
+  action-type inputs <kn-id> <at-id>   List value_from=input params + dynamic_params template
+  action-type execute <kn-id> <at-id> '<envelope-json>' | --dynamic-params '<json>' [--instance '<json>']... [--trigger-type <v>]   Execute action (has side effects)
   action-execution get <kn-id> <execution-id>   Get execution status
   action-log list <kn-id> [options]   List action execution logs
   action-log get <kn-id> <log-id>   Get single execution log

--- a/packages/typescript/src/commands/tool.ts
+++ b/packages/typescript/src/commands/tool.ts
@@ -1,6 +1,6 @@
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { ensureValidToken, formatHttpError, with401RefreshRetry } from "../auth/oauth.js";
-import { listTools, setToolStatuses, uploadTool } from "../api/toolboxes.js";
+import { debugTool, executeTool, listTools, setToolStatuses, uploadTool } from "../api/toolboxes.js";
 import { formatCallOutput } from "./call.js";
 import { resolveBusinessDomain } from "../config/store.js";
 
@@ -8,12 +8,23 @@ const HELP = `kweaver tool
 
 Subcommands:
   upload --toolbox <box-id> <openapi-spec-path> [--metadata-type openapi]
-                                          Upload an OpenAPI spec file as a tool
-  list --toolbox <box-id>                  List tools in a toolbox
-  enable --toolbox <box-id> <tool-id>...   Enable one or more tools
-  disable --toolbox <box-id> <tool-id>...  Disable one or more tools
+                                              Upload an OpenAPI spec file as a tool
+  list --toolbox <box-id>                      List tools in a toolbox
+  enable --toolbox <box-id> <tool-id>...       Enable one or more tools
+  disable --toolbox <box-id> <tool-id>...      Disable one or more tools
+  execute --toolbox <box-id> <tool-id> [--body '<json>'|--body-file <path>]
+                                              Invoke a published+enabled tool
+  debug   --toolbox <box-id> <tool-id> [--body '<json>'|--body-file <path>]
+                                              Invoke a tool (works on draft/disabled too)
 
-Options:
+Options for execute/debug:
+  --header '<json>'       Headers map forwarded to the downstream tool
+                          (Authorization is auto-injected from current session
+                          when --header omits it; pass {} to send none)
+  --query  '<json>'       Query params map forwarded to the downstream tool
+  --timeout <seconds>     Per-call timeout (backend default applies when omitted)
+
+Common options:
   -bd, --biz-domain <s>   Business domain (default: bd_public)
   --pretty                Pretty-print JSON (default)
   --compact               Single-line JSON (pipeline-friendly)`;
@@ -30,6 +41,8 @@ export async function runToolCommand(args: string[]): Promise<number> {
     if (subcommand === "list") return runToolList(rest);
     if (subcommand === "enable") return runToolStatus(rest, "enabled");
     if (subcommand === "disable") return runToolStatus(rest, "disabled");
+    if (subcommand === "execute") return runToolInvoke(rest, "execute");
+    if (subcommand === "debug") return runToolInvoke(rest, "debug");
     return Promise.resolve(-1);
   };
 
@@ -175,5 +188,126 @@ async function runToolStatus(args: string[], status: "enabled" | "disabled"): Pr
     updates: opts.toolIds.map((toolId) => ({ toolId, status: opts.status })),
   });
   console.error(`${status === "enabled" ? "Enabled" : "Disabled"} ${opts.toolIds.length} tool(s) in toolbox ${opts.boxId}`);
+  return 0;
+}
+
+// ── execute / debug ───────────────────────────────────────────────────────────
+
+export interface ToolInvokeOptions {
+  boxId: string;
+  toolId: string;
+  header?: Record<string, unknown>;
+  query?: Record<string, unknown>;
+  body?: unknown;
+  bodyFile?: string;
+  timeout?: number;
+  businessDomain: string;
+  pretty: boolean;
+}
+
+function parseJsonOption(name: string, raw: string): Record<string, unknown> {
+  let value: unknown;
+  try { value = JSON.parse(raw); }
+  catch (e) { throw new Error(`${name} must be valid JSON: ${(e as Error).message}`); }
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function parseToolInvokeArgs(args: string[]): ToolInvokeOptions {
+  let boxId = "";
+  let toolId = "";
+  let businessDomain = "";
+  let pretty = true;
+  let header: Record<string, unknown> | undefined;
+  let query: Record<string, unknown> | undefined;
+  let body: unknown;
+  let bodyProvided = false;
+  let bodyFile: string | undefined;
+  let timeout: number | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--toolbox" && args[i + 1]) { boxId = args[++i]; continue; }
+    if (a === "--header" && args[i + 1]) { header = parseJsonOption("--header", args[++i]); continue; }
+    if (a === "--query" && args[i + 1]) { query = parseJsonOption("--query", args[++i]); continue; }
+    if (a === "--body" && args[i + 1]) {
+      const raw = args[++i];
+      try { body = JSON.parse(raw); }
+      catch (e) { throw new Error(`--body must be valid JSON: ${(e as Error).message}`); }
+      bodyProvided = true;
+      continue;
+    }
+    if (a === "--body-file" && args[i + 1]) { bodyFile = args[++i]; bodyProvided = true; continue; }
+    if (a === "--timeout" && args[i + 1]) {
+      const t = Number(args[++i]);
+      if (!Number.isFinite(t) || t <= 0) throw new Error("--timeout must be a positive number");
+      timeout = t;
+      continue;
+    }
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
+    if (a === "--pretty") { pretty = true; continue; }
+    if (a === "--compact") { pretty = false; continue; }
+    if (!a.startsWith("-") && !toolId) { toolId = a; continue; }
+  }
+
+  if (!boxId) throw new Error("Missing required flag: --toolbox");
+  if (!toolId) throw new Error("Missing required positional argument: <tool-id>");
+  if (bodyFile && body !== undefined) throw new Error("--body and --body-file are mutually exclusive");
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+  return {
+    boxId,
+    toolId,
+    header,
+    query,
+    body: bodyProvided ? body : undefined,
+    bodyFile,
+    timeout,
+    businessDomain,
+    pretty,
+  };
+}
+
+async function loadBodyFile(path: string): Promise<unknown> {
+  let raw: string;
+  try { raw = await readFile(path, "utf8"); }
+  catch (e) { throw new Error(`Cannot read --body-file ${path}: ${(e as Error).message}`); }
+  try { return JSON.parse(raw); }
+  catch (e) { throw new Error(`--body-file ${path} is not valid JSON: ${(e as Error).message}`); }
+}
+
+async function runToolInvoke(args: string[], action: "execute" | "debug"): Promise<number> {
+  let opts: ToolInvokeOptions;
+  try { opts = parseToolInvokeArgs(args); }
+  catch (e) { console.error(e instanceof Error ? e.message : String(e)); return 1; }
+
+  let body: unknown = opts.body;
+  if (opts.bodyFile !== undefined) {
+    try { body = await loadBodyFile(opts.bodyFile); }
+    catch (e) { console.error(e instanceof Error ? e.message : String(e)); return 1; }
+  }
+
+  const token = await ensureValidToken();
+  // Auto-inject Authorization unless caller already provided one — most tools
+  // declare an `Authorization` header parameter and would otherwise be called
+  // anonymously, which the downstream tool answers with 401 token expired.
+  const header = { ...(opts.header ?? {}) };
+  const hasAuth = Object.keys(header).some((k) => k.toLowerCase() === "authorization");
+  if (!hasAuth) header.Authorization = `Bearer ${token.accessToken}`;
+
+  const fn = action === "execute" ? executeTool : debugTool;
+  const responseBody = await fn({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    businessDomain: opts.businessDomain,
+    boxId: opts.boxId,
+    toolId: opts.toolId,
+    header,
+    query: opts.query,
+    body,
+    timeout: opts.timeout,
+  });
+  console.log(formatCallOutput(responseBody, opts.pretty));
   return 0;
 }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -167,6 +167,8 @@ export { BknResource } from "./resources/bkn.js";
 export { ConversationsResource } from "./resources/conversations.js";
 export { ContextLoaderResource } from "./resources/context-loader.js";
 export { SkillsResource } from "./resources/skills.js";
+export { ToolboxesResource } from "./resources/toolboxes.js";
+export type { InvokeToolArgs } from "./resources/toolboxes.js";
 
 // ── Skills (agent-operator-integration) ──────────────────────────────────────
 export type {
@@ -232,6 +234,29 @@ export { DataViewsResource } from "./resources/dataviews.js";
 // ── Business domains (platform API) ───────────────────────────────────────────
 export type { BusinessDomain, ListBusinessDomainsOptions } from "./api/business-domains.js";
 export { listBusinessDomains } from "./api/business-domains.js";
+
+// ── Toolboxes / tools (agent-operator-integration) ────────────────────────────
+export type {
+  CreateToolboxOptions,
+  DeleteToolboxOptions,
+  SetToolboxStatusOptions,
+  UploadToolOptions,
+  SetToolStatusesOptions,
+  ListToolboxesOptions,
+  ListToolsOptions,
+  InvokeToolOptions,
+} from "./api/toolboxes.js";
+export {
+  createToolbox,
+  deleteToolbox,
+  setToolboxStatus,
+  uploadTool,
+  setToolStatuses,
+  listToolboxes,
+  listTools,
+  executeTool,
+  debugTool,
+} from "./api/toolboxes.js";
 
 // ── HTTP utilities ────────────────────────────────────────────────────────────
 export { HttpError, NetworkRequestError, fetchTextOrThrow } from "./utils/http.js";

--- a/packages/typescript/src/resources/toolboxes.ts
+++ b/packages/typescript/src/resources/toolboxes.ts
@@ -1,0 +1,84 @@
+import type { ClientContext } from "../client.js";
+import {
+  debugTool,
+  executeTool,
+  listTools,
+  listToolboxes,
+  setToolStatuses,
+  uploadTool,
+} from "../api/toolboxes.js";
+
+export interface InvokeToolArgs {
+  /** Optional headers to forward to the downstream tool. Authorization is
+   *  auto-injected from the client's access token when omitted; pass `{}` to
+   *  send no headers. */
+  header?: Record<string, unknown>;
+  query?: Record<string, unknown>;
+  body?: unknown;
+  /** Per-call timeout in seconds (backend default applies when omitted). */
+  timeout?: number;
+}
+
+/** Toolbox / tool management on the agent-operator-integration service. */
+export class ToolboxesResource {
+  constructor(private readonly ctx: ClientContext) {}
+
+  async list(opts: { keyword?: string; limit?: number; offset?: number } = {}): Promise<string> {
+    return listToolboxes({ ...this.ctx.base(), ...opts });
+  }
+
+  async listToolsIn(boxId: string): Promise<string> {
+    return listTools({ ...this.ctx.base(), boxId });
+  }
+
+  async uploadTool(opts: {
+    boxId: string;
+    filePath: string;
+    metadataType?: "openapi";
+  }): Promise<string> {
+    return uploadTool({
+      ...this.ctx.base(),
+      boxId: opts.boxId,
+      filePath: opts.filePath,
+      metadataType: opts.metadataType,
+    });
+  }
+
+  async setToolStatuses(opts: {
+    boxId: string;
+    updates: Array<{ toolId: string; status: "enabled" | "disabled" }>;
+  }): Promise<void> {
+    await setToolStatuses({ ...this.ctx.base(), ...opts });
+  }
+
+  /** Execute a published+enabled tool through the toolbox proxy. */
+  async execute(boxId: string, toolId: string, args: InvokeToolArgs = {}): Promise<string> {
+    return executeTool({
+      ...this.ctx.base(),
+      boxId,
+      toolId,
+      ...this.injectAuth(args),
+    });
+  }
+
+  /** Debug a tool through the toolbox proxy (works on draft/disabled tools too). */
+  async debug(boxId: string, toolId: string, args: InvokeToolArgs = {}): Promise<string> {
+    return debugTool({
+      ...this.ctx.base(),
+      boxId,
+      toolId,
+      ...this.injectAuth(args),
+    });
+  }
+
+  // The forwarder requires every header the downstream tool expects to be set
+  // explicitly under `header`; most published tools declare an Authorization
+  // parameter and would otherwise see no token. Auto-inject the active
+  // session token unless the caller already provided one.
+  private injectAuth(args: InvokeToolArgs): InvokeToolArgs {
+    const header = { ...(args.header ?? {}) };
+    const hasAuth = Object.keys(header).some((k) => k.toLowerCase() === "authorization");
+    if (!hasAuth) header.Authorization = `Bearer ${this.ctx.base().accessToken}`;
+    return { ...args, header };
+  }
+}

--- a/packages/typescript/test/cli.test.ts
+++ b/packages/typescript/test/cli.test.ts
@@ -1459,6 +1459,60 @@ test("parseKnActionTypeExecuteArgs parses --timeout", () => {
   assert.equal(opts.timeout, 60);
 });
 
+test("parseKnActionTypeExecuteArgs assembles envelope from --dynamic-params/--instance/--trigger-type", () => {
+  const opts = parseKnActionTypeExecuteArgs([
+    "kn-1",
+    "at-1",
+    "--dynamic-params", '{"task_id":"x","qty":3}',
+    "--instance", '{"task_id":"x"}',
+    "--instance", '{"task_id":"y"}',
+    "--trigger-type", "manual",
+  ]);
+  const body = JSON.parse(opts.body);
+  assert.equal(body.trigger_type, "manual");
+  assert.deepEqual(body._instance_identities, [{ task_id: "x" }, { task_id: "y" }]);
+  assert.deepEqual(body.dynamic_params, { task_id: "x", qty: 3 });
+});
+
+test("parseKnActionTypeExecuteArgs defaults trigger-type=manual and dynamic_params={}", () => {
+  const opts = parseKnActionTypeExecuteArgs([
+    "kn-1", "at-1",
+    "--instance", '{"id":"x"}',
+  ]);
+  const body = JSON.parse(opts.body);
+  assert.equal(body.trigger_type, "manual");
+  assert.deepEqual(body.dynamic_params, {});
+  assert.deepEqual(body._instance_identities, [{ id: "x" }]);
+});
+
+test("parseKnActionTypeExecuteArgs rejects positional body + flag form combined", () => {
+  assert.throws(
+    () => parseKnActionTypeExecuteArgs(["kn-1", "at-1", "{}", "--dynamic-params", "{}"]),
+    /mutually exclusive/,
+  );
+});
+
+test("parseKnActionTypeExecuteArgs rejects no body and no flags", () => {
+  assert.throws(
+    () => parseKnActionTypeExecuteArgs(["kn-1", "at-1"]),
+    /Missing body/,
+  );
+});
+
+test("parseKnActionTypeExecuteArgs rejects non-object --instance JSON", () => {
+  assert.throws(
+    () => parseKnActionTypeExecuteArgs(["kn-1", "at-1", "--instance", "[1,2]"]),
+    /must be a JSON object/,
+  );
+});
+
+test("parseKnActionTypeExecuteArgs rejects invalid --dynamic-params JSON", () => {
+  assert.throws(
+    () => parseKnActionTypeExecuteArgs(["kn-1", "at-1", "--dynamic-params", "not-json"]),
+    /not valid JSON/,
+  );
+});
+
 test("parseAgentSessionsArgs requires agent_id", () => {
   assert.throws(() => parseAgentSessionsArgs([]), /Missing agent_id/);
 });
@@ -2487,4 +2541,69 @@ test("parseRelationTypeDeleteArgs throws on missing args", () => {
     () => parseRelationTypeDeleteArgs(["kn-1"]),
     /Usage|Missing/
   );
+});
+
+import {
+  extractInputParameters,
+  buildDynamicParamsTemplate,
+  renderInputsTable,
+  buildExecuteEnvelope,
+} from "../src/commands/bkn-schema.js";
+
+test("extractInputParameters filters value_from=input only", () => {
+  const raw = JSON.stringify({
+    parameters: [
+      { name: "task_id", value_from: "input", type: "string", source: "body", required: true, description: "Task id" },
+      { name: "Authorization", value_from: "input", type: "string", source: "header" },
+      { name: "tenant", value_from: "const" },
+      { name: "name", value_from: "property" },
+    ],
+  });
+  const inputs = extractInputParameters(raw);
+  assert.deepEqual(
+    inputs.map(p => p.name).sort(),
+    ["Authorization", "task_id"],
+  );
+  const taskId = inputs.find(p => p.name === "task_id")!;
+  assert.equal(taskId.required, true);
+  assert.equal(taskId.source, "body");
+});
+
+test("extractInputParameters walks nested action-type response shapes", () => {
+  const raw = JSON.stringify({
+    data: { action_type: { parameters: [{ name: "x", value_from: "input" }] } },
+  });
+  const inputs = extractInputParameters(raw);
+  assert.deepEqual(inputs.map(p => p.name), ["x"]);
+});
+
+test("buildDynamicParamsTemplate uses type-aware placeholders", () => {
+  const tpl = buildDynamicParamsTemplate([
+    { name: "qty", type: "int" },
+    { name: "ok", type: "bool" },
+    { name: "tags", type: "array" },
+    { name: "title", type: "string", description: "Title", required: true },
+  ]);
+  assert.equal(tpl.qty, 0);
+  assert.equal(tpl.ok, false);
+  assert.deepEqual(tpl.tags, []);
+  assert.match(String(tpl.title), /^<string>/);
+});
+
+test("renderInputsTable handles empty input list", () => {
+  const out = renderInputsTable("at-1", []);
+  assert.match(out, /no parameters with value_from=input/);
+});
+
+test("buildExecuteEnvelope produces canonical shape", () => {
+  const body = buildExecuteEnvelope({
+    triggerType: "manual",
+    dynamicParamsJson: '{"a":1}',
+    instanceJsons: ['{"id":"x"}'],
+  });
+  assert.deepEqual(JSON.parse(body), {
+    trigger_type: "manual",
+    _instance_identities: [{ id: "x" }],
+    dynamic_params: { a: 1 },
+  });
 });

--- a/packages/typescript/test/tool-execute.test.ts
+++ b/packages/typescript/test/tool-execute.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { executeTool, debugTool } from "../src/api/toolboxes.js";
+import { parseToolInvokeArgs } from "../src/commands/tool.js";
+
+const BASE = "https://platform.example";
+const TOKEN = "tok-exec";
+const PREFIX = "/api/agent-operator-integration/v1/tool-box";
+
+function mockFetch(handler: (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = handler as typeof fetch;
+  return () => { globalThis.fetch = original; };
+}
+
+test("executeTool POSTs envelope JSON to /tool-box/{box}/proxy/{tool}", async () => {
+  let captured: { url: string; init?: RequestInit } | null = null;
+  const restore = mockFetch(async (url, init) => {
+    captured = { url: String(url), init };
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  });
+  try {
+    await executeTool({
+      baseUrl: BASE,
+      accessToken: TOKEN,
+      boxId: "b1",
+      toolId: "t1",
+      header: { Authorization: "Bearer abc" },
+      query: { dry: "true" },
+      body: { task_id: "x" },
+      timeout: 42,
+    });
+    assert.ok(captured);
+    assert.equal(captured!.url, `${BASE}${PREFIX}/b1/proxy/t1`);
+    assert.equal(captured!.init?.method, "POST");
+    const sent = JSON.parse(captured!.init?.body as string);
+    assert.deepEqual(sent, {
+      timeout: 42,
+      header: { Authorization: "Bearer abc" },
+      query: { dry: "true" },
+      body: { task_id: "x" },
+    });
+  } finally { restore(); }
+});
+
+test("debugTool POSTs envelope JSON to /tool-box/{box}/tool/{tool}/debug", async () => {
+  let capturedUrl = "";
+  const restore = mockFetch(async (url) => {
+    capturedUrl = String(url);
+    return new Response("{}", { status: 200 });
+  });
+  try {
+    await debugTool({ baseUrl: BASE, accessToken: TOKEN, boxId: "b1", toolId: "t1" });
+    assert.equal(capturedUrl, `${BASE}${PREFIX}/b1/tool/t1/debug`);
+  } finally { restore(); }
+});
+
+test("envelope defaults: omitted timeout absent, header/query/body coerced to {}", async () => {
+  let captured: any = null;
+  const restore = mockFetch(async (_url, init) => {
+    captured = JSON.parse(init?.body as string);
+    return new Response("{}", { status: 200 });
+  });
+  try {
+    await executeTool({ baseUrl: BASE, accessToken: TOKEN, boxId: "b1", toolId: "t1" });
+    assert.deepEqual(captured, { header: {}, query: {}, body: {} });
+    assert.ok(!("timeout" in captured));
+  } finally { restore(); }
+});
+
+// ── CLI parsing ──────────────────────────────────────────────────────────────
+
+test("parseToolInvokeArgs requires --toolbox and a tool id", () => {
+  assert.throws(() => parseToolInvokeArgs([]), /--toolbox/);
+  assert.throws(() => parseToolInvokeArgs(["--toolbox", "b1"]), /tool-id/i);
+});
+
+test("parseToolInvokeArgs parses headers/query/body/timeout", () => {
+  const opts = parseToolInvokeArgs([
+    "--toolbox", "b1", "t1",
+    "--body", '{"k":1}',
+    "--header", '{"X-Foo":"bar"}',
+    "--query", '{"q":"v"}',
+    "--timeout", "30",
+  ]);
+  assert.equal(opts.boxId, "b1");
+  assert.equal(opts.toolId, "t1");
+  assert.deepEqual(opts.body, { k: 1 });
+  assert.deepEqual(opts.header, { "X-Foo": "bar" });
+  assert.deepEqual(opts.query, { q: "v" });
+  assert.equal(opts.timeout, 30);
+});
+
+test("parseToolInvokeArgs rejects --body and --body-file together", () => {
+  assert.throws(
+    () => parseToolInvokeArgs(["--toolbox", "b1", "t1", "--body", "{}", "--body-file", "x.json"]),
+    /mutually exclusive/i,
+  );
+});
+
+test("parseToolInvokeArgs rejects malformed JSON in --header", () => {
+  assert.throws(
+    () => parseToolInvokeArgs(["--toolbox", "b1", "t1", "--header", "not-json"]),
+    /--header/,
+  );
+});
+
+test("parseToolInvokeArgs rejects array for --query (must be object)", () => {
+  assert.throws(
+    () => parseToolInvokeArgs(["--toolbox", "b1", "t1", "--query", "[1,2]"]),
+    /--query.*object/i,
+  );
+});
+
+test("parseToolInvokeArgs rejects non-positive --timeout", () => {
+  assert.throws(
+    () => parseToolInvokeArgs(["--toolbox", "b1", "t1", "--timeout", "0"]),
+    /timeout/i,
+  );
+});

--- a/skills/kweaver-core/references/bkn.md
+++ b/skills/kweaver-core/references/bkn.md
@@ -206,12 +206,130 @@ kweaver bkn subgraph <kn_id> '<json>'   # 子图查询
 ```bash
 kweaver bkn action-type list <kn_id>
 kweaver bkn action-type query <kn_id> <at_id> '<json>'
-kweaver bkn action-type execute <kn_id> <at_id> '<json>'   # 有副作用，执行前确认
+kweaver bkn action-type inputs <kn_id> <at_id>             # 列出 value_from=input 的参数 + dynamic_params 模板
+kweaver bkn action-type execute <kn_id> <at_id> '<envelope-json>'  # 形式 A：传完整信封
+kweaver bkn action-type execute <kn_id> <at_id> \           # 形式 B：CLI 帮你拼信封（推荐）
+  --dynamic-params '<json>' [--instance '<json>']... [--trigger-type manual]
 kweaver bkn action-execution get <kn_id> <execution_id> [--wait/--no-wait] [--timeout 300]
 kweaver bkn action-log list <kn_id> [--offset 0] [--limit 20] [--sort create_time] [--direction desc]
 kweaver bkn action-log get <kn_id> <log_id>
 kweaver bkn action-log cancel <kn_id> <log_id> [--yes/-y]
 ```
+
+### `action-type execute` 请求体契约（重要）
+
+后端只识别下面这种"信封"结构，**顶层散字段会被静默丢弃**——这是新手最常见的踩坑点：
+
+```json
+{
+  "trigger_type": "manual",
+  "_instance_identities": [{ "<primary_key>": "<value>" }],
+  "dynamic_params": {
+    "<param_name>": "<value>",
+    "Authorization": "Bearer <token>"
+  }
+}
+```
+
+| 字段 | 必需性 | 说明 |
+|---|---|---|
+| `trigger_type` | 推荐 | 触发来源标识，常用值 `manual`；缺省时后端会用默认值，但显式写更利于排查 |
+| `_instance_identities` | 看 ActionType 定义 | 数组，标识要操作的实例；"创建类"动作可传 `[]` |
+| `dynamic_params` | **必填** | ActionType 中所有 `value_from: input` 的参数都放这里——**包括声明为 header 的 `Authorization`/`token`**（注意：这里的 `Authorization` 通常是**下游被调系统**的凭证，不一定等于你登录 KWeaver 的会话 token，先看参数 `description`） |
+
+#### `value_from` 参数来源（决定调用方要不要传）
+
+ActionType 的每个 `parameter` 都带一个 `value_from` 字段，**只有 `input` 类型需要调用方在 `dynamic_params` 里传值**，其余两种你不用管：
+
+| value_from | 含义 | 调用方要做什么 | 传了会怎样 |
+|---|---|---|---|
+| `input` | 值由调用方在执行时通过 body 传入（含 `source: header` 的参数，如 `Authorization`/`token`） | **必须**塞进 `dynamic_params`，缺一个下游就拿到 `null` | 正常生效 |
+| `const` | 值在 ActionType 定义里写死，执行时直接用 snapshot 里的常量 | 不用管 | 传了也被丢弃，最终用定义里的常量 |
+| `property` | 值从 `_instance_identities` 解析出的目标实例属性自动取（参数名对应 ObjectType 的 property 名） | 不用管，确保 `_instance_identities` 能解析出实例即可 | 传了也以实例真实属性值为准 |
+
+> 还有一种 `param` 仅出现在 RiskFunction 体系，普通 `action-type execute` 用不到。
+
+##### 实战速查：用 `action-type inputs` 一步查完
+
+```bash
+# 直接列出该 ActionType 的所有 value_from=input 参数（含 type/source/required/description）
+# 并附带一份可直接复制的 dynamic_params 模板
+kweaver bkn action-type inputs <kn_id> <at_id>
+
+# 只要模板（适合脚本）：
+kweaver bkn action-type inputs <kn_id> <at_id> --template
+
+# 只要原始 JSON：
+kweaver bkn action-type inputs <kn_id> <at_id> --json
+```
+
+> 老办法（也能用）：`kweaver bkn action-type query <kn_id> <at_id> '{}' | jq '.parameters[] | select(.value_from=="input")'`。
+
+#### ⚠️ 三条必知规则
+
+1. **顶层散字段会被吞**：`{"_instance_identities":[], "task_id": "x"}` 这种写法里 `task_id` **不会**到达下游，落库后 `dynamic_params` 为 `undefined`。表现是下游 tool 拿到一堆 `null`，可能直接 401（缺 Authorization）或 500（缺必填业务字段）。
+2. **`Authorization` 是 ActionType 自定义的普通参数，不是平台会话 token**：当 ActionType 把它声明为 `value_from: input` + `source: header` 时，**它的语义由 ActionType 自己决定**，通常是要传给下游被调系统的凭证（ERP、外部 LLM、第三方 API 等）。先看参数 `description` 确认要谁的 token，**不要无脑把 `kweaver auth` 的输出粘进去**——SDK 也不会自动塞，避免误把平台 token 泄漏给不相干的下游服务。
+3. **`value_from: const` 无法被 body 覆盖**：要让调用方传值生效，先在 ActionType 定义里把对应参数改为 `value_from: input`；否则 `dynamic_params` 里塞了也会被 snapshot 里的常量盖掉。
+
+#### 推荐：用 flag 形式，让 CLI 帮你拼信封
+
+不想手写整段 envelope JSON？直接传语义槽位，CLI 内部组装出与上面**完全一样**的 body 发出去：
+
+```bash
+kweaver bkn action-type execute supplychain_bkn_v4 create_monitoring_task \
+  --dynamic-params '{
+    "task_id":"demo-001","task_name":"demo task","task_status":"开始",
+    "product_code":"P-001","product_name":"demo product",
+    "demand_start":"2026-04-20","demand_end":"2026-04-21","demand_quantity":3,
+    "production_start":"2026-04-22","production_end":"2026-04-25","production_quantity":3,
+    "created_by":"you",
+    "Authorization":"Bearer <下游系统的 token>"
+  }' \
+  --no-wait
+# 需要操作已有实例时再加 --instance（可重复）：
+#   --instance '{"task_id":"demo-001"}'
+# trigger_type 缺省为 manual，需覆盖时：--trigger-type schedule
+```
+
+互斥规则：positional envelope JSON 和 `--dynamic-params` / `--instance` / `--trigger-type` 不能同时出现，CLI 会直接报错。
+
+#### 完整示例（envelope 形式，生产环境验证通过）
+
+```bash
+TOK=<your bearer token>
+kweaver bkn action-type execute supplychain_bkn_v4 create_monitoring_task \
+  "$(printf '{
+    "trigger_type": "manual",
+    "_instance_identities": [],
+    "dynamic_params": {
+      "task_id": "demo-001",
+      "task_name": "demo task",
+      "task_status": "开始",
+      "product_code": "P-001",
+      "product_name": "demo product",
+      "demand_start": "2026-04-20",
+      "demand_end": "2026-04-21",
+      "demand_quantity": 3,
+      "production_start": "2026-04-22",
+      "production_end": "2026-04-25",
+      "production_quantity": 3,
+      "created_by": "you",
+      "Authorization": "Bearer %s"
+    }
+  }' "$TOK")" \
+  --no-wait
+# 拿到 execution_id 后用 action-log get 看结果
+kweaver bkn action-log get <kn_id> <execution_id>
+```
+
+#### 排错速查
+
+| 现象 | 大概率原因 |
+|---|---|
+| 下游 `401 token expired` / `Common.UnAuthorization` | `dynamic_params` 里没有 `Authorization`（或参数还在顶层散着） |
+| 下游 500 `could not convert ... 'null'` | `dynamic_params` 缺业务必填字段（如 `product_code`） |
+| `action-log get` 看到 `dynamic_params: undefined`、各 result 的 `parameters: {}` | body 是扁平形式，整体被后端丢弃 |
+| 改了 body 仍然走旧值 | ActionType 定义里该参数是 `value_from: const`，需平台侧改为 `input` |
 
 ## Data Source 绑定类型
 

--- a/skills/kweaver-core/references/tool.md
+++ b/skills/kweaver-core/references/tool.md
@@ -11,6 +11,12 @@ kweaver tool upload  --toolbox <box-id> <openapi-spec-path> [--metadata-type ope
 kweaver tool list    --toolbox <box-id> [-bd value] [--pretty|--compact]
 kweaver tool enable  --toolbox <box-id> <tool-id>... [-bd value]
 kweaver tool disable --toolbox <box-id> <tool-id>... [-bd value]
+kweaver tool execute --toolbox <box-id> <tool-id> [--body '<json>'|--body-file <path>]
+                     [--header '<json>'] [--query '<json>'] [--timeout <s>]
+                     [-bd value] [--pretty|--compact]
+kweaver tool debug   --toolbox <box-id> <tool-id> [--body '<json>'|--body-file <path>]
+                     [--header '<json>'] [--query '<json>'] [--timeout <s>]
+                     [-bd value] [--pretty|--compact]
 ```
 
 ## 子命令说明
@@ -49,13 +55,53 @@ kweaver tool enable  --toolbox 1234567890123456789 tool-a tool-b
 kweaver tool disable --toolbox 1234567890123456789 tool-c
 ```
 
+### `execute` / `debug`
+
+通过 toolbox 转发器调用一个 tool。两者共用同一个请求载荷与转发逻辑，唯一区别：
+
+| 子命令 | 调用前置条件 | 后端路由 |
+|--------|--------------|----------|
+| `execute` | tool 已发布且处于 `enabled` 状态 | `POST /tool-box/{box}/proxy/{tool}` |
+| `debug`   | 任意状态（含草稿、`disabled`） | `POST /tool-box/{box}/tool/{tool}/debug` |
+
+**关键：信封（envelope）格式。** 后端期望的请求体是固定结构：
+
+```json
+{
+  "timeout": 60,
+  "header": { "Authorization": "Bearer ..." },
+  "query":  { "key": "value" },
+  "body":   { "...": "..." }
+}
+```
+
+- 若直接发"扁平 body"（不裹 `header/body/query`），转发器会因 `Headers == nil` 把下游 `Authorization` 丢掉，下游服务回 `401 token expired`。
+- CLI 默认会把当前会话的 `Bearer <token>` 作为 `Authorization` 注入 `header`；如果需要匿名调用，传 `--header '{}'` 显式覆盖。
+- `--body` 与 `--body-file` 互斥；都不传则 `body` 为 `{}`。
+- `--timeout` 单位为秒；不传走后端默认。
+
+```bash
+# Execute (要求 tool 已 enabled)
+kweaver tool execute \
+  --toolbox 1234567890123456789 tool-create-task \
+  --body '{"task_id":"t-1","task_name":"demo"}'
+
+# Debug (草稿/disabled 也能跑)
+kweaver tool debug \
+  --toolbox 1234567890123456789 tool-create-task \
+  --body-file payload.json \
+  --header '{"X-Trace-Id":"local-debug-1"}' \
+  --query  '{"dry_run":"true"}' \
+  --timeout 30
+```
+
 ## 通用选项
 
 | 选项 | 说明 | 适用子命令 |
 |------|------|-----------|
 | `-bd, --biz-domain <s>` | 覆盖业务域。默认走 `resolveBusinessDomain()`（`KWEAVER_BUSINESS_DOMAIN` env → 当前平台 `config.json` → `bd_public`） | 全部 |
-| `--pretty` | 把响应体当作 JSON 解析后以 2 空格缩进重排（解析失败则按原文输出，默认） | `upload`、`list` |
-| `--compact` | 原样输出后端响应文本，不做美化（便于管道处理） | `upload`、`list` |
+| `--pretty` | 把响应体当作 JSON 解析后以 2 空格缩进重排（解析失败则按原文输出，默认） | `upload`、`list`、`execute`、`debug` |
+| `--compact` | 原样输出后端响应文本，不做美化（便于管道处理） | `upload`、`list`、`execute`、`debug` |
 
 ## 注意
 


### PR DESCRIPTION
## Summary

Three related ergonomics improvements grouped by one need: *"how do I drive a tool/action without learning the envelope schema by trial and error?"*. Bumps to **0.6.10**.

### 1. `kweaver tool execute` / `kweaver tool debug`
- New CLI subcommands wrapping `POST /tool-box/{box}/proxy|debug/{tool}`.
- Builds the required `header`/`query`/`body`/`timeout` JSON envelope so `Authorization` headers are no longer dropped by `agent-operator-integration`. Auto-injects current session bearer into the envelope header when the caller doesn't specify one.
- SDK parity: `ToolboxesResource.execute` / `.debug` on TS and Python clients, alongside `list` / `upload` / `setStatuses` helpers.

### 2. `kweaver bkn action-type inputs <kn> <at>`
- Lists parameters with `value_from == "input"` (the only ones the caller must supply via `dynamic_params`) plus a type-aware starter template for direct copy/paste into `--dynamic-params`.
- Output modes: default (table + template), `--template`, `--json`.
- Python parity: `client.action_types.inputs(kn, at)`.

### 3. `bkn action-type execute` flag form
- Old positional envelope JSON kept for backward compat.
- New `--dynamic-params` / `--instance` (repeatable) / `--trigger-type` flags let the CLI assemble the envelope; mutually exclusive with positional body to avoid ambiguity.
- Python `execute()` gains `dynamic_params` / `instances` / `trigger_type` kwargs mirroring the CLI; mutex enforced at SDK layer too.

### Documentation

`skills/kweaver-core/references/bkn.md` restructured with:
- `value_from` semantics table (`input` / `const` / `property`).
- `action-type execute` payload contract section.
- New flag-form recipe.
- **Important wording fix**: `dynamic_params.Authorization` is the *downstream-system credential* declared by the ActionType, **not** the platform session token. The SDK intentionally does not auto-forward its own bearer to avoid leaking platform credentials to unrelated downstream services.

`skills/kweaver-core/references/tool.md` documents the envelope shape and execute/debug differences for `kweaver tool`.

Top-level help, sub-command help, README.md / README.zh.md all synced.

## Test plan

### Unit
- TS: 736/736 pass (added `tool-execute.test.ts`, action-type input extraction + envelope assembly cases in `cli.test.ts`).
- Python: 397/397 pass (added `test_toolboxes.py`, action-type input/envelope cases in `test_action_types.py`).

### End-to-end (dip-poc, supplychain_bkn_v4 / create_monitoring_task)
- [x] `inputs` default — table + 17-key template, `Authorization` shown as `source: Header`.
- [x] `inputs --template` — type-aware (`number → 0`, `string → "<string>"`).
- [x] `inputs --json` — sorted parameter list with `name/type/source`.
- [x] `execute` (positional envelope) — `execution_id: d7l1purt6khiag2p1k90`, body landed with all 17 dynamic_params keys.
- [x] `execute` (flag form) — `execution_id: d7l1o83t6khiag2p1k8g`, body landed identically.
- [x] Mutex guard — positional + `--dynamic-params` rejected with clear error.
- [x] `tool execute` envelope path verified earlier in this branch's lifecycle.


Made with [Cursor](https://cursor.com)