### PR TITLE
feat(cli): stateless --token / --base-url and positional <kn-id> for context-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ kweaver auth login https://your-kweaver-instance.com
 kweaver auth login https://your-kweaver-instance.com --alias prod
 ```
 
-Or use environment variables: `KWEAVER_BASE_URL`, `KWEAVER_BUSINESS_DOMAIN`, `KWEAVER_TOKEN`. With saved `~/.kweaver/` sessions from OAuth2 browser login, **the default is to exchange `refresh_token` for a new access token** when the access token expires (no extra flags). For TLS in the Node `kweaver` CLI, see `KWEAVER_TLS_INSECURE` and `NODE_TLS_REJECT_UNAUTHORIZED` in the [TypeScript README](packages/typescript/README.md#environment-variables).
+Or use environment variables: `KWEAVER_BASE_URL`, `KWEAVER_BUSINESS_DOMAIN`, `KWEAVER_TOKEN`, or the CLI flags `kweaver --base-url <url> --token <access-token> …` (stateless mode; see [TypeScript README](packages/typescript/README.md#stateless-token-mode)). With saved `~/.kweaver/` sessions from OAuth2 browser login, **the default is to exchange `refresh_token` for a new access token** when the access token expires (no extra flags). For TLS in the Node `kweaver` CLI, see `KWEAVER_TLS_INSECURE` and `NODE_TLS_REJECT_UNAUTHORIZED` in the [TypeScript README](packages/typescript/README.md#environment-variables).
 
 ### Headless hosts (SSH, CI, containers — no browser)
 
@@ -272,8 +272,10 @@ kweaver bkn action-log list/get/cancel
 kweaver agent list/get/create/update/delete/chat/sessions/history/publish/unpublish
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
 kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
-kweaver context-loader config set/use/list/show
-kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/find-skills/...
+kweaver context-loader tools|resources|templates|prompts <kn-id>
+kweaver context-loader search-schema|tool-call|kn-search|kn-schema-search <kn-id> <query|name> [...]
+kweaver context-loader query-object-instance|query-instance-subgraph|get-logic-properties|get-action-info|find-skills <kn-id> ...
+kweaver context-loader config set/use/list/show                       (deprecated; <kn-id> may be omitted to fall back to saved config)
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-bd domain]
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -81,7 +81,7 @@ kweaver auth login https://your-kweaver-instance.com
 kweaver auth login https://your-kweaver-instance.com --alias prod
 ```
 
-或使用环境变量：`KWEAVER_BASE_URL`、`KWEAVER_BUSINESS_DOMAIN`、`KWEAVER_TOKEN`。通过浏览器 OAuth2 登录写入的 `~/.kweaver/` 会话，**默认在 access token 过期时用 refresh_token 换发新 token**（OAuth2 refresh 授权，无需额外参数）。Node 版 `kweaver` CLI 的 TLS 说明见 [`packages/typescript/README.zh.md`](packages/typescript/README.zh.md) 中「环境变量」一节（含 `KWEAVER_TLS_INSECURE`、`NODE_TLS_REJECT_UNAUTHORIZED`）。
+或使用环境变量：`KWEAVER_BASE_URL`、`KWEAVER_BUSINESS_DOMAIN`、`KWEAVER_TOKEN`，或 CLI flag `kweaver --base-url <url> --token <access-token> …`（stateless 模式；见 [`packages/typescript/README.zh.md`](packages/typescript/README.zh.md#stateless-token-模式)）。通过浏览器 OAuth2 登录写入的 `~/.kweaver/` 会话，**默认在 access token 过期时用 refresh_token 换发新 token**（OAuth2 refresh 授权，无需额外参数）。Node 版 `kweaver` CLI 的 TLS 说明见 [`packages/typescript/README.zh.md`](packages/typescript/README.zh.md) 中「环境变量」一节（含 `KWEAVER_TLS_INSECURE`、`NODE_TLS_REJECT_UNAUTHORIZED`）。
 
 ### 无浏览器环境（SSH、CI、容器）
 
@@ -272,8 +272,10 @@ kweaver bkn action-log list/get/cancel
 kweaver agent list/get/get-by-key/create/update/delete/chat/sessions/history/publish/unpublish
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
 kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
-kweaver context-loader config set/use/list/show
-kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/find-skills/...
+kweaver context-loader tools|resources|templates|prompts <kn-id>
+kweaver context-loader search-schema|tool-call|kn-search|kn-schema-search <kn-id> <query|name> [...]
+kweaver context-loader query-object-instance|query-instance-subgraph|get-logic-properties|get-action-info|find-skills <kn-id> ...
+kweaver context-loader config set/use/list/show                       （deprecated；省略 <kn-id> 时回退到已保存配置）
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-bd domain]
 ```
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -31,7 +31,7 @@ export KWEAVER_BASE_URL=https://your-kweaver-instance.com
 export KWEAVER_TOKEN=your-token
 ```
 
-With both set, API commands use that token even if you never ran `auth login`. You can also run **`kweaver auth status`**, **`kweaver auth whoami`** (supports `--json`), and **`kweaver config show`** when there is **no** current platform in `~/.kweaver/`. In env-token mode, `whoami` resolves the bound identity from EACP `/api/eacp/v1/user/get` and prints `Type` (user/app), `User ID`, `Account` and `Name`; this works for both opaque and JWT tokens. If EACP is unreachable, the CLI falls back to local JWT decode and prints a short hint when the token is opaque.
+With both set, API commands use that token even if you never ran `auth login`. The same applies to **`kweaver --base-url <url> --token <access-token> <command>`** (stateless flag mode; see [Stateless token mode](#stateless-token-mode)). You can also run **`kweaver auth status`**, **`kweaver auth whoami`** (supports `--json`), and **`kweaver config show`** when there is **no** current platform in `~/.kweaver/`. In env-token mode, `whoami` resolves the bound identity from EACP `/api/eacp/v1/user/get` and prints `Type` (user/app), `User ID`, `Account` and `Name`; this works for both opaque and JWT tokens. If EACP is unreachable, the CLI falls back to local JWT decode and prints a short hint when the token is opaque.
 
 `kweaver config list-bd` lists business domains for the current user. App (service) tokens are not bound to an end-user — when the backend rejects the call with `401 invalid user_id`, the CLI re-checks the token type via EACP and, if confirmed `type:"app"`, replaces the cryptic backend body with `This command does not support app accounts.`. Use a user token (interactive `auth login`) for user-bound endpoints.
 
@@ -188,8 +188,10 @@ kweaver bkn action-log list/get/cancel
 kweaver agent list/get/create/update/delete/chat/sessions/history/publish/unpublish
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
 kweaver vega health/stats/inspect/sql/catalog/resource/connector-type
-kweaver context-loader config set/use/list/show
-kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/find-skills/...
+kweaver context-loader tools|resources|templates|prompts <kn-id>
+kweaver context-loader search-schema|tool-call|kn-search|kn-schema-search <kn-id> <query|name> [...]
+kweaver context-loader query-object-instance|query-instance-subgraph|get-logic-properties|get-action-info|find-skills <kn-id> ...
+kweaver context-loader config set/use/list/show                       (deprecated; <kn-id> may be omitted to fall back to saved config)
 kweaver toolbox create/list/publish/unpublish/delete
 kweaver tool upload/list/enable/disable
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-F key=value]
@@ -251,9 +253,32 @@ kweaver tool enable --toolbox <BOX_ID> <TOOL_ID>
 | `KWEAVER_BASE_URL` | KWeaver instance URL |
 | `KWEAVER_BUSINESS_DOMAIN` | Business domain identifier |
 | `KWEAVER_TOKEN` | Access token |
+| `KWEAVER_TOKEN_SOURCE` | Internal sentinel set by the CLI when `--token` is passed; do not set manually |
 | `KWEAVER_NO_AUTH` | Set to `1`/`true`/`yes` to use no-auth sentinel when `KWEAVER_TOKEN` is unset (with `KWEAVER_BASE_URL` or active platform) |
 | `KWEAVER_TLS_INSECURE` | Set to `1` or `true` to skip TLS certificate verification for all HTTPS in the process (dev only; prefer `kweaver auth … --insecure` which saves per platform) |
 | `NODE_TLS_REJECT_UNAUTHORIZED` | Node.js built-in TLS switch: set to `0` to skip certificate verification for HTTPS in this process. The `kweaver` CLI sets this when `KWEAVER_TLS_INSECURE` is set or the saved token has insecure TLS (same scope as above; dev only). |
+
+### Stateless token mode
+
+Pass an access token via `--token` for fully stateless invocations (no read or write of `~/.kweaver/` for that token):
+
+```bash
+kweaver --base-url https://platform.example.com --token "$TOK" bkn list
+```
+
+Resolution order:
+
+| Source | base-url | token |
+|--------|----------|-------|
+| flag   | `--base-url` | `--token` |
+| env    | `KWEAVER_BASE_URL` | `KWEAVER_TOKEN` |
+| disk   | active platform | OAuth session (refreshable) |
+
+When `--token` is used, write-disk commands (`auth login` / `logout` / `use` / `delete` / `switch`, `config set-bd`, the entire `context-loader config` group) error out — drop `--token` or use `kweaver auth login` for a saved session.
+
+`auth whoami` / `auth status` distinguish the two stateless modes: `Source: CLI (flag: --token)` for flag mode, `env (KWEAVER_TOKEN)` for env mode (`whoami --json` uses `"source": "flag"` vs `"source": "env"`).
+
+`kweaver context-loader` runtime subcommands accept `<kn-id>` as the first positional (e.g. `kweaver context-loader tools <kn-id>`) or via the global `--kn-id <id>` / `-k <id>` flag, so they work in stateless mode without any saved config. The `context-loader config set|use|list|remove|show` management group is deprecated, prints a warning on use, and is disabled in its entirety under `--token`.
 
 ### TLS Certificate Troubleshooting
 

--- a/packages/typescript/README.zh.md
+++ b/packages/typescript/README.zh.md
@@ -176,8 +176,10 @@ kweaver bkn action-log list/get/cancel
 kweaver agent list/get/chat/sessions/history
 kweaver skill list/market/get/register/status/delete/content/read-file/download/install
 kweaver vega health|stats|inspect|sql|catalog|resource|connector-type
-kweaver context-loader config set/use/list/show
-kweaver context-loader search-schema/tool-call/kn-search/query-object-instance/find-skills/...
+kweaver context-loader tools|resources|templates|prompts <kn-id>
+kweaver context-loader search-schema|tool-call|kn-search|kn-schema-search <kn-id> <query|name> [...]
+kweaver context-loader query-object-instance|query-instance-subgraph|get-logic-properties|get-action-info|find-skills <kn-id> ...
+kweaver context-loader config set/use/list/show                       （deprecated；省略 <kn-id> 时回退到已保存配置）
 kweaver call <path> [-X METHOD] [-d BODY] [-H header]
 ```
 
@@ -218,9 +220,32 @@ kweaver vega sql -d '{"resource_type":"mysql","query":"SELECT * FROM {{res-1}} L
 | `KWEAVER_BASE_URL` | KWeaver 实例地址 |
 | `KWEAVER_BUSINESS_DOMAIN` | 业务域标识 |
 | `KWEAVER_TOKEN` | 访问令牌 |
+| `KWEAVER_TOKEN_SOURCE` | CLI 传入 `--token` 时由程序设置的内部标记；请勿手动设置 |
 | `KWEAVER_NO_AUTH` | 设为 `1`/`true`/`yes` 且未设置 `KWEAVER_TOKEN` 时使用 no-auth 占位（需 `KWEAVER_BASE_URL` 或已选平台） |
 | `KWEAVER_TLS_INSECURE` | 设为 `1` 或 `true` 时跳过 TLS 证书校验（仅开发；更推荐 `kweaver auth … --insecure` 以按平台持久化） |
 | `NODE_TLS_REJECT_UNAUTHORIZED` | Node.js 内置 TLS 开关：设为 `0` 时在本进程内跳过 HTTPS 证书校验。`kweaver` 在 `KWEAVER_TLS_INSECURE` 生效或已保存 token 为不安全 TLS 时会设置此项（范围同上；仅开发）。 |
+
+### Stateless token 模式
+
+通过 `--token` 传入访问令牌，该次调用对该 token 路径既不读也不写 `~/.kweaver/`：
+
+```bash
+kweaver --base-url https://platform.example.com --token "$TOK" bkn list
+```
+
+来源优先级：
+
+| 来源 | base-url | token |
+|------|----------|-------|
+| flag | `--base-url` | `--token` |
+| env  | `KWEAVER_BASE_URL` | `KWEAVER_TOKEN` |
+| 磁盘 | active platform | OAuth 会话（可 refresh） |
+
+`--token` 模式下会禁用写盘命令：`auth login` / `logout` / `use` / `delete` / `switch`、`config set-bd`、整个 `context-loader config` 子命令组 ——去掉 `--token` 或改用 `kweaver auth login`。
+
+`auth whoami` / `auth status` 通过文案区分来源：flag 模式为 `CLI (flag: --token)`，env 模式为 `env (KWEAVER_TOKEN)`（`whoami --json` 为 `"source": "flag"` 与 `"source": "env"`）。
+
+`kweaver context-loader` 运行时子命令将 `<kn-id>` 作为第一个位置参数（如 `kweaver context-loader tools <kn-id>`），也支持全局 `--kn-id <id>` / `-k <id>` flag，因此在 stateless 模式下可直接使用，无需任何持久化配置。`context-loader config set|use|list|remove|show` 管理子命令已被标记为 deprecated（每次调用打印警告），且在 `--token` 下整组被禁用。
 
 ### TLS 证书问题排查
 

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -20,7 +20,7 @@ function printHelp(): void {
   console.log(`kweaver
 
 Usage:
-  kweaver [--user <userId|username>] <command> [options]
+  kweaver [--base-url <url>] [--token <access-token>] [--user <userId|username>] <command> [options]
   kweaver --version | -V
   kweaver --help | -h
 
@@ -125,18 +125,21 @@ Usage:
   kweaver vega query execute|sql [options]
   kweaver vega connector-type list|get [options]
 
-  kweaver context-loader config set|use|list|remove|show [options]
-  kweaver context-loader tools|resources|templates|prompts [--cursor]
-  kweaver context-loader resource <uri>
-  kweaver context-loader prompt <name> [--args json]
-  kweaver context-loader search-schema <query> [--scope object,relation,action,metric] [--max N]
-  kweaver context-loader tool-call <name> --args '<json>'
-  kweaver context-loader kn-search <query> [--only-schema]      (compat HTTP)
-  kweaver context-loader kn-schema-search <query> [--max N]     (compat HTTP)
-  kweaver context-loader query-object-instance|query-instance-subgraph|get-logic-properties|get-action-info|find-skills ...
+  kweaver context-loader config set|use|list|remove|show [options]                (deprecated; not supported with --token)
+  kweaver context-loader tools|resources|templates|prompts <kn-id> [--cursor]
+  kweaver context-loader resource <kn-id> <uri>
+  kweaver context-loader prompt <kn-id> <name> [--args json]
+  kweaver context-loader search-schema <kn-id> <query> [--scope object,relation,action,metric] [--max N]
+  kweaver context-loader tool-call <kn-id> <name> --args '<json>'
+  kweaver context-loader kn-search <kn-id> <query> [--only-schema]                 (compat HTTP)
+  kweaver context-loader kn-schema-search <kn-id> <query> [--max N]                (compat HTTP)
+  kweaver context-loader query-object-instance|query-instance-subgraph|get-logic-properties|get-action-info|find-skills <kn-id> ...
+                                                          (omit <kn-id> to fall back to deprecated saved config)
   (alias: kweaver context ...)
 
 Global options:
+  --base-url <url>  Override platform base URL for this command (env: KWEAVER_BASE_URL)
+  --token <value>   Override access token for this command (env: KWEAVER_TOKEN; disables write-to-disk commands)
   --user <id|name>  Use a specific user's credentials for this command (env: KWEAVER_USER)
   --pretty / --compact
                     Toggle pretty-printed JSON output. Supported by every
@@ -172,12 +175,45 @@ export async function run(argv: string[]): Promise<number> {
     process.env.KWEAVER_TOKEN = NO_AUTH_TOKEN;
   }
 
-  // Global --user flag: override active user for this invocation
-  const userIdx = argv.indexOf("--user");
+  // Global flags consumed before subcommand dispatch.
+  // Pattern follows --user (legacy): each flag, if present, is removed from argv
+  // and projected into a process.env value that downstream resolvers already read.
   let filteredArgv = argv;
-  if (userIdx !== -1 && userIdx + 1 < argv.length) {
-    process.env.KWEAVER_USER = argv[userIdx + 1];
-    filteredArgv = [...argv.slice(0, userIdx), ...argv.slice(userIdx + 2)];
+
+  function consumeFlag(flag: string): string | undefined {
+    const idx = filteredArgv.indexOf(flag);
+    if (idx === -1 || idx + 1 >= filteredArgv.length) return undefined;
+    const value = filteredArgv[idx + 1];
+    filteredArgv = [...filteredArgv.slice(0, idx), ...filteredArgv.slice(idx + 2)];
+    return value;
+  }
+
+  const userVal = consumeFlag("--user");
+  if (userVal) process.env.KWEAVER_USER = userVal;
+
+  const tokenVal = consumeFlag("--token");
+  const baseUrlVal = consumeFlag("--base-url");
+
+  if (tokenVal) {
+    process.env.KWEAVER_TOKEN = tokenVal;
+    process.env.KWEAVER_TOKEN_SOURCE = "flag";
+  }
+  if (baseUrlVal) {
+    process.env.KWEAVER_BASE_URL = baseUrlVal;
+  }
+
+  // --token requires a base URL from somewhere; fail fast with guidance.
+  if (tokenVal && !process.env.KWEAVER_BASE_URL) {
+    const { getCurrentPlatform } = await import("./config/store.js");
+    if (!getCurrentPlatform()) {
+      console.error(
+        "--token requires a base URL. Provide one of:\n" +
+          "  --base-url <url>\n" +
+          "  export KWEAVER_BASE_URL=<url>\n" +
+          "  kweaver auth login <url>   (save once, reuse later)",
+      );
+      return 1;
+    }
   }
 
   const [command, ...rest] = filteredArgv;

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -1,4 +1,5 @@
 import { isNoAuth } from "../config/no-auth.js";
+import { assertNotStatelessForWrite } from "../config/stateless.js";
 import {
   autoSelectBusinessDomain,
   clearPlatformSession,
@@ -119,6 +120,12 @@ Login options:
   const LOGIN_SUBCOMMANDS = new Set(["status", "list", "use", "delete", "logout", "export", "whoami", "users", "switch"]);
   if (target && !LOGIN_SUBCOMMANDS.has(target)) {
     try {
+      try {
+        assertNotStatelessForWrite("auth login");
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        return 1;
+      }
       const normalizedTarget = normalizeBaseUrl(target);
       const alias = readOption(args, "--alias");
       let username = readOption(args, "--username") ?? readOption(args, "-u");
@@ -326,7 +333,9 @@ Login options:
       }
       console.log(`Config directory: ${getConfigDir()}`);
       console.log(`Platform:         ${active.url} (KWEAVER_BASE_URL)`);
-      console.log(`Token present:    yes (KWEAVER_TOKEN)`);
+      const tokenProvenance =
+        process.env.KWEAVER_TOKEN_SOURCE === "flag" ? "CLI (flag: --token)" : "KWEAVER_TOKEN";
+      console.log(`Token present:    yes (${tokenProvenance})`);
       console.log(`Refresh token:    n/a (env)`);
       return 0;
     }
@@ -426,6 +435,12 @@ Login options:
       console.error(`No saved token for ${useTarget}. Run \`kweaver auth login ${useTarget}\` first.`);
       return 1;
     }
+    try {
+      assertNotStatelessForWrite("auth use");
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      return 1;
+    }
     setCurrentPlatform(useTarget);
     console.log(`Current platform: ${useTarget}`);
     return 0;
@@ -443,6 +458,13 @@ Login options:
     }
     if (!hasPlatform(deleteTarget)) {
       console.error(`No saved token for ${deleteTarget}.`);
+      return 1;
+    }
+
+    try {
+      assertNotStatelessForWrite("auth delete");
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
       return 1;
     }
 
@@ -476,6 +498,12 @@ Login options:
     }
     if (!hasPlatform(logoutTarget)) {
       console.error(`No saved token for ${logoutTarget}.`);
+      return 1;
+    }
+    try {
+      assertNotStatelessForWrite("auth logout");
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
       return 1;
     }
     const logoutUserId = logoutUserArg ? resolveUserId(logoutTarget, logoutUserArg) ?? logoutUserArg : undefined;
@@ -571,6 +599,13 @@ You can specify either the userId (sub claim) or the username (preferred_usernam
     return 1;
   }
 
+  try {
+    assertNotStatelessForWrite("auth switch");
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+
   setActiveUser(platform, resolvedId);
   const profiles = listUserProfiles(platform);
   const profile = profiles.find((p) => p.userId === resolvedId);
@@ -625,14 +660,19 @@ Options:
     // complete picture without forcing them to pick a mode.
     const jwtPayload = decodeJwtPayload(accessToken);
     if (jsonOutput) {
-      const out: Record<string, unknown> = { platform: envUrl, source: "env" };
+      const out: Record<string, unknown> = {
+        platform: envUrl,
+        source: process.env.KWEAVER_TOKEN_SOURCE === "flag" ? "flag" : "env",
+      };
       if (userInfo) out.userInfo = userInfo;
       if (jwtPayload) Object.assign(out, jwtPayload);
       console.log(JSON.stringify(out, null, 2));
       return 0;
     }
     console.log(`Platform: ${envUrl}`);
-    console.log(`Source:   env (KWEAVER_TOKEN)`);
+    console.log(
+      `Source:   ${process.env.KWEAVER_TOKEN_SOURCE === "flag" ? "CLI (flag: --token)" : "env (KWEAVER_TOKEN)"}`,
+    );
     if (userInfo) {
       console.log(`Type:     ${userInfo.type}`);
       console.log(`User ID:  ${userInfo.id}`);

--- a/packages/typescript/src/commands/config.ts
+++ b/packages/typescript/src/commands/config.ts
@@ -6,6 +6,7 @@ import {
   resolveBusinessDomain,
   savePlatformBusinessDomain,
 } from "../config/store.js";
+import { assertNotStatelessForWrite } from "../config/stateless.js";
 
 const HELP = `kweaver config
 
@@ -59,6 +60,12 @@ export async function runConfigCommand(args: string[]): Promise<number> {
       return 1;
     }
     const platform = active.url;
+    try {
+      assertNotStatelessForWrite("config set-bd");
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      return 1;
+    }
     savePlatformBusinessDomain(platform, value);
     const provenance = active.source === "env" ? `${platform} via KWEAVER_BASE_URL` : platform;
     console.log(`Business domain set to: ${value} (${provenance})`);

--- a/packages/typescript/src/commands/context-loader.ts
+++ b/packages/typescript/src/commands/context-loader.ts
@@ -24,11 +24,19 @@ import {
   resolveBusinessDomain,
   setCurrentContextLoader,
 } from "../config/store.js";
+import { assertNotStatelessForWrite } from "../config/stateless.js";
+
+const CONTEXT_LOADER_CONFIG_DEPRECATION =
+  "[deprecated] `kweaver context-loader config ...` will be removed in a future release. " +
+  "Pass <kn-id> as the first positional to runtime subcommands instead, e.g. " +
+  "`kweaver context-loader tools <kn-id>` (or use the `--kn-id <id>` flag).";
 
 const MCP_NOT_CONFIGURED =
   "Context-loader MCP is not configured. Run: kweaver context-loader config set --kn-id <kn-id>";
 
-function ensureContextLoaderConfig(): {
+const MCP_PATH = "/api/agent-retrieval/v1/mcp";
+
+function ensureContextLoaderConfig(knIdOverride?: string): {
   baseUrl: string;
   mcpUrl: string;
   knId: string;
@@ -40,6 +48,18 @@ function ensureContextLoaderConfig(): {
     throw new Error(
       "No platform selected. Set KWEAVER_BASE_URL or run: kweaver auth <platform-url>",
     );
+  }
+
+  // Override path (positional <kn-id> or --kn-id flag): derive MCP URL from
+  // the active platform; do not touch the deprecated saved config.
+  if (knIdOverride) {
+    return {
+      baseUrl: active.url,
+      mcpUrl: active.url.replace(/\/+$/, "") + MCP_PATH,
+      knId: knIdOverride,
+      accessToken: "",
+      businessDomain: resolveBusinessDomain(active.url),
+    };
   }
 
   const kn = getCurrentContextLoaderKn();
@@ -56,6 +76,51 @@ function ensureContextLoaderConfig(): {
   };
 }
 
+// Subcommands that consult `ensureContextLoaderConfig`. The number is the
+// minimum non-flag positional count expected by the handler itself (after
+// kn-id is extracted). When the leading non-flag positional count exceeds
+// this minimum, the first one is treated as <kn-id>.
+const RUNTIME_MIN_POSITIONALS: Record<string, number> = {
+  tools: 0,
+  resources: 0,
+  templates: 0,
+  prompts: 0,
+  prompt: 1,
+  resource: 1,
+  "search-schema": 1,
+  "tool-call": 1,
+  "kn-search": 1,
+  "kn-schema-search": 1,
+  "query-object-instance": 1,
+  "query-instance-subgraph": 1,
+  "get-logic-properties": 1,
+  "get-action-info": 1,
+  "find-skills": 1,
+};
+
+function extractKnIdOverride(subcommand: string, rest: string[]): string | undefined {
+  // 1) Explicit flag wins. `--kn-id <id>` / `-k <id>` is allowed for every
+  //    runtime subcommand and is consumed before the handler sees `rest`.
+  for (let i = 0; i < rest.length; i += 1) {
+    if ((rest[i] === "--kn-id" || rest[i] === "-k") && rest[i + 1]) {
+      const id = rest[i + 1];
+      rest.splice(i, 2);
+      return id;
+    }
+  }
+
+  // 2) Positional <kn-id> as the first non-flag arg, when leading non-flag
+  //    positional count exceeds what the handler itself requires.
+  const min = RUNTIME_MIN_POSITIONALS[subcommand];
+  if (min === undefined) return undefined;
+  let cut = 0;
+  while (cut < rest.length && !rest[cut].startsWith("-")) cut += 1;
+  if (cut > min) {
+    return rest.shift();
+  }
+  return undefined;
+}
+
 function formatOutput(value: unknown, pretty: boolean): string {
   const json = JSON.stringify(value, null, pretty ? 2 : 0);
   return json;
@@ -67,34 +132,38 @@ export async function runContextLoaderCommand(args: string[]): Promise<number> {
   if (!subcommand || subcommand === "--help" || subcommand === "-h") {
     console.log(`kweaver context-loader
 
+KN selection (for runtime subcommands below):
+  Pass <kn-id> as the FIRST positional, e.g. \`kweaver context-loader tools <kn-id>\`,
+  or use the global \`--kn-id <id>\` / \`-k <id>\` flag. When omitted, falls back to
+  the deprecated saved config managed by \`kweaver context-loader config\`.
+
 Subcommands:
-  config set --kn-id <id> [--name n]   Add or update kn config (MCP URL derived from platform)
-  config use <name>                    Switch current config
-  config list                         List all configs and current
-  config remove <name>                 Remove a config
-  config show                         Show current config (knId + mcpUrl)
-  tools                               tools/list - list available tools
-  resources                           resources/list - list resources
-  resource <uri>                      resources/read - read resource by URI
-  templates                           resources/templates/list - list resource templates
-  prompts                             prompts/list - list prompts
-  prompt <name> [--args json]          prompts/get - get prompt by name
-  search-schema <query> [options]      MCP search_schema (object/relation/action/metric types)
-  tool-call <name> --args '<json>'     MCP tools/call for any server tool
-  kn-search <query> [--only-schema]    Compatibility: HTTP kn_search
-  kn-schema-search <query> [--max N]   Compatibility: HTTP semantic-search
-  query-object-instance <json>         Layer 2: Query instances (args as JSON)
-  query-instance-subgraph <json>       Layer 2: Query subgraph (args as JSON)
-  get-logic-properties <json>          Layer 3: Get logic property values (args as JSON)
-  get-action-info <json>               Layer 3: Get action info (args as JSON)
-  find-skills <ot_id> [options]        Layer 3: Recall skills for an object type
+  config set --kn-id <id> [--name n]   [deprecated] Add or update kn config
+  config use <name>                    [deprecated] Switch current config
+  config list                          [deprecated] List all configs and current
+  config remove <name>                 [deprecated] Remove a config
+  config show                          [deprecated] Show current config (knId + mcpUrl)
+  tools <kn-id>                        tools/list - list available tools
+  resources <kn-id>                    resources/list - list resources
+  resource <kn-id> <uri>               resources/read - read resource by URI
+  templates <kn-id>                    resources/templates/list - list resource templates
+  prompts <kn-id>                      prompts/list - list prompts
+  prompt <kn-id> <name> [--args json]  prompts/get - get prompt by name
+  search-schema <kn-id> <query> [opts] MCP search_schema (object/relation/action/metric)
+  tool-call <kn-id> <name> --args '<json>'  MCP tools/call for any server tool
+  kn-search <kn-id> <query> [--only-schema]  Compatibility: HTTP kn_search
+  kn-schema-search <kn-id> <query> [--max N] Compatibility: HTTP semantic-search
+  query-object-instance <kn-id> <json>       Layer 2: Query instances
+  query-instance-subgraph <kn-id> <json>     Layer 2: Query subgraph
+  get-logic-properties <kn-id> <json>        Layer 3: Get logic property values
+  get-action-info <kn-id> <json>             Layer 3: Get action info
+  find-skills <kn-id> <ot_id> [options]      Layer 3: Recall skills for an object type
 
 Examples:
-  kweaver context-loader config set --kn-id d5iv6c9818p72mpje8pg
-  kweaver context-loader config set --kn-id xyz123 --name project-a
-  kweaver context-loader search-schema "利润率" --scope object,metric --max 5
-  kweaver context-loader tool-call search_schema --args '{"query":"利润率"}'
-  kweaver context-loader kn-search "高血压 治疗 药品" --only-schema --pretty`);
+  kweaver context-loader tools d5iv6c9818p72mpje8pg
+  kweaver context-loader search-schema d5iv6c9818p72mpje8pg "利润率" --scope object,metric --max 5
+  kweaver context-loader tool-call d5iv6c9818p72mpje8pg search_schema --args '{"query":"利润率"}'
+  kweaver context-loader kn-search d5iv6c9818p72mpje8pg "高血压 治疗 药品" --only-schema --pretty`);
     return 0;
   }
 
@@ -109,9 +178,13 @@ Examples:
     rest.splice(prettyIdx, 1);
   }
 
+  // Extract `<kn-id>` (positional or --kn-id/-k flag) before per-subcommand
+  // arg parsing. When provided it bypasses the deprecated saved config.
+  const knIdOverride = extractKnIdOverride(subcommand, rest);
+
   const dispatch = async (): Promise<number> => {
     const token = await ensureValidToken();
-    const base = ensureContextLoaderConfig();
+    const base = ensureContextLoaderConfig(knIdOverride);
     const options = { ...base, accessToken: token.accessToken };
 
     if (subcommand === "tools") return runListTools(options, rest, pretty);
@@ -151,16 +224,30 @@ async function runConfigCommand(args: string[]): Promise<number> {
   const [action, ...rest] = args;
 
   if (!action || action === "--help" || action === "-h") {
-    console.log(`kweaver context-loader config
+    console.log(`kweaver context-loader config  [deprecated]
 
 Subcommands:
   set --kn-id <id> [--name <name>]   Add or update kn config (default name: default)
   use <name>                         Switch current config
   list                               List all configs and current
   remove <name>                      Remove a config
-  show                               Show current config (knId + mcpUrl)`);
+  show                               Show current config (knId + mcpUrl)
+
+Note: this command group is deprecated and will be removed in a future release.
+      It is disabled entirely in stateless mode (\`--token\`).`);
     return 0;
   }
+
+  // Stateless mode (`--token`) does not support any context-loader config
+  // operations; the saved config lives under `~/.kweaver/` and is foreign
+  // to the stateless paradigm.
+  try {
+    assertNotStatelessForWrite(`context-loader config ${action}`);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  console.warn(CONTEXT_LOADER_CONFIG_DEPRECATION);
 
   const active = resolveActivePlatform();
   if (!active) {
@@ -518,22 +605,18 @@ async function runKnSearch(
 ): Promise<number> {
   let query: string | undefined;
   let onlySchema = false;
-  let knIdOverride: string | undefined;
 
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
     if (arg === "--only-schema") {
       onlySchema = true;
-    } else if ((arg === "--kn-id" || arg === "-k") && args[i + 1]) {
-      knIdOverride = args[i + 1];
-      i += 1;
     } else if (!arg.startsWith("-") && !query) {
       query = arg;
     }
   }
 
   if (!query) {
-    console.error("Usage: kweaver context-loader kn-search <query> [--kn-id <id>] [--only-schema]");
+    console.error("Usage: kweaver context-loader kn-search <kn-id> <query> [--only-schema]");
     return 1;
   }
 
@@ -541,7 +624,7 @@ async function runKnSearch(
     baseUrl: options.baseUrl,
     accessToken: options.accessToken,
     businessDomain: options.businessDomain,
-    knId: knIdOverride ?? options.knId,
+    knId: options.knId,
     query,
     onlySchema,
   });

--- a/packages/typescript/src/config/stateless.ts
+++ b/packages/typescript/src/config/stateless.ts
@@ -1,0 +1,23 @@
+/**
+ * Stateless token mode: user passed --token on the CLI for this invocation.
+ *
+ * In stateless mode the CLI must not mutate ~/.kweaver/ — we error out from
+ * any command that would write tokens, sessions, or per-platform config.
+ *
+ * KWEAVER_TOKEN env (without --token flag) is NOT considered stateless: the
+ * env-var path predates this feature and keeps its existing semantics for
+ * backward compatibility. The cli.ts argv parser sets KWEAVER_TOKEN_SOURCE=flag
+ * only when --token was passed explicitly.
+ */
+export function isStatelessTokenMode(): boolean {
+  return process.env.KWEAVER_TOKEN_SOURCE === "flag";
+}
+
+export function assertNotStatelessForWrite(commandName: string): void {
+  if (isStatelessTokenMode()) {
+    throw new Error(
+      `Cannot run \`${commandName}\` with --token. The --token flag is for stateless invocations and ` +
+        `must not mutate ~/.kweaver/. Drop --token, or use \`kweaver auth login\` to obtain a saved session.`,
+    );
+  }
+}

--- a/packages/typescript/test/cli.test.ts
+++ b/packages/typescript/test/cli.test.ts
@@ -228,14 +228,14 @@ test("run context-loader help includes standard MCP short commands", async () =>
   try {
     await run(["context-loader"]);
     const help = lines.join("\n");
-    assert.ok(help.includes("resource <uri>"), "help should include resource");
+    assert.ok(help.includes("resource <kn-id> <uri>"), "help should include resource");
     assert.ok(help.includes("templates"), "help should include templates");
     assert.ok(help.includes("prompts"), "help should include prompts");
-    assert.ok(help.includes("prompt <name>"), "help should include prompt");
+    assert.ok(help.includes("prompt <kn-id> <name>"), "help should include prompt");
     assert.ok(help.includes("tools/list"), "help should map tools to tools/list");
     assert.ok(help.includes("resources/list"), "help should map resources to resources/list");
-    assert.ok(help.includes("search-schema <query>"), "help should include search-schema");
-    assert.ok(help.includes("tool-call <name>"), "help should include generic tool-call");
+    assert.ok(help.includes("search-schema <kn-id> <query>"), "help should include search-schema");
+    assert.ok(help.includes("tool-call <kn-id> <name>"), "help should include generic tool-call");
   } finally {
     console.log = originalLog;
   }
@@ -322,6 +322,77 @@ test("run context-loader search-schema calls MCP search_schema", async () => {
       schema_brief: true,
       enable_rerank: false,
     });
+  } finally {
+    globalThis.fetch = originalFetch;
+    console.log = originalLog;
+  }
+});
+
+test("run context-loader search-schema accepts positional <kn-id> (no saved config)", async () => {
+  // No `addContextLoaderEntry` is called: the only path from <kn-id> to mcpUrl
+  // must be the override branch in `ensureContextLoaderConfig`.
+  const configDir = createConfigDir();
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+
+  const store = await importStoreModule(configDir);
+  store.saveTokenConfig({
+    baseUrl: "https://dip.aishu.cn",
+    accessToken: "t",
+    tokenType: "bearer",
+    scope: "openid",
+    obtainedAt: new Date().toISOString(),
+  });
+  store.setCurrentPlatform("https://dip.aishu.cn");
+
+  const seenUrls: string[] = [];
+  const captured: { toolName?: string; args?: Record<string, unknown> } = {};
+  const originalFetch = globalThis.fetch;
+  const originalLog = console.log;
+  console.log = () => {};
+  globalThis.fetch = async (input, init) => {
+    seenUrls.push(typeof input === "string" ? input : (input as URL | Request).toString());
+    const body = JSON.parse(init?.body as string) as Record<string, unknown>;
+    if (body.method === "initialize") {
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: body.id, result: {} }), {
+        status: 200,
+        headers: { "MCP-Session-Id": "cli-session" },
+      });
+    }
+    if (body.method === "notifications/initialized") {
+      return new Response(JSON.stringify({ jsonrpc: "2.0" }), { status: 200 });
+    }
+    if (body.method === "tools/call") {
+      const params = body.params as { name?: string; arguments?: Record<string, unknown> };
+      captured.toolName = params.name;
+      captured.args = params.arguments;
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { content: [{ type: "text", text: "{}" }] },
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    const cli = await importCliModule(configDir);
+    const code = await cli.run([
+      "context-loader",
+      "search-schema",
+      "kn-positional-id",
+      "Pod",
+    ]);
+    assert.equal(code, 0);
+    assert.equal(captured.toolName, "search_schema");
+    assert.ok(
+      seenUrls.some((u) => u.includes("/api/agent-retrieval/v1/mcp")),
+      "MCP URL should be derived from active platform when <kn-id> is positional",
+    );
+    // The dispatcher consumed the kn-id; only the query should reach the handler.
+    assert.equal((captured.args as { query?: string }).query, "Pod");
   } finally {
     globalThis.fetch = originalFetch;
     console.log = originalLog;

--- a/packages/typescript/test/stateless-flags.test.ts
+++ b/packages/typescript/test/stateless-flags.test.ts
@@ -1,0 +1,250 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  isStatelessTokenMode,
+  assertNotStatelessForWrite,
+} from "../src/config/stateless.js";
+import { run } from "../src/cli.js";
+
+test("isStatelessTokenMode: false when KWEAVER_TOKEN_SOURCE unset", () => {
+  delete process.env.KWEAVER_TOKEN_SOURCE;
+  assert.equal(isStatelessTokenMode(), false);
+});
+
+test("isStatelessTokenMode: true when KWEAVER_TOKEN_SOURCE=flag", () => {
+  process.env.KWEAVER_TOKEN_SOURCE = "flag";
+  try {
+    assert.equal(isStatelessTokenMode(), true);
+  } finally {
+    delete process.env.KWEAVER_TOKEN_SOURCE;
+  }
+});
+
+test("assertNotStatelessForWrite throws with helpful message", () => {
+  process.env.KWEAVER_TOKEN_SOURCE = "flag";
+  try {
+    assert.throws(
+      () => assertNotStatelessForWrite("auth login"),
+      /auth login.*--token.*stateless/s,
+    );
+  } finally {
+    delete process.env.KWEAVER_TOKEN_SOURCE;
+  }
+});
+
+test("assertNotStatelessForWrite no-op when not stateless", () => {
+  delete process.env.KWEAVER_TOKEN_SOURCE;
+  assert.doesNotThrow(() => assertNotStatelessForWrite("auth login"));
+});
+
+test("--token sets KWEAVER_TOKEN env and KWEAVER_TOKEN_SOURCE=flag", async () => {
+  const origTok = process.env.KWEAVER_TOKEN;
+  const origSrc = process.env.KWEAVER_TOKEN_SOURCE;
+  const origBase = process.env.KWEAVER_BASE_URL;
+  delete process.env.KWEAVER_TOKEN;
+  delete process.env.KWEAVER_TOKEN_SOURCE;
+  process.env.KWEAVER_BASE_URL = "https://example.invalid";
+  try {
+    await run(["--token", "abc123", "version"]);
+    assert.equal(process.env.KWEAVER_TOKEN, "abc123");
+    assert.equal(process.env.KWEAVER_TOKEN_SOURCE, "flag");
+  } finally {
+    if (origTok !== undefined) process.env.KWEAVER_TOKEN = origTok;
+    else delete process.env.KWEAVER_TOKEN;
+    if (origSrc !== undefined) process.env.KWEAVER_TOKEN_SOURCE = origSrc;
+    else delete process.env.KWEAVER_TOKEN_SOURCE;
+    if (origBase !== undefined) process.env.KWEAVER_BASE_URL = origBase;
+    else delete process.env.KWEAVER_BASE_URL;
+  }
+});
+
+test("--base-url sets KWEAVER_BASE_URL env", async () => {
+  const orig = process.env.KWEAVER_BASE_URL;
+  delete process.env.KWEAVER_BASE_URL;
+  try {
+    await run(["--base-url", "https://x.example", "version"]);
+    assert.equal(process.env.KWEAVER_BASE_URL, "https://x.example");
+  } finally {
+    if (orig !== undefined) process.env.KWEAVER_BASE_URL = orig;
+    else delete process.env.KWEAVER_BASE_URL;
+  }
+});
+
+test("--token without any base-url fails with guidance", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "kw-stateless-"));
+  const origCfg = process.env.KWEAVERC_CONFIG_DIR;
+  const origTok = process.env.KWEAVER_TOKEN;
+  const origBase = process.env.KWEAVER_BASE_URL;
+  process.env.KWEAVERC_CONFIG_DIR = tmp;
+  delete process.env.KWEAVER_TOKEN;
+  delete process.env.KWEAVER_BASE_URL;
+  const errors: string[] = [];
+  const origErr = console.error;
+  console.error = (msg: unknown) => {
+    errors.push(String(msg));
+  };
+  try {
+    const code = await run(["--token", "tok", "bkn", "list"]);
+    assert.equal(code, 1);
+    assert.match(errors.join("\n"), /--token requires a base URL/);
+  } finally {
+    console.error = origErr;
+    if (origCfg !== undefined) process.env.KWEAVERC_CONFIG_DIR = origCfg;
+    else delete process.env.KWEAVERC_CONFIG_DIR;
+    if (origTok !== undefined) process.env.KWEAVER_TOKEN = origTok;
+    if (origBase !== undefined) process.env.KWEAVER_BASE_URL = origBase;
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("--token blocks `auth login`", async () => {
+  const errors: string[] = [];
+  const origErr = console.error;
+  console.error = (msg: unknown) => {
+    errors.push(String(msg));
+  };
+  process.env.KWEAVER_BASE_URL = "https://example.invalid";
+  try {
+    const code = await run(["--token", "tok", "auth", "login", "https://example.invalid"]);
+    assert.equal(code, 1);
+    assert.match(errors.join("\n"), /Cannot run.*auth login.*--token/s);
+  } finally {
+    console.error = origErr;
+    delete process.env.KWEAVER_BASE_URL;
+    delete process.env.KWEAVER_TOKEN;
+    delete process.env.KWEAVER_TOKEN_SOURCE;
+  }
+});
+
+test("--token blocks `config set-bd`", async () => {
+  const errors: string[] = [];
+  const origErr = console.error;
+  console.error = (msg: unknown) => {
+    errors.push(String(msg));
+  };
+  process.env.KWEAVER_BASE_URL = "https://example.invalid";
+  try {
+    const code = await run(["--token", "tok", "config", "set-bd", "bd_x"]);
+    assert.equal(code, 1);
+    assert.match(errors.join("\n"), /Cannot run.*config set-bd.*--token/s);
+  } finally {
+    console.error = origErr;
+    delete process.env.KWEAVER_BASE_URL;
+    delete process.env.KWEAVER_TOKEN;
+    delete process.env.KWEAVER_TOKEN_SOURCE;
+  }
+});
+
+test("--token blocks `context-loader config set`", async () => {
+  const errors: string[] = [];
+  const origErr = console.error;
+  console.error = (msg: unknown) => {
+    errors.push(String(msg));
+  };
+  process.env.KWEAVER_BASE_URL = "https://example.invalid";
+  try {
+    const code = await run([
+      "--token",
+      "tok",
+      "context-loader",
+      "config",
+      "set",
+      "--kn-id",
+      "kn-x",
+    ]);
+    assert.equal(code, 1);
+    assert.match(errors.join("\n"), /Cannot run.*context-loader config set.*--token/s);
+  } finally {
+    console.error = origErr;
+    delete process.env.KWEAVER_BASE_URL;
+    delete process.env.KWEAVER_TOKEN;
+    delete process.env.KWEAVER_TOKEN_SOURCE;
+  }
+});
+
+test("--token blocks read-only `context-loader config show` too", async () => {
+  const errors: string[] = [];
+  const origErr = console.error;
+  console.error = (msg: unknown) => {
+    errors.push(String(msg));
+  };
+  process.env.KWEAVER_BASE_URL = "https://example.invalid";
+  try {
+    const code = await run(["--token", "tok", "context-loader", "config", "show"]);
+    assert.equal(code, 1);
+    assert.match(errors.join("\n"), /Cannot run.*context-loader config show.*--token/s);
+  } finally {
+    console.error = origErr;
+    delete process.env.KWEAVER_BASE_URL;
+    delete process.env.KWEAVER_TOKEN;
+    delete process.env.KWEAVER_TOKEN_SOURCE;
+  }
+});
+
+test("`context-loader config show` prints deprecation warning (env mode)", async () => {
+  const warnings: string[] = [];
+  const origWarn = console.warn;
+  const origLog = console.log;
+  console.warn = (msg: unknown) => {
+    warnings.push(String(msg));
+  };
+  console.log = () => {};
+  const tmp = mkdtempSync(join(tmpdir(), "kw-cfg-deprec-"));
+  const origCfg = process.env.KWEAVERC_CONFIG_DIR;
+  process.env.KWEAVERC_CONFIG_DIR = tmp;
+  process.env.KWEAVER_BASE_URL = "https://example.invalid";
+  process.env.KWEAVER_TOKEN = "tok";
+  delete process.env.KWEAVER_TOKEN_SOURCE;
+  try {
+    await run(["context-loader", "config", "show"]);
+    assert.match(warnings.join("\n"), /deprecated.*context-loader config/i);
+  } finally {
+    console.warn = origWarn;
+    console.log = origLog;
+    if (origCfg !== undefined) process.env.KWEAVERC_CONFIG_DIR = origCfg;
+    else delete process.env.KWEAVERC_CONFIG_DIR;
+    delete process.env.KWEAVER_BASE_URL;
+    delete process.env.KWEAVER_TOKEN;
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("whoami shows Source: CLI (flag: --token) when --token was used", async () => {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: unknown) => {
+    logs.push(String(msg));
+  };
+  process.env.KWEAVER_BASE_URL = "https://127.0.0.1:1";
+  try {
+    await run(["--token", "header.payload.sig", "auth", "whoami"]);
+    assert.match(logs.join("\n"), /Source:\s+CLI \(flag: --token\)/);
+  } finally {
+    console.log = origLog;
+    delete process.env.KWEAVER_BASE_URL;
+    delete process.env.KWEAVER_TOKEN;
+    delete process.env.KWEAVER_TOKEN_SOURCE;
+  }
+});
+
+test("whoami still shows Source: env (KWEAVER_TOKEN) for env-only mode", async () => {
+  const logs: string[] = [];
+  const origLog = console.log;
+  console.log = (msg: unknown) => {
+    logs.push(String(msg));
+  };
+  process.env.KWEAVER_BASE_URL = "https://127.0.0.1:1";
+  process.env.KWEAVER_TOKEN = "header.payload.sig";
+  delete process.env.KWEAVER_TOKEN_SOURCE;
+  try {
+    await run(["auth", "whoami"]);
+    assert.match(logs.join("\n"), /Source:\s+env \(KWEAVER_TOKEN\)/);
+  } finally {
+    console.log = origLog;
+    delete process.env.KWEAVER_BASE_URL;
+    delete process.env.KWEAVER_TOKEN;
+  }
+});

--- a/skills/kweaver-core/SKILL.md
+++ b/skills/kweaver-core/SKILL.md
@@ -33,7 +33,7 @@ npm install -g @kweaver-ai/kweaver-sdk
 ## 使用方式
 
 ```bash
-kweaver [--user <userId|username>] <command> [subcommand] [options]
+kweaver [--base-url <url>] [--token <access-token>] [--user <userId|username>] <command> [subcommand] [options]
 ```
 
 **完整子命令与参数以当前安装的 CLI 为准**：运行 `kweaver --help`（或 `-h`）查看与代码同步的用法列表；查版本用 `kweaver --version` / `-V` / `kweaver version`。子命令细节用 `kweaver <group> <subcommand> --help`（例如 `kweaver auth --help`、`kweaver bkn push --help`）。
@@ -50,9 +50,10 @@ kweaver [--user <userId|username>] <command> [subcommand] [options]
 
 ### 认证优先级
 
-1. `KWEAVER_TOKEN` + `KWEAVER_BASE_URL` 环境变量 → 静态 Token（如存在则优先使用，**不会**用 refresh 换发）
-2. `~/.kweaver/` 凭据（`kweaver auth login` 写入）→ **默认**用 refresh_token 换发 access_token（推荐）
-3. `KWEAVER_USER` 环境变量（或全局 `--user` 参数）→ 使用指定用户的凭证，不切换活跃用户
+1. CLI 全局 `--token` + `--base-url`（或已有 `KWEAVER_BASE_URL` / active platform）→ Stateless flag 模式（一次性传 token，本次调用不读写 `~/.kweaver/`；token 过期不会自动续期；不能用 `auth login` / `logout` 等会修改本地凭据的命令）
+2. `KWEAVER_TOKEN` + `KWEAVER_BASE_URL` 环境变量 → 静态 Token（如存在则优先使用，**不会**用 refresh 换发）
+3. `~/.kweaver/` 凭据（`kweaver auth login` 写入）→ **默认**用 refresh_token 换发 access_token（推荐）
+4. `KWEAVER_USER` 环境变量（或全局 `--user` 参数）→ 使用指定用户的凭证，不切换活跃用户
 
 ### 业务域优先级（与认证独立）
 
@@ -76,7 +77,7 @@ kweaver [--user <userId|username>] <command> [subcommand] [options]
 | `toolbox` | 平台工具箱（toolbox）管理 | `toolbox create --name <n> --service-url <url>`、`toolbox list`、`toolbox publish/unpublish <id>`、`toolbox delete <id> [-y]` | `references/toolbox.md` |
 | `tool` | 工具箱内 tool 注册与启停（OpenAPI） | `tool upload --toolbox <id> <openapi-spec>`、`tool list --toolbox <id>`、`tool enable/disable --toolbox <id> <tool-id>...` | `references/tool.md` |
 | `vega` | Vega 可观测平台 | `vega health`, `vega catalog list`, `vega resource list`, `vega query execute -d <json>`, `vega sql --resource-type <t> --query "<sql>"` / `vega sql -d <json>` | `references/vega.md` |
-| `context-loader` | MCP 分层检索 | `context-loader config show`, `context-loader kn-search <query>` | `references/context-loader.md` |
+| `context-loader` | MCP 分层检索 | `context-loader tools <kn-id>`, `context-loader kn-search <kn-id> <query>`（也支持 `--kn-id <id>` flag；省略时回退到 deprecated 的 `context-loader config`） | `references/context-loader.md` |
 | `call` | 通用 API 调用 | `call <url> [-X POST] [-d '...']`（可用 `curl` 别名；支持 `--url`、`--data-raw` 等，见 `kweaver --help`） | `references/call.md` |
 
 ## 操作指南

--- a/skills/kweaver-core/references/auth.md
+++ b/skills/kweaver-core/references/auth.md
@@ -28,13 +28,14 @@ kweaver auth delete <url|alias> [--user <id|username>]
 
 | 场景 | 是否读 `KWEAVER_TOKEN` / `KWEAVER_BASE_URL` | 说明 |
 |------|---------------------------------------------|------|
+| **CLI 全局flag** `--token` / `--base-url` | 是（注入为 env） | 最高优先级之一；`--token` 会设置内部 `KWEAVER_TOKEN_SOURCE=flag`，**禁止**写盘命令（`auth login`/`logout`/`use`/`delete`/`switch`、`config set-bd`、整个 `context-loader config` 组）。`whoami`/`status` 在 flag 模式下标注 `CLI (flag: --token)`（`whoami --json` 为 `"source":"flag"`）。 |
 | 业务命令（`bkn`、`call`、`agent`、`kn`、`vega` 等） | 是 | 解析顺序一般为 **显式参数 > 环境变量 > `~/.kweaver/`**（与 SDK 一致）。 |
-| `kweaver auth status`、`kweaver auth whoami`、`kweaver config show` | 是（兜底） | 默认读 `~/.kweaver/` 的当前平台；**若无当前平台**，可同时设置 `KWEAVER_BASE_URL` + `KWEAVER_TOKEN`。`whoami` 在 env 模式下会调用一次 EACP `/api/eacp/v1/user/get` 在线获取身份，展示 `Type`/`User ID`/`Account`/`Name`（对 opaque 与 JWT 都生效）；EACP 不可达时回退本地 JWT 解码。**不写盘、不缓存、不增加旗标**。 |
+| `kweaver auth status`、`kweaver auth whoami`、`kweaver config show` | 是（兜底） | 默认读 `~/.kweaver/` 的当前平台；**若无当前平台**，可同时设置 `KWEAVER_BASE_URL` + `KWEAVER_TOKEN`。`whoami` 在 env 模式下会调用一次 EACP `/api/eacp/v1/user/get` 在线获取身份，展示 `Type`/`User ID`/`Account`/`Name`（对 opaque 与 JWT 都生效）；EACP 不可达时回退本地 JWT 解码。**不写盘、不缓存、不增加flag**。 |
 | `kweaver auth users` / `auth switch` / `auth export`、`kweaver config set-bd` | 否 | 只操作本地已保存的多用户档案或写 `~/.kweaver/`；环境变量中的 token **不会**被这些命令读取。 |
 
-**常用环境变量**：`KWEAVER_BASE_URL`（与 `KWEAVER_TOKEN` 配对时通常必填）、`KWEAVER_TOKEN`（可带或不带 `Bearer ` 前缀）、`KWEAVER_TLS_INSECURE`、`KWEAVER_BUSINESS_DOMAIN`、`KWEAVER_USER`、`KWEAVER_NO_AUTH`。
+**常用环境变量**：`KWEAVER_BASE_URL`（与 `KWEAVER_TOKEN` 配对时通常必填）、`KWEAVER_TOKEN`（可带或不带 `Bearer ` 前缀）、`KWEAVER_TLS_INSECURE`、`KWEAVER_BUSINESS_DOMAIN`、`KWEAVER_USER`、`KWEAVER_NO_AUTH`。`KWEAVER_TOKEN_SOURCE` 为 CLI 内部 sentinel（`--token` flag时设为 `flag`），**请勿手动设置**。
 
-**env 模式下 `auth status` / `whoami` 输出**：`whoami` 会标注 `Source: env (KWEAVER_TOKEN)`；refresh_token 在 env 路径下为 **n/a**。`whoami --json` 输出包含 `"source": "env"`、EACP 解析出的 `userInfo: { type, id, account?, name? }`，以及（EACP 不可达时）回退的 JWT payload。
+**env / flag 模式下 `auth status` / `whoami` 输出**：纯 env 路径下 `whoami` 标注 `Source: env (KWEAVER_TOKEN)`；使用 `--token` flag时为 `Source: CLI (flag: --token)`。refresh_token 在 env/flag 路径下为 **n/a**。`whoami --json` 输出包含 `"source": "env"` 或 `"source": "flag"`、EACP 解析出的 `userInfo: { type, id, account?, name? }`，以及（EACP 不可达时）回退的 JWT payload。
 
 **应用账号（app token）调用 `config list-bd`**：后端会以 `401 invalid user_id` 拒绝。CLI 检测到 401 后会复核一次 EACP 类型，若为 `type:"app"` 则把错误改写为 `This command does not support app accounts.`；其它情况保留原始错误文本。app token 不能调用任何"按用户绑定"的接口，请改用交互式 `auth login` 获得的用户 token。
 

--- a/skills/kweaver-core/references/context-loader.md
+++ b/skills/kweaver-core/references/context-loader.md
@@ -1,8 +1,23 @@
 # Context Loader 命令参考
 
-MCP JSON-RPC 协议的分层检索。需要先配置 KN 上下文。
+MCP JSON-RPC 协议的分层检索。
 
-## 配置
+## KN 选择
+
+运行时子命令接受 `<kn-id>` 作为**第一个位置参数**（与 `kweaver bkn …` 风格一致），MCP endpoint 自动从当前平台派生为 `<base-url>/api/agent-retrieval/v1/mcp`，无需任何持久化配置。也支持全局 `--kn-id <id>` / `-k <id>` flag。
+
+```bash
+kweaver context-loader tools <kn-id>
+kweaver context-loader search-schema <kn-id> "Pod"
+# 或者
+kweaver context-loader tools --kn-id <kn-id>
+```
+
+## 配置（已废弃）
+
+> **Deprecated**: `context-loader config` 子命令仍保留向后兼容，但每次调用打印 deprecation 警告，未来版本将移除。stateless 模式（`--token`）下整个 `config` 子命令组（`set` / `use` / `list` / `remove` / `show`）都直接被拒绝。
+>
+> 当运行时子命令省略 `<kn-id>` 且未提供 `--kn-id` flag时，会回退到此处保存的 `current` 条目（仅为兼容历史用法）。新代码请直接传 `<kn-id>`。
 
 ```bash
 kweaver context-loader config set --kn-id kn-123 [--name myconfig]
@@ -14,14 +29,16 @@ kweaver context-loader config remove myconfig
 
 ## MCP 内省
 
+下面所有示例中的 `<kn-id>` 也可以省略以回退到 deprecated 的 saved config（见上节）。
+
 ```bash
-kweaver context-loader tools           # 可用工具列表
-kweaver context-loader tool-call <name> --args '<json>'  # 直接调用任意 MCP tool
-kweaver context-loader resources       # 可用资源列表
-kweaver context-loader resource <uri>  # 读取资源
-kweaver context-loader templates       # 资源模板
-kweaver context-loader prompts         # 可用 prompt
-kweaver context-loader prompt <name> [--args '<json>']
+kweaver context-loader tools <kn-id>                       # 可用工具列表
+kweaver context-loader tool-call <kn-id> <name> --args '<json>'  # 直接调用任意 MCP tool
+kweaver context-loader resources <kn-id>                   # 可用资源列表
+kweaver context-loader resource <kn-id> <uri>              # 读取资源
+kweaver context-loader templates <kn-id>                   # 资源模板
+kweaver context-loader prompts <kn-id>                     # 可用 prompt
+kweaver context-loader prompt <kn-id> <name> [--args '<json>']
 ```
 
 ## Layer 1 — Schema 搜索
@@ -29,9 +46,9 @@ kweaver context-loader prompt <name> [--args '<json>']
 推荐使用 `search-schema`，它调用 MCP `search_schema`，支持 `object_types`、`relation_types`、`action_types`、`metric_types`。
 
 ```bash
-kweaver context-loader search-schema "Pod"
-kweaver context-loader search-schema "利润率" --scope object,metric --max 10 --brief --no-rerank
-kweaver context-loader search-schema "Pod" --format toon
+kweaver context-loader search-schema <kn-id> "Pod"
+kweaver context-loader search-schema <kn-id> "利润率" --scope object,metric --max 10 --brief --no-rerank
+kweaver context-loader search-schema <kn-id> "Pod" --format toon
 ```
 
 参数映射：`--format` -> `response_format`，`--scope` -> `search_scope`，`--max` -> `max_concepts`，`--brief` -> `schema_brief: true`，`--no-rerank` -> `enable_rerank: false`。
@@ -39,8 +56,8 @@ kweaver context-loader search-schema "Pod" --format toon
 兼容命令仍保留，但**全部走 Context Loader 公共 HTTP endpoint**（`/api/agent-retrieval/v1/kn/kn_search` 与 `/semantic-search`），不再触碰已被移除的 MCP `kn_search` / `kn_schema_search`：
 
 ```bash
-kweaver context-loader kn-search "Pod" [--only-schema]
-kweaver context-loader kn-schema-search "Pod" [--max 10]
+kweaver context-loader kn-search <kn-id> "Pod" [--only-schema]
+kweaver context-loader kn-schema-search <kn-id> "Pod" [--max 10]
 ```
 
 > SDK 层同样走 HTTP：TS `client.bkn.knSearch(...)`、Python `client.query.kn_search(...)` / `client.query.kn_schema_search(...)`。`ContextLoaderResource` 不再暴露 `kn_search` / `kn_schema_search` 方法——MCP 入口请直接用 `searchSchema` / `callTool`。
@@ -49,20 +66,20 @@ kweaver context-loader kn-schema-search "Pod" [--max 10]
 
 ```bash
 # 条件查询
-kweaver context-loader query-object-instance '{"ot_id": "ot-1", "condition": {"operation": "and", "sub_conditions": [{"field": "name", "operation": "==", "value_from": "const", "value": "web-pod"}]}, "limit": 5}'
+kweaver context-loader query-object-instance <kn-id> '{"ot_id": "ot-1", "condition": {"operation": "and", "sub_conditions": [{"field": "name", "operation": "==", "value_from": "const", "value": "web-pod"}]}, "limit": 5}'
 
 # 子图查询
-kweaver context-loader query-instance-subgraph '{"relation_type_paths": [{"start_ot_id": "ot-1", "paths": [{"rt_id": "rt-1", "direction": "positive"}]}]}'
+kweaver context-loader query-instance-subgraph <kn-id> '{"relation_type_paths": [{"start_ot_id": "ot-1", "paths": [{"rt_id": "rt-1", "direction": "positive"}]}]}'
 ```
 
 ## Layer 3 — 逻辑属性 & Action
 
 ```bash
 # 获取逻辑属性
-kweaver context-loader get-logic-properties '{"ot_id": "ot-1", "query": "status", "_instance_identities": [{"id": "123"}], "properties": ["status", "cpu"]}'
+kweaver context-loader get-logic-properties <kn-id> '{"ot_id": "ot-1", "query": "status", "_instance_identities": [{"id": "123"}], "properties": ["status", "cpu"]}'
 
 # 获取 Action 信息
-kweaver context-loader get-action-info '{"at_id": "at-1", "_instance_identity": {"id": "123"}}'
+kweaver context-loader get-action-info <kn-id> '{"at_id": "at-1", "_instance_identity": {"id": "123"}}'
 ```
 
 ### find-skills — 召回对象类下的 Skill
@@ -71,13 +88,13 @@ kweaver context-loader get-action-info '{"at_id": "at-1", "_instance_identity": 
 
 ```bash
 # 仅按对象类召回（top_k 默认 10）
-kweaver context-loader find-skills ot_drug
+kweaver context-loader find-skills <kn-id> ot_drug
 
 # 加自然语言查询和 top_k
-kweaver context-loader find-skills ot_drug --query "treatment" --top-k 5
+kweaver context-loader find-skills <kn-id> ot_drug --query "treatment" --top-k 5
 
 # 缩小到具体实例 + 切到 toon 输出
-kweaver context-loader find-skills ot_drug \
+kweaver context-loader find-skills <kn-id> ot_drug \
   --instance-identities '[{"drug_id": "DRUG_001"}]' \
   --format toon
 ```


### PR DESCRIPTION
## Summary

- Add stateless invocation: global `--token` + `--base-url` skip all reads/writes under `~/.kweaver/`. Internal sentinel `KWEAVER_TOKEN_SOURCE=flag` distinguishes flag-supplied token from env (`KWEAVER_TOKEN`).
- Guard write-to-disk commands with `assertNotStatelessForWrite` (`auth login/use/delete/logout/switch`, `config set-bd`, **all** `context-loader config *` including read-only `show/list`).
- `context-loader` runtime subcommands now accept `<kn-id>` as the first positional (or `--kn-id`) and derive the MCP URL from the active platform; saved config remains a deprecated fallback for old projects, prefixed with `[deprecated] ...` warning.
- `auth whoami` / `status` source label: `saved (~/.kweaver/...)` vs `env (KWEAVER_TOKEN)` vs `CLI (flag: --token)`.
- Update help text, READMEs, `SKILL.md`, references; replace `旗标` with `flag` in zh docs and simplify the stateless wording.
- New `packages/typescript/src/config/stateless.ts`; new `test/stateless-flags.test.ts`; extend `test/cli.test.ts`.

## Behavior matrix

| Scenario | exit | Notes |
|---|---|---|
| `--token` + business read commands | 0 | Output structurally identical to saved session |
| `--token` + write-to-disk (`auth/config/context-loader config *`) | 1 | `Cannot run \`...\` with --token` |
| `--token` + runtime `context-loader` + positional `<kn-id>` | 0 | Same output as saved session |
| `--token` + runtime `context-loader` without `<kn-id>` and no saved cfg | 1 | `Context-loader MCP is not configured` |
| Old project: saved-config fallback + runtime without `<kn-id>` | 0 | Backward compatible |
| Old project: `context-loader config <any>` | 0/1 | Works; emits `[deprecated]` warning |
| `--token` without base-url and no active platform | 1 | `--token requires a base URL` |
| `auth whoami` | 0 | `Source` distinguishes saved / env / CLI |

## Test plan

- [x] `make test` (TS unit, 801 tests passing, lint clean)
- [x] Manual against `https://dip-poc.aishu.cn`:
  - [x] `auth whoami` shows three distinct `Source:` labels (saved / env / CLI)
  - [x] `bkn list --limit 5` byte-identical between saved session and `--token` mode
  - [x] `agent list`, `vega health` byte-identical
  - [x] `ds list` structurally identical (server returns non-deterministic permission array order; same in saved-vs-saved runs)
  - [x] `context-loader tools/kn-search/kn-schema-search` three-way A=B=C (saved+positional / stateless+positional / saved-config fallback) structurally identical
  - [x] All `context-loader config *` (set/use/list/show/remove) blocked under `--token` with exit 1
  - [x] `auth login/logout`, `config set-bd` blocked under `--token` with exit 1
  - [x] `--token` runs do not modify `~/.kweaver/` (md5 unchanged before/after)
  - [x] Empty `KWEAVERC_CONFIG_DIR` + `--token` without `--base-url` exits 1 with helpful error

Made with [Cursor](https://cursor.com)