### PR TITLE
fix(ds): dedup ds connect by tuple and surface name conflicts (#93)

### DIFF
--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -61,6 +61,7 @@ Usage:
   kweaver ds delete <id> [-y]
   kweaver ds tables <id> [--keyword X]
   kweaver ds connect <db_type> <host> <port> <database> --account X --password Y [--schema S] [--name N]
+                     [--reuse-existing|--force-new]
 
   kweaver dataflow list [-bd value]
   kweaver dataflow run <dagId> (--file <path> | --url <remote-url> --name <filename>) [-bd value]

--- a/packages/typescript/src/commands/ds.ts
+++ b/packages/typescript/src/commands/ds.ts
@@ -54,7 +54,10 @@ Subcommands:
   delete <id> [-y]                  Delete a datasource
   tables <id> [--keyword X]         List tables with columns
   connect <db_type> <host> <port> <database> --account X --password Y [--schema Z] [--name N]
+                                              [--reuse-existing|--force-new]
     Test connectivity, register datasource, and discover tables.
+    By default reuses an existing ds with the same (type, host, port, database, account)
+    instead of creating a duplicate. --force-new always creates a new entry.
   import-csv <ds-id> --files <glob_or_list> [--table-prefix X] [--batch-size N]
     Import CSV files into datasource tables via dataflow API.`);
     return 0;
@@ -229,6 +232,95 @@ async function runDsTablesCommand(args: string[]): Promise<number> {
   return 0;
 }
 
+/**
+ * Match candidate signature against a list response (the kind returned by
+ * `listDatasources`). Connection metadata lives under `bin_data` — host,
+ * port, account, plus type-specific fields (`database_name` for MySQL etc.).
+ *
+ * Exported for unit testing.
+ */
+export interface DsMatchSignature {
+  type: string;
+  host: string;
+  port: number;
+  database: string;
+  account: string;
+  name?: string;
+}
+
+export interface DsMatchHit {
+  id: string;
+  name: string;
+  matchedByName: boolean;
+  matchedByTuple: boolean;
+}
+
+interface DsListEntry {
+  id?: string;
+  name?: string;
+  type?: string;
+  bin_data?: {
+    host?: string;
+    port?: number;
+    account?: string;
+    database_name?: string;
+    schema_name?: string;
+  };
+}
+
+export function findExistingDatasource(
+  listBody: string,
+  sig: DsMatchSignature,
+): DsMatchHit | undefined {
+  const parsed = JSON.parse(listBody) as { entries?: DsListEntry[] } | DsListEntry[];
+  const entries = Array.isArray(parsed) ? parsed : (parsed.entries ?? []);
+  const tupleMatch = entries.find(
+    (e) =>
+      e.id &&
+      e.type === sig.type &&
+      e.bin_data?.host === sig.host &&
+      Number(e.bin_data?.port) === Number(sig.port) &&
+      e.bin_data?.database_name === sig.database &&
+      e.bin_data?.account === sig.account,
+  );
+  if (tupleMatch) {
+    return {
+      id: String(tupleMatch.id),
+      name: String(tupleMatch.name ?? ""),
+      matchedByName: tupleMatch.name === sig.name,
+      matchedByTuple: true,
+    };
+  }
+  if (sig.name) {
+    const nameMatch = entries.find((e) => e.id && e.name === sig.name);
+    if (nameMatch) {
+      return {
+        id: String(nameMatch.id),
+        name: String(nameMatch.name),
+        matchedByName: true,
+        matchedByTuple: false,
+      };
+    }
+  }
+  return undefined;
+}
+
+export function findDatasourceIdByName(listBody: string, name: string): string | undefined {
+  const parsed = JSON.parse(listBody) as { entries?: DsListEntry[] } | DsListEntry[];
+  const entries = Array.isArray(parsed) ? parsed : (parsed.entries ?? []);
+  const hit = entries.find((e) => e.id && e.name === name);
+  return hit?.id ? String(hit.id) : undefined;
+}
+
+function isDuplicateNameError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  // HttpError.message is just "HTTP 400 ..."; the description lives in body.
+  const status = "status" in err ? Number((err as { status: unknown }).status) : NaN;
+  const body = "body" in err ? String((err as { body: unknown }).body) : "";
+  if (status !== 400) return false;
+  return /数据源名称已存在|datasource name.*exist|already exists/i.test(body);
+}
+
 async function runDsConnectCommand(args: string[]): Promise<number> {
   let dbType = "";
   let host = "";
@@ -238,6 +330,7 @@ async function runDsConnectCommand(args: string[]): Promise<number> {
   let password = "";
   let schema: string | undefined;
   let name: string | undefined;
+  let forceNew = false;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
@@ -257,6 +350,14 @@ async function runDsConnectCommand(args: string[]): Promise<number> {
       name = args[++i];
       continue;
     }
+    if (arg === "--force-new") {
+      forceNew = true;
+      continue;
+    }
+    if (arg === "--reuse-existing") {
+      forceNew = false;
+      continue;
+    }
     if (!arg.startsWith("-")) {
       if (!dbType) dbType = arg;
       else if (!host) host = arg;
@@ -267,7 +368,7 @@ async function runDsConnectCommand(args: string[]): Promise<number> {
 
   if (!dbType || !host || !database || !account || !password) {
     console.error(
-      "Usage: kweaver ds connect <db_type> <host> <port> <database> --account X --password Y [--schema Z] [--name N]"
+      "Usage: kweaver ds connect <db_type> <host> <port> <database> --account X --password Y [--schema Z] [--name N] [--reuse-existing|--force-new]"
     );
     return 1;
   }
@@ -278,6 +379,31 @@ async function runDsConnectCommand(args: string[]): Promise<number> {
 
   const token = await ensureValidToken();
   const base = { baseUrl: token.baseUrl, accessToken: token.accessToken };
+  const dsName = name ?? database;
+
+  // Pre-flight dedup: connection-tuple match is the silent-orphan vector.
+  // Backend already rejects duplicate names with 400, but won't notice
+  // tuple collisions, so we own that check.
+  if (!forceNew) {
+    const listBody = await listDatasources({ ...base });
+    const hit = findExistingDatasource(listBody, {
+      type: dbType,
+      host,
+      port,
+      database,
+      account,
+      name: dsName,
+    });
+    if (hit) {
+      const why = hit.matchedByTuple
+        ? "matched by (type,host,port,database,account)"
+        : "matched by --name";
+      console.error(
+        `Reusing existing datasource ${hit.id} (${hit.name}); ${why}. Use --force-new to override.`,
+      );
+      return printDsConnectOutput(base, hit.id);
+    }
+  }
 
   console.error("Testing connectivity ...");
   await testDatasource({
@@ -291,31 +417,55 @@ async function runDsConnectCommand(args: string[]): Promise<number> {
     schema,
   });
 
-  const dsName = name ?? database;
-  const createBody = await createDatasource({
-    ...base,
-    name: dsName,
-    type: dbType,
-    host,
-    port,
-    database,
-    account,
-    password,
-    schema,
-  });
-
-  const dsId = extractDatasourceId(createBody);
+  let dsId = "";
+  try {
+    const createBody = await createDatasource({
+      ...base,
+      name: dsName,
+      type: dbType,
+      host,
+      port,
+      database,
+      account,
+      password,
+      schema,
+    });
+    dsId = extractDatasourceId(createBody);
+  } catch (err) {
+    // Backend checks name uniqueness but not tuple. If we raced another caller
+    // (or tuple match got disabled by --force-new and the name still collides),
+    // turn the raw 400 into a useful pointer to the existing id.
+    if (isDuplicateNameError(err)) {
+      // Backend rejected the name; look it up specifically (not by tuple —
+      // sibling ds sharing the same connection would mislead the pointer).
+      const listBody = await listDatasources({ ...base });
+      const existingId = findDatasourceIdByName(listBody, dsName);
+      if (existingId) {
+        console.error(
+          `Datasource name '${dsName}' already exists as ${existingId}. Re-run without --force-new to reuse it, or pick a different --name.`,
+        );
+        return 1;
+      }
+    }
+    throw err;
+  }
   if (!dsId) {
     console.error("Failed to get datasource ID from create response");
     return 1;
   }
 
-  const tablesBody = await listTablesWithColumns({
-    ...base,
-    id: dsId,
-  });
+  return printDsConnectOutput(base, dsId);
+}
 
-  const tables = JSON.parse(tablesBody) as Array<{ name: string; columns: Array<{ name: string; type: string; comment?: string }> }>;
+async function printDsConnectOutput(
+  base: { baseUrl: string; accessToken: string },
+  dsId: string,
+): Promise<number> {
+  const tablesBody = await listTablesWithColumns({ ...base, id: dsId });
+  const tables = JSON.parse(tablesBody) as Array<{
+    name: string;
+    columns: Array<{ name: string; type: string; comment?: string }>;
+  }>;
   const output = {
     datasource_id: dsId,
     tables: tables.map((t) => ({

--- a/packages/typescript/test/ds-connect-dedup.test.ts
+++ b/packages/typescript/test/ds-connect-dedup.test.ts
@@ -1,0 +1,181 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { findExistingDatasource, findDatasourceIdByName } from "../src/commands/ds.js";
+
+const SUPPLY_CHAIN = {
+  id: "11111111-1111-1111-1111-111111111111",
+  name: "supply_chain",
+  type: "mysql",
+  bin_data: {
+    host: "192.168.40.105",
+    port: 3306,
+    account: "root",
+    database_name: "supply_chain",
+    connect_protocol: "jdbc",
+  },
+};
+
+const OTHER_DB = {
+  id: "22222222-2222-2222-2222-222222222222",
+  name: "other_alias",
+  type: "mysql",
+  bin_data: {
+    host: "192.168.40.105",
+    port: 3306,
+    account: "root",
+    database_name: "other_db",
+    connect_protocol: "jdbc",
+  },
+};
+
+const SAME_TUPLE_DIFF_NAME = {
+  id: "33333333-3333-3333-3333-333333333333",
+  name: "supply_alias",
+  type: "mysql",
+  bin_data: {
+    host: "192.168.40.105",
+    port: 3306,
+    account: "root",
+    database_name: "supply_chain",
+    connect_protocol: "jdbc",
+  },
+};
+
+function listBody(...entries: object[]): string {
+  return JSON.stringify({ entries, total_count: entries.length });
+}
+
+test("findExistingDatasource: tuple+name match flags both", () => {
+  const hit = findExistingDatasource(listBody(SUPPLY_CHAIN, OTHER_DB), {
+    type: "mysql",
+    host: "192.168.40.105",
+    port: 3306,
+    database: "supply_chain",
+    account: "root",
+    name: "supply_chain",
+  });
+  assert.equal(hit?.id, SUPPLY_CHAIN.id);
+  assert.equal(hit?.matchedByTuple, true);
+  assert.equal(hit?.matchedByName, true);
+});
+
+test("findExistingDatasource: tuple match wins over name when both exist separately", () => {
+  // user passes --name supply_chain but a *different* ds owns that name;
+  // the tuple matches a third entry. Prefer the tuple hit (more specific).
+  const nameSquatter = { ...OTHER_DB, name: "supply_chain", id: "99999999-9999-9999-9999-999999999999" };
+  const hit = findExistingDatasource(listBody(SAME_TUPLE_DIFF_NAME, nameSquatter), {
+    type: "mysql",
+    host: "192.168.40.105",
+    port: 3306,
+    database: "supply_chain",
+    account: "root",
+    name: "supply_chain",
+  });
+  assert.equal(hit?.id, SAME_TUPLE_DIFF_NAME.id);
+  assert.equal(hit?.matchedByTuple, true);
+  assert.equal(hit?.matchedByName, false);
+});
+
+test("findExistingDatasource: tuple match without name match", () => {
+  const hit = findExistingDatasource(listBody(SAME_TUPLE_DIFF_NAME), {
+    type: "mysql",
+    host: "192.168.40.105",
+    port: 3306,
+    database: "supply_chain",
+    account: "root",
+    name: "fresh_name",
+  });
+  assert.equal(hit?.id, SAME_TUPLE_DIFF_NAME.id);
+  assert.equal(hit?.matchedByTuple, true);
+  assert.equal(hit?.matchedByName, false);
+});
+
+test("findExistingDatasource: name fallback when no tuple match", () => {
+  const renamedOnDifferentHost = {
+    ...SUPPLY_CHAIN,
+    bin_data: { ...SUPPLY_CHAIN.bin_data, host: "10.0.0.1" },
+  };
+  const hit = findExistingDatasource(listBody(renamedOnDifferentHost), {
+    type: "mysql",
+    host: "192.168.40.105",
+    port: 3306,
+    database: "supply_chain",
+    account: "root",
+    name: "supply_chain",
+  });
+  assert.equal(hit?.id, renamedOnDifferentHost.id);
+  assert.equal(hit?.matchedByTuple, false);
+  assert.equal(hit?.matchedByName, true);
+});
+
+test("findExistingDatasource: returns undefined when nothing matches", () => {
+  const hit = findExistingDatasource(listBody(OTHER_DB), {
+    type: "mysql",
+    host: "192.168.40.105",
+    port: 3306,
+    database: "supply_chain",
+    account: "root",
+    name: "supply_chain",
+  });
+  assert.equal(hit, undefined);
+});
+
+test("findExistingDatasource: type mismatch is not a tuple hit", () => {
+  const hit = findExistingDatasource(listBody(SUPPLY_CHAIN), {
+    type: "postgresql",
+    host: "192.168.40.105",
+    port: 3306,
+    database: "supply_chain",
+    account: "root",
+    name: "fresh_name",
+  });
+  assert.equal(hit, undefined);
+});
+
+test("findExistingDatasource: port stringified vs numeric both match", () => {
+  const hit = findExistingDatasource(
+    listBody({ ...SUPPLY_CHAIN, bin_data: { ...SUPPLY_CHAIN.bin_data, port: "3306" as unknown as number } }),
+    {
+      type: "mysql",
+      host: "192.168.40.105",
+      port: 3306,
+      database: "supply_chain",
+      account: "root",
+      name: "supply_chain",
+    },
+  );
+  assert.equal(hit?.id, SUPPLY_CHAIN.id);
+});
+
+test("findDatasourceIdByName: returns id when name matches", () => {
+  const id = findDatasourceIdByName(listBody(SUPPLY_CHAIN, OTHER_DB), "other_alias");
+  assert.equal(id, OTHER_DB.id);
+});
+
+test("findDatasourceIdByName: undefined when no match", () => {
+  const id = findDatasourceIdByName(listBody(SUPPLY_CHAIN), "missing");
+  assert.equal(id, undefined);
+});
+
+test("findDatasourceIdByName: prefers exact name over tuple sibling", () => {
+  // Two ds share the same tuple but only one matches the name — name lookup
+  // must return that one, not the first tuple sibling.
+  const id = findDatasourceIdByName(
+    listBody(SAME_TUPLE_DIFF_NAME, SUPPLY_CHAIN),
+    SUPPLY_CHAIN.name,
+  );
+  assert.equal(id, SUPPLY_CHAIN.id);
+});
+
+test("findExistingDatasource: handles bare-array list responses", () => {
+  const hit = findExistingDatasource(JSON.stringify([SUPPLY_CHAIN]), {
+    type: "mysql",
+    host: "192.168.40.105",
+    port: 3306,
+    database: "supply_chain",
+    account: "root",
+    name: "supply_chain",
+  });
+  assert.equal(hit?.id, SUPPLY_CHAIN.id);
+});


### PR DESCRIPTION
Closes #93.

## Summary

`kweaver ds connect` 之前两个失败模式都不友好：

- 不同 `--name` 同 host/port/db/account → backend **不查连接元组**，每次创建新 ds，retry/cleanup 不彻底的脚本静默堆积
- 同 `--name` 连两次 → backend 返 `HTTP 400 数据源名称已存在`，但 CLI 把 raw 错误抛给用户，**不告诉已有那条的 id**

修复两件事：

- **连接前查重**：`listDatasources` 一次拉回（已抛弃错误的 `?type=<connector>` 过滤），按 (type, host, port, database, account) 元组在内存里查；命中默认 reuse + warning，`--force-new` 跳过
- **400 enrichment**：`createDatasource` 抛 `数据源名称已存在` 时，按 **name** 精确查回已有 id（不用 tuple — 同 tuple 多个 sibling 时会指错），改成可读的 `'X' already exists as <id>`

## E2E 验证（192.168.40.62）

| 场景 | 结果 |
|------|------|
| 同 `--name` 连两次（默认） | 第二次 reuse + 1 条 ds ✓ |
| 不同 `--name` 同连接元组 | reuse 已有 + warn + 1 条 ds ✓ |
| `--force-new` + 已存在 name | enriched 400 指向正确 id（按 name 找回） ✓ |
| `--force-new` + 新 name | 真创建新 ds ✓ |

## 修复中也发现的两个 bug

跑 e2e 时撞到的，已一并修：

1. `listDatasources({ type: dbType })`（如 `type=mysql`）→ backend 400，它的 `type` 参数其实要的是 `structured/no-structured/other` 数据类，不是连接器。改成不传 type、内存里按 `e.type === sig.type` 过滤
2. enrichment 第一版用 tuple match 找已有 id，但同 tuple 多条 ds 时返回了 sibling 的 id（误导用户）。改成专门的 `findDatasourceIdByName` 按 name 精确找

## 变更范围

- `packages/typescript/src/commands/ds.ts` (+~150 / -20)
- `packages/typescript/src/cli.ts` (1 行 help)
- `packages/typescript/test/ds-connect-dedup.test.ts`（新，11 个 case）

## Test plan

- [x] 单元测试：`findExistingDatasource` (tuple/name 优先级、port string vs int、bare-array、type mismatch) + `findDatasourceIdByName` 共 11 个 case
- [x] 全量回归：`npm test` → 766 pass / 0 fail
- [x] `npm run lint` + `npm run build` 干净
- [x] e2e on 192.168.40.62（见上表四条）

## 备注

原 P1 报告的"同 host/port/database/name 连两次 = 两个 UUID 不同的 ds，无 conflict 提示"在 192.168.40.62 上 **不准确** —— 后端按 name 去重，第二次返 400。但场景 2（不同 name 同元组）的"堆积"是真实的，本 PR 把两种情况一起解决。

🤖 Generated with [Claude Code](https://claude.com/claude-code)