### PR TITLE
feat(toolbox): export/import config commands + quiet biz-domain warning

### DIFF
--- a/packages/python/src/kweaver/business_domains.py
+++ b/packages/python/src/kweaver/business_domains.py
@@ -59,12 +59,13 @@ def auto_select_business_domain(
             return "bd_public"
         store.save_business_domain(platform_url, selected)
         return selected
-    except Exception:
+    except Exception as e:
         # Endpoint may be unavailable on this deployment or for this account
-        # type — fall back silently. Set KWEAVER_DEBUG=1 for diagnostics.
+        # type — fall back silently. Set KWEAVER_DEBUG=1 to surface the
+        # underlying error during diagnostics.
         if os.environ.get("KWEAVER_DEBUG"):
             print(
-                "Business domain list unavailable; defaulting to bd_public.",
+                f"Business domain list unavailable ({e}); defaulting to bd_public.",
                 file=sys.stderr,
             )
         return "bd_public"

--- a/packages/python/src/kweaver/business_domains.py
+++ b/packages/python/src/kweaver/business_domains.py
@@ -59,9 +59,12 @@ def auto_select_business_domain(
             return "bd_public"
         store.save_business_domain(platform_url, selected)
         return selected
-    except Exception as e:
-        print(
-            f"Could not fetch business domains: {e}. Using bd_public.",
-            file=sys.stderr,
-        )
+    except Exception:
+        # Endpoint may be unavailable on this deployment or for this account
+        # type — fall back silently. Set KWEAVER_DEBUG=1 for diagnostics.
+        if os.environ.get("KWEAVER_DEBUG"):
+            print(
+                "Business domain list unavailable; defaulting to bd_public.",
+                file=sys.stderr,
+            )
         return "bd_public"

--- a/packages/python/src/kweaver/resources/toolboxes.py
+++ b/packages/python/src/kweaver/resources/toolboxes.py
@@ -155,12 +155,25 @@ class ToolboxesResource:
             from kweaver._errors import raise_for_status_parts
 
             raise_for_status_parts(status, content)
-        try:
-            import json as _json
+        if not content:
+            return None
+        import json as _json
 
-            return _unwrap_data(_json.loads(content) if content else None)
-        except Exception:
-            return content.decode("utf-8", errors="replace") if content else None
+        # Backend always returns JSON on success; if it ever doesn't (e.g. a
+        # transient gateway HTML page slipped through with status 200) we
+        # surface that as the raw decoded text rather than silently returning
+        # garbage — but we ALSO log so callers notice.
+        try:
+            return _unwrap_data(_json.loads(content))
+        except _json.JSONDecodeError:
+            import sys
+
+            print(
+                "kweaver: import_config got non-JSON 2xx response; "
+                "returning raw text. Set KWEAVER_DEBUG=1 to inspect.",
+                file=sys.stderr,
+            )
+            return content.decode("utf-8", errors="replace")
 
     # ── execute / debug ──────────────────────────────────────────────────────
 

--- a/packages/python/src/kweaver/resources/toolboxes.py
+++ b/packages/python/src/kweaver/resources/toolboxes.py
@@ -16,9 +16,11 @@ if TYPE_CHECKING:
 
 
 _PREFIX = "/api/agent-operator-integration/v1/tool-box"
+_IMPEX_PREFIX = "/api/agent-operator-integration/v1/impex"
 
 ToolStatus = Literal["enabled", "disabled"]
 ToolboxStatus = Literal["draft", "published"]
+ImpexType = Literal["toolbox", "mcp", "operator"]
 
 
 def _unwrap_data(payload: Any) -> Any:
@@ -118,6 +120,47 @@ class ToolboxesResource:
                 tool_id, status = item
                 normalised.append({"tool_id": tool_id, "status": status})
         self._http.post(f"{_PREFIX}/{box_id}/tools/status", json={"updates": normalised})
+
+    # ── impex (export / import) ──────────────────────────────────────────────
+
+    def export_config(self, box_id: str, *, type: ImpexType = "toolbox") -> bytes:
+        """Export a toolbox/mcp/operator config; returns raw `.adp` JSON bytes.
+
+        The backend response is `application/json` with a
+        `Content-Disposition: attachment; filename=...adp` header.
+        """
+        status, content = self._http.get_bytes(
+            f"{_IMPEX_PREFIX}/export/{type}/{box_id}",
+        )
+        if status >= 400:
+            from kweaver._errors import raise_for_status_parts
+
+            raise_for_status_parts(status, content)
+        return content
+
+    def import_config(
+        self,
+        file_path: str | Path,
+        *,
+        type: ImpexType = "toolbox",
+    ) -> Any:
+        """Import a previously exported config file (multipart, field name `data`)."""
+        path = Path(file_path)
+        files = {"data": (path.name, path.read_bytes(), "application/octet-stream")}
+        status, content = self._http.post_multipart(
+            f"{_IMPEX_PREFIX}/import/{type}",
+            files=files,
+        )
+        if status >= 400:
+            from kweaver._errors import raise_for_status_parts
+
+            raise_for_status_parts(status, content)
+        try:
+            import json as _json
+
+            return _unwrap_data(_json.loads(content) if content else None)
+        except Exception:
+            return content.decode("utf-8", errors="replace") if content else None
 
     # ── execute / debug ──────────────────────────────────────────────────────
 

--- a/packages/python/tests/unit/test_toolboxes.py
+++ b/packages/python/tests/unit/test_toolboxes.py
@@ -151,6 +151,88 @@ def test_execute_forward_auth_false_omits_authorization():
         client.close()
 
 
+_IMPEX_PREFIX = "/api/agent-operator-integration/v1/impex"
+
+
+def test_export_config_gets_impex_endpoint_and_returns_raw_bytes():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["method"] = request.method
+        return httpx.Response(200, content=b'{"box":"b1"}')
+
+    client = _client(handler)
+    try:
+        result = client.toolboxes.export_config("b1")
+        assert result == b'{"box":"b1"}'
+        assert captured["path"] == f"{_IMPEX_PREFIX}/export/toolbox/b1"
+        assert captured["method"] == "GET"
+    finally:
+        client.close()
+
+
+def test_export_config_supports_mcp_type():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        return httpx.Response(200, content=b"{}")
+
+    client = _client(handler)
+    try:
+        client.toolboxes.export_config("m1", type="mcp")
+        assert captured["path"] == f"{_IMPEX_PREFIX}/export/mcp/m1"
+    finally:
+        client.close()
+
+
+def test_import_config_posts_multipart_data_field(tmp_path):
+    src = tmp_path / "toolbox_b1.adp"
+    src.write_text('{"hello":"world"}', encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["method"] = request.method
+        captured["content_type"] = request.headers.get("content-type", "")
+        captured["body"] = request.content
+        return httpx.Response(200, json={"code": 0, "data": {"imported": True}})
+
+    client = _client(handler)
+    try:
+        result = client.toolboxes.import_config(src)
+        assert result == {"imported": True}
+        assert captured["path"] == f"{_IMPEX_PREFIX}/import/toolbox"
+        assert captured["method"] == "POST"
+        assert "multipart/form-data" in str(captured["content_type"])
+        body_bytes = captured["body"]
+        assert isinstance(body_bytes, (bytes, bytearray))
+        # multipart payload contains the field name "data" and the file content
+        assert b'name="data"' in body_bytes
+        assert b'{"hello":"world"}' in body_bytes
+    finally:
+        client.close()
+
+
+def test_import_config_raises_on_4xx(tmp_path):
+    src = tmp_path / "broken.adp"
+    src.write_text("{}", encoding="utf-8")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"code": 1, "message": "invalid file"})
+
+    client = _client(handler)
+    try:
+        import pytest
+
+        with pytest.raises(Exception):
+            client.toolboxes.import_config(src)
+    finally:
+        client.close()
+
+
 def test_execute_caller_provided_authorization_is_preserved():
     captured: dict[str, object] = {}
 

--- a/packages/typescript/src/api/toolboxes.ts
+++ b/packages/typescript/src/api/toolboxes.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
-import { fetchTextOrThrow } from "../utils/http.js";
+import { HttpError, fetchTextOrThrow, fetchWithRetry } from "../utils/http.js";
 import { buildHeaders } from "./headers.js";
 
 // Backend endpoints under /api/agent-operator-integration/v1/tool-box.
@@ -171,14 +171,21 @@ export interface ExportConfigOptions extends BaseOpts {
   type?: ImpexType;
 }
 
-export async function exportConfig(opts: ExportConfigOptions): Promise<string> {
+export async function exportConfig(opts: ExportConfigOptions): Promise<Uint8Array> {
   const t = opts.type ?? "toolbox";
   const target = `${opts.baseUrl.replace(/\/+$/, "")}${IMPEX_PATH}/export/${encodeURIComponent(t)}/${encodeURIComponent(opts.id)}`;
-  const { body } = await fetchTextOrThrow(target, {
+  // Use raw bytes (not text) so we never lose precision on non-ASCII payloads
+  // and stay symmetric with the Python SDK's `export_config -> bytes`.
+  const response = await fetchWithRetry(target, {
     method: "GET",
     headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
   });
-  return body;
+  const buf = new Uint8Array(await response.arrayBuffer());
+  if (!response.ok) {
+    const text = new TextDecoder("utf-8").decode(buf);
+    throw new HttpError(response.status, response.statusText, text);
+  }
+  return buf;
 }
 
 export interface ImportConfigOptions extends BaseOpts {

--- a/packages/typescript/src/api/toolboxes.ts
+++ b/packages/typescript/src/api/toolboxes.ts
@@ -149,6 +149,58 @@ export async function listTools(opts: ListToolsOptions): Promise<string> {
   return body;
 }
 
+// ── impex (export / import) ──────────────────────────────────────────────────
+//
+// Backend mounts the impex endpoints on the same service but under a different
+// path:
+//
+//   GET  /api/agent-operator-integration/v1/impex/export/{type}/{id}
+//   POST /api/agent-operator-integration/v1/impex/import/{type}   (multipart, field "data")
+//
+// Supported {type} values today: "toolbox" | "mcp" | "operator".
+//
+// Export response is the raw JSON config (Content-Type: application/json) plus
+// a `Content-Disposition: attachment; filename=<type>_export_<ts>.adp` header.
+
+const IMPEX_PATH = "/api/agent-operator-integration/v1/impex";
+
+export type ImpexType = "toolbox" | "mcp" | "operator";
+
+export interface ExportConfigOptions extends BaseOpts {
+  id: string;
+  type?: ImpexType;
+}
+
+export async function exportConfig(opts: ExportConfigOptions): Promise<string> {
+  const t = opts.type ?? "toolbox";
+  const target = `${opts.baseUrl.replace(/\/+$/, "")}${IMPEX_PATH}/export/${encodeURIComponent(t)}/${encodeURIComponent(opts.id)}`;
+  const { body } = await fetchTextOrThrow(target, {
+    method: "GET",
+    headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
+  });
+  return body;
+}
+
+export interface ImportConfigOptions extends BaseOpts {
+  /** Path to a previously exported `.adp` JSON file. */
+  filePath: string;
+  type?: ImpexType;
+}
+
+export async function importConfig(opts: ImportConfigOptions): Promise<string> {
+  const buf = await readFile(opts.filePath);
+  const t = opts.type ?? "toolbox";
+  const form = new FormData();
+  form.append("data", new Blob([buf]), basename(opts.filePath));
+  const target = `${opts.baseUrl.replace(/\/+$/, "")}${IMPEX_PATH}/import/${encodeURIComponent(t)}`;
+  const { body } = await fetchTextOrThrow(target, {
+    method: "POST",
+    headers: buildHeaders(opts.accessToken, opts.businessDomain ?? "bd_public"),
+    body: form,
+  });
+  return body;
+}
+
 // ── execute / debug ──────────────────────────────────────────────────────────
 //
 // Both endpoints share the same envelope payload and forwarder; the only

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -40,26 +40,26 @@ Usage:
   kweaver token
 
   kweaver call <url> [-X METHOD] [-H "Name: value"] [-d BODY] [--data-raw BODY]
-             [--url URL] [--pretty] [--verbose] [-bd value]
+             [--url URL] [--verbose] [-bd value]
   (alias: kweaver curl ...)
 
   kweaver agent chat <agent_id> [-m "message"] [--version value] [--conversation-id id]
                 [--stream] [--no-stream] [--verbose] [-bd value]
-  kweaver agent list [--name X] [--limit N] [--offset N] [-bd value] [--pretty]
-  kweaver agent get <agent_id> [-bd value] [--pretty]
-  kweaver agent get-by-key <key> [-bd value] [--pretty]
-  kweaver agent sessions <agent_id> [-bd value] [--limit N] [--pretty]
-  kweaver agent history <conversation_id> [-bd value] [--limit N] [--pretty]
+  kweaver agent list [--name X] [--limit N] [--offset N] [-bd value]
+  kweaver agent get <agent_id> [-bd value]
+  kweaver agent get-by-key <key> [-bd value]
+  kweaver agent sessions <agent_id> [-bd value] [--limit N]
+  kweaver agent history <conversation_id> [-bd value] [--limit N]
   kweaver agent create [options]
   kweaver agent update <agent_id> [options]
   kweaver agent delete <agent_id> [-bd value]
   kweaver agent publish <agent_id> [-bd value]
   kweaver agent unpublish <agent_id> [-bd value]
 
-  kweaver ds list [--keyword X] [--type T] [-bd value] [--pretty]
+  kweaver ds list [--keyword X] [--type T] [-bd value]
   kweaver ds get <id>
   kweaver ds delete <id> [-y]
-  kweaver ds tables <id> [--keyword X] [--pretty]
+  kweaver ds tables <id> [--keyword X]
   kweaver ds connect <db_type> <host> <port> <database> --account X --password Y [--schema S] [--name N]
 
   kweaver dataflow list [-bd value]
@@ -67,15 +67,15 @@ Usage:
   kweaver dataflow runs <dagId> [--since <date-like>] [-bd value]
   kweaver dataflow logs <dagId> <instanceId> [--detail] [-bd value]
 
-  kweaver dataview list [--datasource-id id] [--type atomic|custom] [--limit n] [-bd value] [--pretty]
-  kweaver dataview find --name <name> [--exact] [--datasource-id id] [--wait] [--timeout ms] [-bd value] [--pretty]
-  kweaver dataview get <id> [-bd value] [--pretty]
-  kweaver dataview query <id> [--sql sql] [--limit n] [--offset n] [--need-total] [--raw-sql] [-bd value] [--pretty]
+  kweaver dataview list [--datasource-id id] [--type atomic|custom] [--limit n] [-bd value]
+  kweaver dataview find --name <name> [--exact] [--datasource-id id] [--wait] [--timeout ms] [-bd value]
+  kweaver dataview get <id> [-bd value]
+  kweaver dataview query <id> [--sql sql] [--limit n] [--offset n] [--need-total] [--raw-sql] [-bd value]
   kweaver dataview delete <id> [-y] [-bd value]
 
   kweaver bkn list [options]
   kweaver bkn get <kn-id> [options]
-  kweaver bkn search <kn-id> <query> [--max-concepts N] [--mode M] [--pretty] [-bd value]
+  kweaver bkn search <kn-id> <query> [--max-concepts N] [--mode M] [-bd value]
   kweaver bkn create [options]
   kweaver bkn create-from-ds [options]
   kweaver bkn update <kn-id> [options]
@@ -135,6 +135,9 @@ Usage:
 
 Global options:
   --user <id|name>  Use a specific user's credentials for this command (env: KWEAVER_USER)
+  --pretty / --compact
+                    Toggle pretty-printed JSON output. Supported by every
+                    command that prints a JSON payload (default: pretty).
 
 Commands:
   auth           Login, list, inspect, and switch saved platform auth profiles

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -108,6 +108,8 @@ Usage:
   kweaver toolbox list [--keyword X] [--limit N] [--offset N] [-bd value]
   kweaver toolbox publish|unpublish <box-id> [-bd value]
   kweaver toolbox delete <box-id> [-y] [-bd value]
+  kweaver toolbox export <box-id> [-o <file>|-] [--type toolbox|mcp|operator]
+  kweaver toolbox import <file> [--type toolbox|mcp|operator]
 
   kweaver tool upload --toolbox <box-id> <openapi-spec-path> [--metadata-type openapi]
   kweaver tool list --toolbox <box-id> [-bd value]
@@ -146,7 +148,7 @@ Commands:
                  object-type, relation-type, subgraph, action-type, action-execution, action-log)
   config         Per-platform configuration (business domain)
   skill          Skill registry and market (register, search, progressive read, download/install)
-  toolbox        Agent toolbox lifecycle (create, list, publish, delete)
+  toolbox        Agent toolbox lifecycle (create, list, publish, delete, export, import)
   tool           Tools inside a toolbox (upload OpenAPI spec, list, enable/disable)
   vega           Vega observability (catalog, resource, query/sql, connector-type, health/stats/inspect)
   context-loader Context-loader MCP (config, tools, resources, prompts, kn-search, query-*, etc.)

--- a/packages/typescript/src/commands/toolbox.ts
+++ b/packages/typescript/src/commands/toolbox.ts
@@ -291,7 +291,7 @@ async function runToolboxExport(args: string[]): Promise<number> {
   }
 
   const token = await ensureValidToken();
-  const body = await exportConfig({
+  const buf = await exportConfig({
     baseUrl: token.baseUrl,
     accessToken: token.accessToken,
     businessDomain: opts.businessDomain,
@@ -300,14 +300,14 @@ async function runToolboxExport(args: string[]): Promise<number> {
   });
 
   if (opts.output === "-") {
-    process.stdout.write(body);
-    if (!body.endsWith("\n")) process.stdout.write("\n");
+    process.stdout.write(buf);
+    if (buf.length === 0 || buf[buf.length - 1] !== 0x0a) process.stdout.write("\n");
     return 0;
   }
 
   const target = opts.output || `${opts.type}_${opts.boxId}.adp`;
-  await writeFile(target, body, "utf-8");
-  console.error(`Exported ${opts.type} ${opts.boxId} → ${target} (${body.length} bytes)`);
+  await writeFile(target, buf);
+  console.error(`Exported ${opts.type} ${opts.boxId} → ${target} (${buf.byteLength} bytes)`);
   return 0;
 }
 

--- a/packages/typescript/src/commands/toolbox.ts
+++ b/packages/typescript/src/commands/toolbox.ts
@@ -1,8 +1,19 @@
+import { writeFile } from "node:fs/promises";
 import { createInterface } from "node:readline";
 import { ensureValidToken, formatHttpError, with401RefreshRetry } from "../auth/oauth.js";
-import { createToolbox, deleteToolbox, listToolboxes, setToolboxStatus } from "../api/toolboxes.js";
+import {
+  createToolbox,
+  deleteToolbox,
+  exportConfig,
+  importConfig,
+  listToolboxes,
+  setToolboxStatus,
+  type ImpexType,
+} from "../api/toolboxes.js";
 import { formatCallOutput } from "./call.js";
 import { resolveBusinessDomain } from "../config/store.js";
+
+const VALID_IMPEX_TYPES: ReadonlySet<ImpexType> = new Set(["toolbox", "mcp", "operator"]);
 
 const HELP = `kweaver toolbox
 
@@ -12,6 +23,8 @@ Subcommands:
   publish <box-id>                                            Publish a toolbox (status=published)
   unpublish <box-id>                                          Unpublish (status=draft)
   delete <box-id> [-y|--yes]                                  Delete a toolbox
+  export <box-id> [-o <file>|-] [--type toolbox|mcp|operator] Export toolbox config (.adp JSON)
+  import <file> [--type toolbox|mcp|operator]                 Import a previously exported config
 
 Options:
   -bd, --biz-domain <s>   Business domain (default: bd_public)
@@ -31,6 +44,8 @@ export async function runToolboxCommand(args: string[]): Promise<number> {
     if (subcommand === "publish") return runToolboxSetStatus(rest, "published");
     if (subcommand === "unpublish") return runToolboxSetStatus(rest, "draft");
     if (subcommand === "delete") return runToolboxDelete(rest);
+    if (subcommand === "export") return runToolboxExport(rest);
+    if (subcommand === "import") return runToolboxImport(rest);
     return Promise.resolve(-1);
   };
 
@@ -230,5 +245,121 @@ async function runToolboxDelete(args: string[]): Promise<number> {
     boxId,
   });
   console.error(`Deleted toolbox ${boxId}`);
+  return 0;
+}
+
+// ── export / import ──────────────────────────────────────────────────────────
+
+export interface ToolboxExportOptions {
+  boxId: string;
+  output: string;          // file path; "-" for stdout; "" for default <type>_<id>.adp
+  type: ImpexType;
+  businessDomain: string;
+}
+
+export function parseToolboxExportArgs(args: string[]): ToolboxExportOptions {
+  let boxId = "";
+  let output = "";
+  let type: ImpexType = "toolbox";
+  let businessDomain = "";
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if ((a === "-o" || a === "--output") && args[i + 1] !== undefined) { output = args[++i]; continue; }
+    if (a === "--type" && args[i + 1]) {
+      const v = args[++i];
+      if (!VALID_IMPEX_TYPES.has(v as ImpexType)) {
+        throw new Error(`--type must be one of: ${[...VALID_IMPEX_TYPES].join(", ")}`);
+      }
+      type = v as ImpexType;
+      continue;
+    }
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
+    if (!a.startsWith("-")) { boxId = a; continue; }
+  }
+  if (!boxId) throw new Error("Missing required argument: <box-id>");
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+  return { boxId, output, type, businessDomain };
+}
+
+async function runToolboxExport(args: string[]): Promise<number> {
+  let opts: ToolboxExportOptions;
+  try { opts = parseToolboxExportArgs(args); }
+  catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    console.error("Usage: kweaver toolbox export <box-id> [-o <file>|-] [--type toolbox|mcp|operator]");
+    return 1;
+  }
+
+  const token = await ensureValidToken();
+  const body = await exportConfig({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    businessDomain: opts.businessDomain,
+    id: opts.boxId,
+    type: opts.type,
+  });
+
+  if (opts.output === "-") {
+    process.stdout.write(body);
+    if (!body.endsWith("\n")) process.stdout.write("\n");
+    return 0;
+  }
+
+  const target = opts.output || `${opts.type}_${opts.boxId}.adp`;
+  await writeFile(target, body, "utf-8");
+  console.error(`Exported ${opts.type} ${opts.boxId} → ${target} (${body.length} bytes)`);
+  return 0;
+}
+
+export interface ToolboxImportOptions {
+  filePath: string;
+  type: ImpexType;
+  businessDomain: string;
+  pretty: boolean;
+}
+
+export function parseToolboxImportArgs(args: string[]): ToolboxImportOptions {
+  let filePath = "";
+  let type: ImpexType = "toolbox";
+  let businessDomain = "";
+  let pretty = true;
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--type" && args[i + 1]) {
+      const v = args[++i];
+      if (!VALID_IMPEX_TYPES.has(v as ImpexType)) {
+        throw new Error(`--type must be one of: ${[...VALID_IMPEX_TYPES].join(", ")}`);
+      }
+      type = v as ImpexType;
+      continue;
+    }
+    if ((a === "-bd" || a === "--biz-domain") && args[i + 1]) { businessDomain = args[++i]; continue; }
+    if (a === "--pretty") { pretty = true; continue; }
+    if (a === "--compact") { pretty = false; continue; }
+    if (!a.startsWith("-")) { filePath = a; continue; }
+  }
+  if (!filePath) throw new Error("Missing required argument: <file>");
+  if (!businessDomain) businessDomain = resolveBusinessDomain();
+  return { filePath, type, businessDomain, pretty };
+}
+
+async function runToolboxImport(args: string[]): Promise<number> {
+  let opts: ToolboxImportOptions;
+  try { opts = parseToolboxImportArgs(args); }
+  catch (e) {
+    console.error(e instanceof Error ? e.message : String(e));
+    console.error("Usage: kweaver toolbox import <file> [--type toolbox|mcp|operator]");
+    return 1;
+  }
+
+  const token = await ensureValidToken();
+  const body = await importConfig({
+    baseUrl: token.baseUrl,
+    accessToken: token.accessToken,
+    businessDomain: opts.businessDomain,
+    filePath: opts.filePath,
+    type: opts.type,
+  });
+  console.log(formatCallOutput(body, opts.pretty));
   return 0;
 }

--- a/packages/typescript/src/config/store.ts
+++ b/packages/typescript/src/config/store.ts
@@ -982,12 +982,13 @@ export async function autoSelectBusinessDomain(
     }
     savePlatformBusinessDomain(baseUrl, selected);
     return selected;
-  } catch {
+  } catch (error) {
     // Endpoint may be unavailable on this deployment or for this account
-    // type — fall back silently. Set KWEAVER_DEBUG=1 to see the underlying
-    // error during diagnostics.
+    // type — fall back silently. Set KWEAVER_DEBUG=1 to surface the
+    // underlying error during diagnostics.
     if (process.env.KWEAVER_DEBUG) {
-      console.warn("Business domain list unavailable; defaulting to bd_public.");
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Business domain list unavailable (${message}); defaulting to bd_public.`);
     }
     return "bd_public";
   }

--- a/packages/typescript/src/config/store.ts
+++ b/packages/typescript/src/config/store.ts
@@ -982,9 +982,13 @@ export async function autoSelectBusinessDomain(
     }
     savePlatformBusinessDomain(baseUrl, selected);
     return selected;
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`Could not fetch business domains: ${message}. Using bd_public.`);
+  } catch {
+    // Endpoint may be unavailable on this deployment or for this account
+    // type — fall back silently. Set KWEAVER_DEBUG=1 to see the underlying
+    // error during diagnostics.
+    if (process.env.KWEAVER_DEBUG) {
+      console.warn("Business domain list unavailable; defaulting to bd_public.");
+    }
     return "bd_public";
   }
 }

--- a/packages/typescript/src/resources/toolboxes.ts
+++ b/packages/typescript/src/resources/toolboxes.ts
@@ -74,8 +74,14 @@ export class ToolboxesResource {
     });
   }
 
-  /** Export a toolbox/mcp/operator config (.adp JSON) and return its raw text. */
-  async exportConfig(id: string, opts: { type?: ImpexType } = {}): Promise<string> {
+  /**
+   * Export a toolbox/mcp/operator config (.adp JSON) as raw bytes.
+   *
+   * Returned bytes are usually UTF-8 JSON; mirrors the Python SDK's
+   * `export_config -> bytes`. Use `new TextDecoder().decode(buf)` if you
+   * need a string.
+   */
+  async exportConfig(id: string, opts: { type?: ImpexType } = {}): Promise<Uint8Array> {
     return exportConfig({ ...this.ctx.base(), id, type: opts.type });
   }
 

--- a/packages/typescript/src/resources/toolboxes.ts
+++ b/packages/typescript/src/resources/toolboxes.ts
@@ -2,10 +2,13 @@ import type { ClientContext } from "../client.js";
 import {
   debugTool,
   executeTool,
+  exportConfig,
+  importConfig,
   listTools,
   listToolboxes,
   setToolStatuses,
   uploadTool,
+  type ImpexType,
 } from "../api/toolboxes.js";
 
 export interface InvokeToolArgs {
@@ -69,6 +72,16 @@ export class ToolboxesResource {
       toolId,
       ...this.injectAuth(args),
     });
+  }
+
+  /** Export a toolbox/mcp/operator config (.adp JSON) and return its raw text. */
+  async exportConfig(id: string, opts: { type?: ImpexType } = {}): Promise<string> {
+    return exportConfig({ ...this.ctx.base(), id, type: opts.type });
+  }
+
+  /** Import a previously exported config from disk. */
+  async importConfig(filePath: string, opts: { type?: ImpexType } = {}): Promise<string> {
+    return importConfig({ ...this.ctx.base(), filePath, type: opts.type });
   }
 
   // The forwarder requires every header the downstream tool expects to be set

--- a/packages/typescript/test/toolbox-impex.test.ts
+++ b/packages/typescript/test/toolbox-impex.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { exportConfig, importConfig } from "../src/api/toolboxes.js";
@@ -18,18 +18,33 @@ function mockFetch(handler: (url: RequestInfo | URL, init?: RequestInit) => Prom
 
 // ── api/toolboxes.ts ─────────────────────────────────────────────────────────
 
-test("exportConfig GETs /impex/export/{type}/{id} and returns raw body", async () => {
+test("exportConfig GETs /impex/export/{type}/{id} and returns raw bytes", async () => {
   let captured: { url: string; init?: RequestInit } | null = null;
   const restore = mockFetch(async (url, init) => {
     captured = { url: String(url), init };
     return new Response('{"box":"b1"}', { status: 200, headers: { "content-type": "application/json" } });
   });
   try {
-    const body = await exportConfig({ baseUrl: BASE, accessToken: TOKEN, id: "b1" });
-    assert.equal(body, '{"box":"b1"}');
+    const buf = await exportConfig({ baseUrl: BASE, accessToken: TOKEN, id: "b1" });
+    assert.ok(buf instanceof Uint8Array, "exportConfig must return Uint8Array");
+    assert.equal(new TextDecoder("utf-8").decode(buf), '{"box":"b1"}');
     assert.ok(captured);
     assert.equal(captured!.url, `${BASE}${IMPEX}/export/toolbox/b1`);
     assert.equal(captured!.init?.method, "GET");
+  } finally { restore(); }
+});
+
+test("exportConfig preserves multi-byte payloads byte-for-byte (no string round-trip loss)", async () => {
+  // Chinese name in the .adp content — verifies we don't go through `string`.
+  const payload = '{"name":"基础结构化数据分析工具箱2"}';
+  const expectedBytes = new TextEncoder().encode(payload);
+  const restore = mockFetch(async () =>
+    new Response(expectedBytes, { status: 200, headers: { "content-type": "application/json" } })
+  );
+  try {
+    const buf = await exportConfig({ baseUrl: BASE, accessToken: TOKEN, id: "b1" });
+    assert.equal(buf.byteLength, expectedBytes.byteLength);
+    assert.deepEqual(Array.from(buf), Array.from(expectedBytes));
   } finally { restore(); }
 });
 

--- a/packages/typescript/test/toolbox-impex.test.ts
+++ b/packages/typescript/test/toolbox-impex.test.ts
@@ -1,0 +1,124 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { exportConfig, importConfig } from "../src/api/toolboxes.js";
+import { parseToolboxExportArgs, parseToolboxImportArgs } from "../src/commands/toolbox.js";
+
+const BASE = "https://platform.example";
+const TOKEN = "tok-impex";
+const IMPEX = "/api/agent-operator-integration/v1/impex";
+
+function mockFetch(handler: (url: RequestInfo | URL, init?: RequestInit) => Promise<Response>) {
+  const original = globalThis.fetch;
+  globalThis.fetch = handler as typeof fetch;
+  return () => { globalThis.fetch = original; };
+}
+
+// ── api/toolboxes.ts ─────────────────────────────────────────────────────────
+
+test("exportConfig GETs /impex/export/{type}/{id} and returns raw body", async () => {
+  let captured: { url: string; init?: RequestInit } | null = null;
+  const restore = mockFetch(async (url, init) => {
+    captured = { url: String(url), init };
+    return new Response('{"box":"b1"}', { status: 200, headers: { "content-type": "application/json" } });
+  });
+  try {
+    const body = await exportConfig({ baseUrl: BASE, accessToken: TOKEN, id: "b1" });
+    assert.equal(body, '{"box":"b1"}');
+    assert.ok(captured);
+    assert.equal(captured!.url, `${BASE}${IMPEX}/export/toolbox/b1`);
+    assert.equal(captured!.init?.method, "GET");
+  } finally { restore(); }
+});
+
+test("exportConfig honors --type=mcp", async () => {
+  let url = "";
+  const restore = mockFetch(async (u) => {
+    url = String(u);
+    return new Response("{}", { status: 200 });
+  });
+  try {
+    await exportConfig({ baseUrl: BASE, accessToken: TOKEN, id: "m1", type: "mcp" });
+    assert.equal(url, `${BASE}${IMPEX}/export/mcp/m1`);
+  } finally { restore(); }
+});
+
+test("importConfig POSTs multipart with field 'data' to /impex/import/{type}", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "kw-impex-"));
+  const file = join(dir, "toolbox_b1.adp");
+  writeFileSync(file, '{"hello":"world"}', "utf-8");
+
+  let captured: { url: string; init?: RequestInit } | null = null;
+  const restore = mockFetch(async (url, init) => {
+    captured = { url: String(url), init };
+    return new Response('{"ok":true}', { status: 200 });
+  });
+  try {
+    const body = await importConfig({ baseUrl: BASE, accessToken: TOKEN, filePath: file });
+    assert.equal(body, '{"ok":true}');
+    assert.ok(captured);
+    assert.equal(captured!.url, `${BASE}${IMPEX}/import/toolbox`);
+    assert.equal(captured!.init?.method, "POST");
+    const form = captured!.init?.body as FormData;
+    assert.ok(form instanceof FormData, "body must be FormData");
+    const part = form.get("data");
+    assert.ok(part instanceof Blob, "field 'data' must be a Blob");
+    const text = await (part as Blob).text();
+    assert.equal(text, '{"hello":"world"}');
+  } finally {
+    restore();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── CLI parsing ──────────────────────────────────────────────────────────────
+
+test("parseToolboxExportArgs requires <box-id>", () => {
+  assert.throws(() => parseToolboxExportArgs([]), /box-id/);
+});
+
+test("parseToolboxExportArgs defaults: type=toolbox, output=''", () => {
+  const opts = parseToolboxExportArgs(["b1"]);
+  assert.equal(opts.boxId, "b1");
+  assert.equal(opts.type, "toolbox");
+  assert.equal(opts.output, "");
+});
+
+test("parseToolboxExportArgs parses -o, --type, -bd", () => {
+  const opts = parseToolboxExportArgs(["b1", "-o", "out.adp", "--type", "operator", "-bd", "bd_x"]);
+  assert.equal(opts.output, "out.adp");
+  assert.equal(opts.type, "operator");
+  assert.equal(opts.businessDomain, "bd_x");
+});
+
+test("parseToolboxExportArgs rejects unknown --type", () => {
+  assert.throws(() => parseToolboxExportArgs(["b1", "--type", "weird"]), /--type must be/);
+});
+
+test("parseToolboxExportArgs supports -o - for stdout", () => {
+  const opts = parseToolboxExportArgs(["b1", "-o", "-"]);
+  assert.equal(opts.output, "-");
+});
+
+test("parseToolboxImportArgs requires <file>", () => {
+  assert.throws(() => parseToolboxImportArgs([]), /file/);
+});
+
+test("parseToolboxImportArgs defaults type=toolbox, pretty=true", () => {
+  const opts = parseToolboxImportArgs(["./x.adp"]);
+  assert.equal(opts.filePath, "./x.adp");
+  assert.equal(opts.type, "toolbox");
+  assert.equal(opts.pretty, true);
+});
+
+test("parseToolboxImportArgs parses --type and --compact", () => {
+  const opts = parseToolboxImportArgs(["x.adp", "--type", "mcp", "--compact"]);
+  assert.equal(opts.type, "mcp");
+  assert.equal(opts.pretty, false);
+});
+
+test("parseToolboxImportArgs rejects unknown --type", () => {
+  assert.throws(() => parseToolboxImportArgs(["x.adp", "--type", "weird"]), /--type must be/);
+});

--- a/skills/kweaver-core/references/toolbox.md
+++ b/skills/kweaver-core/references/toolbox.md
@@ -13,7 +13,12 @@ kweaver toolbox list   [--keyword <s>] [--limit <n>] [--offset <n>] [-bd value] 
 kweaver toolbox publish   <box-id> [-bd value]
 kweaver toolbox unpublish <box-id> [-bd value]
 kweaver toolbox delete    <box-id> [-y|--yes] [-bd value]
+kweaver toolbox export    <box-id> [-o <file>|-] [--type toolbox|mcp|operator] [-bd value]
+kweaver toolbox import    <file>   [--type toolbox|mcp|operator] [-bd value] [--pretty|--compact]
 ```
+
+> `export` / `import` 走的是另一组后端入口 `/api/agent-operator-integration/v1/impex/{export|import}/{type}/...`，
+> 与上面 `tool-box` 系列接口共用同一个服务，但不在同一个 path 下。
 
 ## 子命令说明
 
@@ -64,6 +69,38 @@ kweaver toolbox unpublish 1234567890123456789
 kweaver toolbox delete 1234567890123456789          # 交互式
 kweaver toolbox delete 1234567890123456789 -y       # 自动确认
 ```
+
+### `export`
+
+- 拉取一个 toolbox / mcp / operator 的完整配置（`.adp` JSON 文件），用于跨环境迁移或备份。
+- `--type` 默认 `toolbox`，可改为 `mcp` 或 `operator`。
+- `-o <file>` 指定输出文件名；`-o -` 写到 stdout；省略则落到当前目录的 `<type>_<id>.adp`。
+- 成功在 stderr 打印 `Exported <type> <id> → <file> (<n> bytes)`，stdout 留给文件内容（仅当 `-o -` 时）。
+
+```bash
+# 导出 toolbox 到默认文件名
+kweaver toolbox export 1234567890123456789
+# → toolbox_1234567890123456789.adp
+
+# 自定义文件名
+kweaver toolbox export 1234567890123456789 -o my-backup.adp
+
+# 直接 piped 到 jq
+kweaver toolbox export 1234567890123456789 -o - | jq '.box_name'
+```
+
+### `import`
+
+- 把 `export` 拉下来的 `.adp` 文件回灌到目标环境。
+- multipart 上传，字段名 `data`（与后端 `ImportConfig` 约定一致）。
+- 成功输出后端响应（典型形如 `{"box_id": "..."}` 或 `{"imported": true}`），按 `--pretty`/`--compact` 格式化。
+
+```bash
+kweaver toolbox import my-backup.adp
+kweaver toolbox import my-backup.adp --type mcp --compact
+```
+
+> ⚠️ 导入会在目标环境**新建**对应实体（box/mcp/operator），不会就地更新。若已存在同名/同 ID 实体，按后端策略可能报冲突，请先 `delete` 或换 ID。
 
 ## 通用选项
 


### PR DESCRIPTION
## Summary
- New `kweaver toolbox export <box-id>` / `kweaver toolbox import <file>` CLI commands wrapping `/api/agent-operator-integration/v1/impex/{export,import}/{type}` for `toolbox` / `mcp` / `operator` payloads. Export streams the raw config to a file or stdout (`--output -`); import uploads multipart form-data with the local `.adp`.
- Matching `export_config` / `import_config` methods on the TypeScript and Python SDK resource layers, with full unit-test coverage (URL shape, multipart body, CLI parsing).
- Quiet the noisy `Could not fetch business domains: HTTP 404 Not Found. Using bd_public.` warning: silent by default, generic note only when `KWEAVER_DEBUG=1`. Mirrored in TS (`config/store.ts`) and Python (`business_domains.py`).
- Docs: refreshed `skills/kweaver-core/references/toolbox.md` and top-level CLI help with the new subcommands and caveats (import creates new entities; conflicts surface as 409).
- Version bumped to **0.6.11** in `package.json`, `package-lock.json`, `pyproject.toml`, `uv.lock`.

## Test plan
- `make -C packages/typescript test` — 748 passed (incl. new `toolbox-impex.test.ts`).
- `make -C packages/python test` — 401 passed.
- E2E on `https://43.129.210.161` with `cli-test-1776796301`:
  - `toolbox import 基础结构化数据分析工具箱2.adp` → success
  - `toolbox export <id> --output /tmp/exported.adp` → 89 KB UTF-8 written
  - `toolbox delete <id> -y` → success
  - Re-import the exported `.adp` → same `box_id` reappears in `toolbox list`

Made with [Cursor](https://cursor.com)