### PR TITLE
feat(context-loader): add find_skills MCP wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ kweaver agent list/get/create/update/delete/chat/sessions/history/publish/unpubl
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
 kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
 kweaver context-loader config set/use/list/show
-kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/...
+kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/find-skills/...
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-bd domain]
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -273,7 +273,7 @@ kweaver agent list/get/get-by-key/create/update/delete/chat/sessions/history/pub
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
 kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
 kweaver context-loader config set/use/list/show
-kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/...
+kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/find-skills/...
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-bd domain]
 ```
 

--- a/packages/python/src/kweaver/resources/context_loader.py
+++ b/packages/python/src/kweaver/resources/context_loader.py
@@ -300,6 +300,42 @@ class ContextLoaderResource:
             "_instance_identity": instance_identity,
         })
 
+    def find_skills(
+        self,
+        object_type_id: str,
+        *,
+        skill_query: str | None = None,
+        top_k: int | None = None,
+        instance_identities: list[dict[str, Any]] | None = None,
+        response_format: Literal["json", "toon"] | None = None,
+    ) -> dict[str, Any]:
+        """Recall skills attached to an object type via the find_skills MCP tool.
+
+        Args:
+            object_type_id: Required object type id whose skills should be recalled.
+            skill_query: Optional natural-language query to narrow recall.
+            top_k: Optional 1..20 cap on returned skills.
+            instance_identities: Optional list of instance identities to scope recall.
+            response_format: Optional output format ("json" or "toon").
+
+        Returns:
+            Tool payload with ``entries`` and an optional ``message``.
+        """
+        if not object_type_id:
+            raise ValueError("find_skills: object_type_id is required.")
+        if top_k is not None and not (1 <= top_k <= 20):
+            raise ValueError("find_skills: top_k must be between 1 and 20.")
+        args: dict[str, Any] = {"object_type_id": object_type_id}
+        if response_format is not None:
+            args["response_format"] = response_format
+        if instance_identities is not None:
+            args["instance_identities"] = instance_identities
+        if skill_query is not None:
+            args["skill_query"] = skill_query
+        if top_k is not None:
+            args["top_k"] = top_k
+        return self._call_tool("find_skills", args)
+
     # ── MCP introspection ────────────────────────────────────────────────────
 
     def list_tools(self, cursor: str | None = None) -> dict[str, Any]:

--- a/packages/python/tests/unit/test_context_loader.py
+++ b/packages/python/tests/unit/test_context_loader.py
@@ -307,6 +307,42 @@ def test_get_action_info_returns_dynamic_tools():
         pass
 
 
+# ── Layer 3: find_skills ─────────────────────────────────────────────────────
+
+
+def test_find_skills_sends_required_and_optional_args():
+    """find_skills: passes object_type_id and only the optional fields that were set."""
+    expected = {"entries": [{"skill_id": "sk1", "name": "Skill 1"}]}
+    cl, transport = _make_cl([_tool_response(expected)])
+    try:
+        result = cl.find_skills(
+            "ot_drug",
+            skill_query="treatment",
+            top_k=5,
+        )
+        assert result["entries"][0]["skill_id"] == "sk1"
+        tool_request = transport.requests[-1]
+        assert tool_request["params"]["name"] == "find_skills"
+        assert tool_request["params"]["arguments"] == {
+            "object_type_id": "ot_drug",
+            "skill_query": "treatment",
+            "top_k": 5,
+        }
+    finally:
+        pass
+
+
+def test_find_skills_validates_inputs():
+    """find_skills: rejects empty object_type_id and out-of-range top_k."""
+    cl, _ = _make_cl([])
+    with pytest.raises(ValueError, match="object_type_id is required"):
+        cl.find_skills("")
+    with pytest.raises(ValueError, match="top_k must be between 1 and 20"):
+        cl.find_skills("ot", top_k=0)
+    with pytest.raises(ValueError, match="top_k must be between 1 and 20"):
+        cl.find_skills("ot", top_k=21)
+
+
 # ── MCP introspection ─────────────────────────────────────────────────────────
 
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -189,7 +189,7 @@ kweaver agent list/get/create/update/delete/chat/sessions/history/publish/unpubl
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
 kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
 kweaver context-loader config set/use/list/show
-kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/...
+kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/find-skills/...
 kweaver toolbox create/list/publish/unpublish/delete
 kweaver tool upload/list/enable/disable
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-F key=value]

--- a/packages/typescript/README.zh.md
+++ b/packages/typescript/README.zh.md
@@ -177,7 +177,7 @@ kweaver agent list/get/chat/sessions/history
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
 kweaver vega health|stats|inspect|sql|catalog|resource|connector-type
 kweaver context-loader config set/use/list/show
-kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/...
+kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/find-skills/...
 kweaver call <path> [-X METHOD] [-d BODY] [-H header]
 ```
 

--- a/packages/typescript/src/api/context-loader.ts
+++ b/packages/typescript/src/api/context-loader.ts
@@ -157,6 +157,22 @@ export interface GetActionInfoArgs {
   _instance_identity: Record<string, string>;
 }
 
+/** Layer 3: find_skills arguments (object_type_id is required). */
+export interface FindSkillsArgs {
+  object_type_id: string;
+  response_format?: "json" | "toon";
+  instance_identities?: Record<string, unknown>[];
+  skill_query?: string;
+  /** 1..20, default 10 on the server side. */
+  top_k?: number;
+}
+
+/** Layer 3: find_skills result. */
+export interface FindSkillsResult {
+  entries: Array<{ skill_id: string; name: string; description?: string }>;
+  message?: string;
+}
+
 /** Error when get_logic_properties_values returns MISSING_INPUT_PARAMS. */
 export interface MissingInputParamsError {
   error_code: "MISSING_INPUT_PARAMS";
@@ -402,6 +418,33 @@ export async function getActionInfo(
 ): Promise<unknown> {
   validateInstanceIdentity(args._instance_identity, "_instance_identity");
   return callTool(options, "get_action_info", { ...args });
+}
+
+/**
+ * Layer 3: find_skills. Recall skills attached to an object type or
+ * (optionally) narrowed to specific instances.
+ */
+export async function findSkills(
+  options: ContextLoaderCallOptions,
+  args: FindSkillsArgs
+): Promise<FindSkillsResult> {
+  if (!args.object_type_id || typeof args.object_type_id !== "string") {
+    throw new Error("find_skills: object_type_id is required.");
+  }
+  if (args.top_k !== undefined && (args.top_k < 1 || args.top_k > 20)) {
+    throw new Error("find_skills: top_k must be between 1 and 20.");
+  }
+  if (args.instance_identities !== undefined) {
+    validateInstanceIdentities(args.instance_identities);
+  }
+  const toolArgs: Record<string, unknown> = {
+    object_type_id: args.object_type_id,
+  };
+  if (args.response_format !== undefined) toolArgs.response_format = args.response_format;
+  if (args.instance_identities !== undefined) toolArgs.instance_identities = args.instance_identities;
+  if (args.skill_query !== undefined) toolArgs.skill_query = args.skill_query;
+  if (args.top_k !== undefined) toolArgs.top_k = args.top_k;
+  return (await callTool(options, "find_skills", toolArgs)) as FindSkillsResult;
 }
 
 /** MCP tools/list. Returns list of available tools. */

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -130,7 +130,7 @@ Usage:
   kweaver context-loader tool-call <name> --args '<json>'
   kweaver context-loader kn-search <query> [--only-schema]      (compat HTTP)
   kweaver context-loader kn-schema-search <query> [--max N]     (compat HTTP)
-  kweaver context-loader query-object-instance|query-instance-subgraph|get-logic-properties|get-action-info ...
+  kweaver context-loader query-object-instance|query-instance-subgraph|get-logic-properties|get-action-info|find-skills ...
   (alias: kweaver context ...)
 
 Global options:

--- a/packages/typescript/src/commands/context-loader.ts
+++ b/packages/typescript/src/commands/context-loader.ts
@@ -7,6 +7,7 @@ import {
   queryInstanceSubgraph,
   getLogicPropertiesValues,
   getActionInfo,
+  findSkills,
   listTools,
   listResources,
   readResource,
@@ -86,6 +87,7 @@ Subcommands:
   query-instance-subgraph <json>       Layer 2: Query subgraph (args as JSON)
   get-logic-properties <json>          Layer 3: Get logic property values (args as JSON)
   get-action-info <json>               Layer 3: Get action info (args as JSON)
+  find-skills <ot_id> [options]        Layer 3: Recall skills for an object type
 
 Examples:
   kweaver context-loader config set --kn-id d5iv6c9818p72mpje8pg
@@ -126,6 +128,7 @@ Examples:
     if (subcommand === "query-instance-subgraph") return runQueryInstanceSubgraph(options, rest, pretty);
     if (subcommand === "get-logic-properties") return runGetLogicProperties(options, rest, pretty);
     if (subcommand === "get-action-info") return runGetActionInfo(options, rest, pretty);
+    if (subcommand === "find-skills") return runFindSkills(options, rest, pretty);
     return -1;
   };
 
@@ -663,6 +666,74 @@ async function runGetActionInfo(
     return 1;
   }
   const result = await getActionInfo(options, body);
+  console.log(formatOutput(result, pretty));
+  return 0;
+}
+
+async function runFindSkills(
+  options: { mcpUrl: string; knId: string; accessToken: string },
+  args: string[],
+  pretty: boolean
+): Promise<number> {
+  const usage =
+    "Usage: kweaver context-loader find-skills <object_type_id> " +
+    "[--query <text>] [--top-k N] [--instance-identities <json>] [--format json|toon]";
+
+  let objectTypeId: string | undefined;
+  let skillQuery: string | undefined;
+  let topK: number | undefined;
+  let instanceIdentities: Record<string, unknown>[] | undefined;
+  let responseFormat: "json" | "toon" | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if ((arg === "--query" || arg === "-q") && args[i + 1]) {
+      skillQuery = args[i + 1];
+      i += 1;
+    } else if ((arg === "--top-k" || arg === "-n") && args[i + 1]) {
+      topK = parseInt(args[i + 1], 10);
+      if (!Number.isFinite(topK)) {
+        console.error(usage);
+        return 1;
+      }
+      i += 1;
+    } else if ((arg === "--instance-identities" || arg === "-i") && args[i + 1]) {
+      try {
+        const parsed = JSON.parse(args[i + 1]) as unknown;
+        if (!Array.isArray(parsed)) {
+          throw new Error("--instance-identities must be a JSON array");
+        }
+        instanceIdentities = parsed as Record<string, unknown>[];
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        return 1;
+      }
+      i += 1;
+    } else if ((arg === "--format" || arg === "-f") && args[i + 1]) {
+      const value = args[i + 1];
+      if (value !== "json" && value !== "toon") {
+        console.error(usage);
+        return 1;
+      }
+      responseFormat = value;
+      i += 1;
+    } else if (!arg.startsWith("-") && !objectTypeId) {
+      objectTypeId = arg;
+    }
+  }
+
+  if (!objectTypeId) {
+    console.error(usage);
+    return 1;
+  }
+
+  const result = await findSkills(options, {
+    object_type_id: objectTypeId,
+    skill_query: skillQuery,
+    top_k: topK,
+    instance_identities: instanceIdentities,
+    response_format: responseFormat,
+  });
   console.log(formatOutput(result, pretty));
   return 0;
 }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -130,6 +130,8 @@ export type {
   QueryInstanceSubgraphArgs,
   GetLogicPropertiesValuesArgs,
   GetActionInfoArgs,
+  FindSkillsArgs,
+  FindSkillsResult,
   MissingInputParamsError,
 } from "./api/context-loader.js";
 export {
@@ -139,6 +141,7 @@ export {
   queryInstanceSubgraph,
   getLogicPropertiesValues,
   getActionInfo,
+  findSkills,
   formatMissingInputParamsHint,
   validateCondition,
   validateInstanceIdentity,

--- a/packages/typescript/src/resources/context-loader.ts
+++ b/packages/typescript/src/resources/context-loader.ts
@@ -5,6 +5,7 @@ import {
   queryInstanceSubgraph,
   getLogicPropertiesValues,
   getActionInfo,
+  findSkills,
 } from "../api/context-loader.js";
 import type {
   SearchSchemaArgs,
@@ -12,6 +13,8 @@ import type {
   QueryInstanceSubgraphArgs,
   GetLogicPropertiesValuesArgs,
   GetActionInfoArgs,
+  FindSkillsArgs,
+  FindSkillsResult,
 } from "../api/context-loader.js";
 import type { ClientContext } from "../client.js";
 
@@ -54,5 +57,9 @@ export class ContextLoaderResource {
 
   async getActionInfo(args: GetActionInfoArgs): Promise<unknown> {
     return getActionInfo(this.opts(), args);
+  }
+
+  async findSkills(args: FindSkillsArgs): Promise<FindSkillsResult> {
+    return findSkills(this.opts(), args);
   }
 }

--- a/packages/typescript/test/context-loader.test.ts
+++ b/packages/typescript/test/context-loader.test.ts
@@ -8,6 +8,7 @@ import {
   validateInstanceIdentities,
   callTool,
   searchSchema,
+  findSkills,
   listTools,
   listResources,
   readResource,
@@ -239,6 +240,73 @@ test("searchSchema preserves explicit toon response format", async () => {
   } finally {
     globalThis.fetch = originalFetch;
   }
+});
+
+test("findSkills sends find_skills with required object_type_id and optional fields", async () => {
+  const received: { body: string }[] = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_input, init) => {
+    const body = (init as RequestInit)?.body as string;
+    received.push({ body });
+    const parsed = body ? (JSON.parse(body) as { method?: string }) : {};
+    if (parsed.method === "initialize") {
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2024-11-05", capabilities: {} } }),
+        { headers: { "Content-Type": "application/json", "MCP-Session-Id": "session-find" } }
+      );
+    }
+    if (parsed.method === "notifications/initialized") {
+      return new Response("", { status: 200 });
+    }
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        result: {
+          content: [
+            { type: "text", text: JSON.stringify({ entries: [{ skill_id: "s1", name: "Skill 1" }] }) },
+          ],
+        },
+        id: 1,
+      }),
+      { headers: { "Content-Type": "application/json" } }
+    );
+  };
+
+  try {
+    const result = await findSkills(
+      { mcpUrl: "https://mcp.example.com/mcp", knId: "kn-1", accessToken: "tok" },
+      { object_type_id: "ot_drug", skill_query: "treatment", top_k: 5 }
+    );
+    assert.equal(result.entries.length, 1);
+    assert.equal(result.entries[0].skill_id, "s1");
+    const parsed = JSON.parse(received[2].body);
+    assert.equal(parsed.params.name, "find_skills");
+    assert.equal(parsed.params.arguments.object_type_id, "ot_drug");
+    assert.equal(parsed.params.arguments.skill_query, "treatment");
+    assert.equal(parsed.params.arguments.top_k, 5);
+    assert.equal(parsed.params.arguments.instance_identities, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("findSkills rejects missing object_type_id and invalid top_k", async () => {
+  await assert.rejects(
+    () =>
+      findSkills(
+        { mcpUrl: "https://mcp.example.com/mcp", knId: "kn-1", accessToken: "tok" },
+        { object_type_id: "" }
+      ),
+    /object_type_id is required/
+  );
+  await assert.rejects(
+    () =>
+      findSkills(
+        { mcpUrl: "https://mcp.example.com/mcp", knId: "kn-1", accessToken: "tok" },
+        { object_type_id: "ot", top_k: 0 }
+      ),
+    /top_k must be between 1 and 20/
+  );
 });
 
 function installMcpListFetchMock(

--- a/skills/kweaver-core/references/context-loader.md
+++ b/skills/kweaver-core/references/context-loader.md
@@ -63,16 +63,76 @@ kweaver context-loader get-logic-properties '{"ot_id": "ot-1", "query": "status"
 
 # 获取 Action 信息
 kweaver context-loader get-action-info '{"at_id": "at-1", "_instance_identity": {"id": "123"}}'
-
-# 召回某个对象类下的 Skill（top_k 范围 1..20，默认 10）
-kweaver context-loader find-skills ot_drug --query "treatment" --top-k 5
-# 可选：缩小到具体实例
-kweaver context-loader find-skills ot_drug \
-  --instance-identities '[{"drug_id": "DRUG_001"}]' \
-  --format json
 ```
 
-> SDK 等价方法：TS `client.contextLoader.findSkills({ object_type_id, ... })`，Python `client.context_loader.find_skills("ot_drug", skill_query=..., top_k=...)`。`object_type_id` 必填，`top_k` 必须在 1..20 之间，`response_format` 仅接受 `"json"` / `"toon"`。
+### find-skills — 召回对象类下的 Skill
+
+按对象类（可选缩小到具体实例）召回挂载的 Skill。对应 MCP tool `find_skills`，0.7.0 起可用。
+
+```bash
+# 仅按对象类召回（top_k 默认 10）
+kweaver context-loader find-skills ot_drug
+
+# 加自然语言查询和 top_k
+kweaver context-loader find-skills ot_drug --query "treatment" --top-k 5
+
+# 缩小到具体实例 + 切到 toon 输出
+kweaver context-loader find-skills ot_drug \
+  --instance-identities '[{"drug_id": "DRUG_001"}]' \
+  --format toon
+```
+
+**CLI 参数**
+
+| 参数 | 必填 | 说明 |
+|------|:----:|------|
+| `<object_type_id>` | ✅ | 位置参数，对象类 id |
+| `--query / -q <text>` | | 自然语言查询，缩小召回范围 |
+| `--top-k / -n <N>` | | 1..20，默认 10 |
+| `--instance-identities / -i '<json-array>'` | | 实例身份数组（来自 Layer 2 `_instance_identity`） |
+| `--format / -f json\|toon` | | 输出格式，默认 `json` |
+
+**返回结构**
+
+```json
+{
+  "entries": [
+    { "skill_id": "sk_xxx", "name": "Skill 1", "description": "..." }
+  ],
+  "message": "..."
+}
+```
+
+**SDK 等价**
+
+```ts
+// TypeScript
+const result = await client.contextLoader.findSkills({
+  object_type_id: "ot_drug",
+  skill_query: "treatment",
+  top_k: 5,
+  // instance_identities: [{ drug_id: "DRUG_001" }],
+  // response_format: "json",
+});
+```
+
+```python
+# Python
+result = client.context_loader.find_skills(
+    "ot_drug",
+    skill_query="treatment",
+    top_k=5,
+    # instance_identities=[{"drug_id": "DRUG_001"}],
+    # response_format="json",
+)
+```
+
+**校验规则（client side）**
+
+- `object_type_id` 必填，空字符串直接抛错。
+- `top_k`（若提供）必须在 `[1, 20]`，否则抛错；不传时由服务端按默认 10 处理。
+- `instance_identities`（若提供）必须是数组，每个元素是普通对象（复用 `validateInstanceIdentities`）。
+- `response_format` 仅接受 `"json"` / `"toon"`。
 
 ## JSON 格式
 

--- a/skills/kweaver-core/references/context-loader.md
+++ b/skills/kweaver-core/references/context-loader.md
@@ -63,7 +63,16 @@ kweaver context-loader get-logic-properties '{"ot_id": "ot-1", "query": "status"
 
 # 获取 Action 信息
 kweaver context-loader get-action-info '{"at_id": "at-1", "_instance_identity": {"id": "123"}}'
+
+# 召回某个对象类下的 Skill（top_k 范围 1..20，默认 10）
+kweaver context-loader find-skills ot_drug --query "treatment" --top-k 5
+# 可选：缩小到具体实例
+kweaver context-loader find-skills ot_drug \
+  --instance-identities '[{"drug_id": "DRUG_001"}]' \
+  --format json
 ```
+
+> SDK 等价方法：TS `client.contextLoader.findSkills({ object_type_id, ... })`，Python `client.context_loader.find_skills("ot_drug", skill_query=..., top_k=...)`。`object_type_id` 必填，`top_k` 必须在 1..20 之间，`response_format` 仅接受 `"json"` / `"toon"`。
 
 ## JSON 格式
 


### PR DESCRIPTION
## Summary
- 补齐 `context-loader` 0.7.0 `tools_meta.json` 中唯一缺失的类型化封装：`find_skills`。
- TS：`api/context-loader.ts` 新增 `FindSkillsArgs` / `FindSkillsResult` + `findSkills()`；`ContextLoaderResource.findSkills()`；CLI `kweaver context-loader find-skills <ot_id> [--query --top-k --instance-identities --format]`；`index.ts` 同步导出。
- Py：`ContextLoaderResource.find_skills(object_type_id, *, skill_query, top_k, instance_identities, response_format)`，附 `object_type_id` 必填 / `top_k ∈ [1,20]` 校验。
- 文档：`skills/kweaver-core/references/context-loader.md` Layer 3 段补 CLI 示例与 SDK 指引。
- 测试：TS + Py 各 2 个单元测试覆盖请求体 + 输入校验。

## Test plan
- [x] `make -C packages/typescript test` — 738 passed
- [x] `make -C packages/python test` — 399 passed