### PR TITLE
fix(bkn): subgraph query_type 与 JSON 体形态一致（relation_path vs 默认子图）

### DIFF
--- a/packages/typescript/src/commands/bkn-query.ts
+++ b/packages/typescript/src/commands/bkn-query.ts
@@ -40,12 +40,16 @@ Query subgraph via ontology-query API. JSON body format see references/json-form
   }
 
   try {
-    // Auto-detect query_type=relation_path when body contains source_object_type_id
+    // Map body shape to ontology-query subgraph query_type:
+    // - relation_type_paths mode → ?query_type=relation_path
+    // - source_object_type_id mode → omit query_type (default path; do not send relation_path)
     let queryType: "" | "relation_path" | undefined;
     try {
       const parsedBody = JSON.parse(body) as Record<string, unknown>;
-      if (parsedBody.source_object_type_id) {
+      if (Array.isArray(parsedBody.relation_type_paths)) {
         queryType = "relation_path";
+      } else if (parsedBody.source_object_type_id) {
+        queryType = "";
       }
     } catch {
       // Not valid JSON — let the API return the error

--- a/skills/kweaver-core/references/bkn.md
+++ b/skills/kweaver-core/references/bkn.md
@@ -201,6 +201,8 @@ kweaver bkn search <kn_id> <query> [--max-concepts <n>] [--mode <mode>]   # 语�
 kweaver bkn subgraph <kn_id> '<json>'   # 子图查询
 ```
 
+CLI maps JSON body to ontology-query `query_type`: if `relation_type_paths` is present, append `query_type=relation_path`; if only `source_object_type_id` (default subgraph mode), omit `query_type`.
+
 ## Action Type / Log / Execution
 
 ```bash


### PR DESCRIPTION
## 1. 变更说明（Purpose）
> 这个 PR 解决了什么问题、实现了什么功能？

- **解决的问题**：`kweaver bkn subgraph` 在请求体包含 `source_object_type_id` 时错误地附加 `query_type=relation_path`，导致 ontology-query 将「从起点做子图探索」误判为「基于路径的子图查询」。
- **实现功能**：按 JSON 体形态映射 `query_type`：存在 `relation_type_paths` 数组时使用 `?query_type=relation_path`；仅含 `source_object_type_id`（默认子图模式）时不应走 `relation_path`（通过 `queryType = ""` 与 `subgraph()` 约定对齐）。
- **关联 Issue**：#（如有请补）

## 2. 修改类型（Type of Change）
- [ ] 新功能 (Feature)
- [x] Bug 修复
- [ ] 性能优化
- [ ] 代码重构
- [x] 文档更新
- [ ] 依赖升级
- [ ] 样式/UI 调整
- [ ] 测试用例

## 3. 实现方案（How & Why）
- **逻辑**：解析 JSON 后优先判断 `Array.isArray(parsedBody.relation_type_paths)` → `queryType = "relation_path"`；否则若存在 `parsedBody.source_object_type_id` → `queryType = ""`，避免误发路径查询模式。
- **文档**：在 `skills/kweaver-core/references/bkn.md` 补充 CLI 与 ontology-query `query_type` 的对应说明（英文一句）。

**Diff 摘要**（相对 `main`）：
- `packages/typescript/src/commands/bkn-query.ts`：`runKnSubgraphCommand` 中子图请求的 `query_type` 推断与注释。
- `skills/kweaver-core/references/bkn.md`：`bkn subgraph` 参考说明。

## 4. 自测清单（Self Check）
- [x] 分支已 rebase 至 `main`
- [ ] 新增/修改了单元测试（本变更未包含 UT）
- [ ] 已用真实接口验证两种子图模式
- [ ] 无日志/异常/报错
- [ ] 兼容相关场景

## 5. 截图/日志（可选）
N/A

## 6. 检查项（Reviewer 用）
- [ ] 代码逻辑清晰
- [ ] 命名规范、无冗余代码
- [ ] 安全/权限无问题
- [ ] 符合团队编码规范
- [ ] 合并不会影响主分支

## 7. 备注（Notes）
- Base：`main`；Head：`bug/fix-bkn-query`。
