### PR TITLE
fix(bkn): fail-fast on PK auto-detection ambiguity, add --pk-map

### DIFF
--- a/packages/typescript/src/commands/bkn-ops.ts
+++ b/packages/typescript/src/commands/bkn-ops.ts
@@ -42,6 +42,8 @@ import {
   pollWithBackoff,
   detectPrimaryKey,
   detectDisplayKey,
+  formatPkDetectionError,
+  parsePkMap,
   confirmYes,
 } from "./bkn-utils.js";
 
@@ -573,6 +575,8 @@ Create a knowledge network from a datasource (dataviews + object types + optiona
 Options:
   --name <s>       Knowledge network name (required)
   --tables <a,b>   Comma-separated table names (default: all)
+  --pk-map <s>     Explicit primary keys: <table>:<field>[,<table>:<field>...]
+                   Required when auto-detection fails (no unique column in sample)
   --build (default)  Build after creation
   --no-build       Skip build after creation
   --timeout <n>    Build timeout in seconds (default: 300)
@@ -584,6 +588,7 @@ export function parseKnCreateFromDsArgs(args: string[]): {
   dsId: string;
   name: string;
   tables: string[];
+  pkMap: Record<string, string>;
   build: boolean;
   timeout: number;
   businessDomain: string;
@@ -593,6 +598,7 @@ export function parseKnCreateFromDsArgs(args: string[]): {
   let dsId = "";
   let name = "";
   let tablesStr = "";
+  let pkMapStr = "";
   let build = true;
   let timeout = 300;
   let businessDomain = "";
@@ -608,6 +614,10 @@ export function parseKnCreateFromDsArgs(args: string[]): {
     }
     if (arg === "--tables" && args[i + 1]) {
       tablesStr = args[++i];
+      continue;
+    }
+    if (arg === "--pk-map" && args[i + 1]) {
+      pkMapStr = args[++i];
       continue;
     }
     if (arg === "--build") {
@@ -644,8 +654,9 @@ export function parseKnCreateFromDsArgs(args: string[]): {
   if (!dsId || !name) {
     throw new Error("Usage: kweaver bkn create-from-ds <ds-id> --name X [options]");
   }
+  const pkMap = pkMapStr ? parsePkMap(pkMapStr) : {};
   if (!businessDomain) businessDomain = resolveBusinessDomain();
-  return { dsId, name, tables, build, timeout, businessDomain, pretty, noRollback };
+  return { dsId, name, tables, pkMap, build, timeout, businessDomain, pretty, noRollback };
 }
 
 /** Sanitize a table name into a BKN-safe ID (alphanumeric + underscore). */
@@ -742,6 +753,38 @@ export async function runKnCreateFromDsCommand(
       "Object type names derived from table names",
     );
 
+    // Pre-flight: resolve PK for every table BEFORE any side effect.
+    // Auto-detection silently picking the wrong column was the cause of
+    // issue #97 (KN built with ~5 indexed docs out of 2036 source rows).
+    // Resolve order: --pk-map override → cardinality-based detection → fail-fast.
+    const tablePks: Record<string, string> = {};
+    const unknownPkMapTables = Object.keys(options.pkMap).filter(
+      (name) => !targetTables.some((t) => t.name === name),
+    );
+    if (unknownPkMapTables.length > 0) {
+      throw new Error(
+        `--pk-map references unknown table(s): ${unknownPkMapTables.join(", ")}`
+      );
+    }
+    for (const t of targetTables) {
+      const override = options.pkMap[t.name];
+      if (override) {
+        if (!t.columns.some((c) => c.name === override)) {
+          throw new Error(
+            `--pk-map specifies '${override}' for table '${t.name}', but no such column. ` +
+              `Columns: ${t.columns.map((c) => c.name).join(", ")}`
+          );
+        }
+        tablePks[t.name] = override;
+        continue;
+      }
+      const result = detectPrimaryKey(t, sampleRows?.[t.name]);
+      if (!result.pk) {
+        throw new Error(formatPkDetectionError(t.name, result));
+      }
+      tablePks[t.name] = result.pk;
+    }
+
     // Phase 1: Create DataViews for each table. findDataView is idempotent;
     // not tracked for rollback so a retry can reuse what's already there.
     console.error(`Creating data views for ${targetTables.length} table(s) ...`);
@@ -791,7 +834,7 @@ export async function runKnCreateFromDsCommand(
       // (object_type_service.go:213-355) — all-or-nothing.
       console.error(`Creating ${targetTables.length} object type(s) ...`);
       const entries = targetTables.map((t) => {
-        const pk = detectPrimaryKey(t, sampleRows?.[t.name]);
+        const pk = tablePks[t.name]!;
         const dk = detectDisplayKey(t, pk);
         return {
           branch: "main",
@@ -904,7 +947,7 @@ Options:
   --tables <a,b>       Tables to include in KN (default: all imported)
   --build (default)    Build after creation
   --no-build           Skip build
-  --recreate           Use "insert" mode on first batch (only effective for new tables)
+  --pk-map <s>         Explicit primary keys: <table>:<field>[,<table>:<field>...]
   --timeout <n>        Build timeout in seconds (default: 300)
   --no-rollback        Keep partially-created KN on failure (debug; default: rollback)
   -bd, --biz-domain    Business domain (default: bd_public)`;
@@ -916,8 +959,8 @@ export function parseKnCreateFromCsvArgs(args: string[]): {
   tablePrefix: string;
   batchSize: number;
   tables: string[];
+  pkMap: Record<string, string>;
   build: boolean;
-  recreate: boolean;
   timeout: number;
   businessDomain: string;
   noRollback: boolean;
@@ -928,8 +971,8 @@ export function parseKnCreateFromCsvArgs(args: string[]): {
   let tablePrefix = "";
   let batchSize = 500;
   let tablesStr = "";
+  let pkMapStr = "";
   let build = true;
-  let recreate = false;
   let timeout = 300;
   let businessDomain = "";
   let noRollback = false;
@@ -966,8 +1009,8 @@ export function parseKnCreateFromCsvArgs(args: string[]): {
       build = false;
       continue;
     }
-    if (arg === "--recreate") {
-      recreate = true;
+    if (arg === "--pk-map" && args[i + 1]) {
+      pkMapStr = args[++i];
       continue;
     }
     if (arg === "--no-rollback") {
@@ -992,8 +1035,9 @@ export function parseKnCreateFromCsvArgs(args: string[]): {
   if (!dsId || !files || !name) {
     throw new Error("Usage: kweaver bkn create-from-csv <ds-id> --files <glob> --name X [options]");
   }
+  const pkMap = pkMapStr ? parsePkMap(pkMapStr) : {};
   if (!businessDomain) businessDomain = resolveBusinessDomain();
-  return { dsId, files, name, tablePrefix, batchSize, tables, build, recreate, timeout, businessDomain, noRollback };
+  return { dsId, files, name, tablePrefix, batchSize, tables, pkMap, build, timeout, businessDomain, noRollback };
 }
 
 export async function runKnCreateFromCsvCommand(args: string[]): Promise<number> {
@@ -1034,7 +1078,6 @@ export async function runKnCreateFromCsvCommand(args: string[]): Promise<number>
     "--table-prefix", options.tablePrefix,
     "--batch-size", String(options.batchSize),
     "-bd", options.businessDomain,
-    ...(options.recreate ? ["--recreate"] : []),
   ];
   const importResult = await runDsImportCsv(importArgs);
   if (importResult.code !== 0) {
@@ -1071,6 +1114,7 @@ export async function runKnCreateFromCsvCommand(args: string[]): Promise<number>
     console.error("No tables available for KN creation — aborting");
     return 1;
   }
+  const pkMapEntries = Object.entries(options.pkMap);
   const knArgs = [
     options.dsId,
     "--name", options.name,
@@ -1078,6 +1122,9 @@ export async function runKnCreateFromCsvCommand(args: string[]): Promise<number>
     options.build ? "--build" : "--no-build",
     "--timeout", String(options.timeout),
     "-bd", options.businessDomain,
+    ...(pkMapEntries.length > 0
+      ? ["--pk-map", pkMapEntries.map(([t, f]) => `${t}:${f}`).join(",")]
+      : []),
     ...(options.noRollback ? ["--no-rollback"] : []),
   ];
   return runKnCreateFromDsCommand(knArgs, importResult.sampleRows);

--- a/packages/typescript/src/commands/bkn-utils.ts
+++ b/packages/typescript/src/commands/bkn-utils.ts
@@ -94,20 +94,103 @@ export function parseOntologyQueryFlags(args: string[]): {
 
 export const DISPLAY_HINTS = ["name", "title", "label", "display_name", "description"];
 
-/** Detect primary key: first column (left-to-right) with all unique values in the sample. */
+export interface PkCandidate { name: string; cardinality: number; }
+
+export interface PkDetectionResult {
+  /** Detected PK column name, or null when detection is not confident. */
+  pk: string | null;
+  /** All columns sorted by cardinality desc. Empty when no sample. */
+  candidates: PkCandidate[];
+  /** 0 when no sample data was provided. */
+  sampleSize: number;
+}
+
+export const PK_NAME_HINTS = ["id", "_id", "pk"];
+
+/**
+ * Detect primary key from a row sample. Returns null pk when no column has
+ * unique values across the sample — caller must fail-fast and prompt for --pk-map.
+ * Among columns that ARE fully unique, prefers PK-like names (id, *_id, pk).
+ */
 export function detectPrimaryKey(
   table: { name: string; columns: Array<{ name: string; type: string }> },
   rows?: Array<Record<string, string | null>>,
-): string {
-  if (rows && rows.length > 0) {
-    for (const col of table.columns) {
-      const values = rows.map((r) => r[col.name]);
-      const unique = new Set(values);
-      if (unique.size === rows.length) return col.name;
+): PkDetectionResult {
+  if (!rows || rows.length === 0) {
+    return { pk: null, candidates: [], sampleSize: 0 };
+  }
+
+  const candidates: PkCandidate[] = table.columns
+    .map((col) => {
+      const unique = new Set(rows.map((r) => r[col.name]));
+      return { name: col.name, cardinality: unique.size };
+    })
+    .sort((a, b) => b.cardinality - a.cardinality);
+
+  const fullCardinality = candidates.filter((c) => c.cardinality === rows.length);
+  if (fullCardinality.length === 0) {
+    return { pk: null, candidates, sampleSize: rows.length };
+  }
+
+  const named = fullCardinality.find((c) => {
+    const lower = c.name.toLowerCase();
+    return PK_NAME_HINTS.some((h) => lower === h || lower.endsWith(`_${h}`));
+  });
+
+  return {
+    pk: named?.name ?? fullCardinality[0]!.name,
+    candidates,
+    sampleSize: rows.length,
+  };
+}
+
+/** Format a user-facing error message when PK auto-detection fails. */
+export function formatPkDetectionError(tableName: string, result: PkDetectionResult): string {
+  const lines = [`Cannot auto-detect primary key for table '${tableName}'.`];
+
+  if (result.sampleSize === 0) {
+    lines.push(
+      `  No sample data available — chain with 'kweaver ds import-csv' or use --pk-map.`
+    );
+  } else {
+    lines.push(`  No column has unique values in the ${result.sampleSize}-row sample.`);
+    lines.push(`  Top candidates by cardinality:`);
+    const top = result.candidates.slice(0, 5);
+    const maxNameLen = Math.max(...top.map((c) => c.name.length));
+    for (const c of top) {
+      lines.push(`    ${c.name.padEnd(maxNameLen)}  ${c.cardinality} unique`);
     }
   }
-  // Fallback: first column
-  return table.columns[0]?.name ?? "id";
+
+  lines.push(``);
+  lines.push(`  Re-run with --pk-map to specify explicitly:`);
+  lines.push(`    --pk-map ${tableName}:<column>`);
+  return lines.join("\n");
+}
+
+/**
+ * Parse --pk-map string into a Record<table, field>.
+ * Format: "<table>:<field>[,<table>:<field>...]". Throws on invalid input.
+ */
+export function parsePkMap(input: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const pair of input.split(",").map((s) => s.trim()).filter(Boolean)) {
+    const idx = pair.indexOf(":");
+    if (idx <= 0 || idx >= pair.length - 1) {
+      throw new Error(
+        `Invalid --pk-map entry '${pair}'. Expected '<table>:<field>[,<table>:<field>...]'`
+      );
+    }
+    const table = pair.slice(0, idx).trim();
+    const field = pair.slice(idx + 1).trim();
+    if (!table || !field) {
+      throw new Error(
+        `Invalid --pk-map entry '${pair}'. Expected '<table>:<field>[,<table>:<field>...]'`
+      );
+    }
+    result[table] = field;
+  }
+  return result;
 }
 
 export function detectDisplayKey(

--- a/packages/typescript/test/bkn-create-from-ds.test.ts
+++ b/packages/typescript/test/bkn-create-from-ds.test.ts
@@ -1,5 +1,8 @@
-import test from "node:test";
+import test, { before, after } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   assertValidBknObjectNames,
@@ -7,6 +10,24 @@ import {
   parseKnCreateFromDsArgs,
   parseKnCreateFromCsvArgs,
 } from "../src/commands/bkn-ops.js";
+import {
+  detectPrimaryKey,
+  formatPkDetectionError,
+  parsePkMap,
+} from "../src/commands/bkn-utils.js";
+
+let savedConfigDir: string | undefined;
+before(() => {
+  savedConfigDir = process.env.KWEAVERC_CONFIG_DIR;
+  process.env.KWEAVERC_CONFIG_DIR = mkdtempSync(join(tmpdir(), "kweaver-bkn-create-test-"));
+});
+after(() => {
+  if (savedConfigDir !== undefined) {
+    process.env.KWEAVERC_CONFIG_DIR = savedConfigDir;
+  } else {
+    delete process.env.KWEAVERC_CONFIG_DIR;
+  }
+});
 
 // ── assertValidBknObjectNames ────────────────────────────────────────────────
 
@@ -77,4 +98,145 @@ test("parseKnCreateFromCsvArgs: --no-rollback round-trips", () => {
     "--no-rollback",
   ]);
   assert.equal(opts.noRollback, true);
+});
+
+// ── detectPrimaryKey ─────────────────────────────────────────────────────────
+
+const TBL = (cols: string[]) => ({
+  name: "t",
+  columns: cols.map((name) => ({ name, type: "string" })),
+});
+
+test("detectPrimaryKey: returns null pk when no sample provided", () => {
+  const r = detectPrimaryKey(TBL(["a", "b"]));
+  assert.equal(r.pk, null);
+  assert.equal(r.sampleSize, 0);
+  assert.deepEqual(r.candidates, []);
+});
+
+test("detectPrimaryKey: returns null pk when no column is fully unique", () => {
+  // 'sector' has 2 unique values in 4-row sample — the issue #97 scenario.
+  const rows = [
+    { sector: "auto", company: "A" },
+    { sector: "auto", company: "B" },
+    { sector: "tech", company: "C" },
+    { sector: "tech", company: "C" },
+  ];
+  const r = detectPrimaryKey(TBL(["sector", "company"]), rows);
+  assert.equal(r.pk, null);
+  assert.equal(r.sampleSize, 4);
+  // Candidates sorted desc by cardinality.
+  assert.equal(r.candidates[0]!.name, "company");
+  assert.equal(r.candidates[0]!.cardinality, 3);
+  assert.equal(r.candidates[1]!.name, "sector");
+  assert.equal(r.candidates[1]!.cardinality, 2);
+});
+
+test("detectPrimaryKey: picks the unique column when only one is fully unique", () => {
+  const rows = [
+    { id: "1", sector: "auto" },
+    { id: "2", sector: "auto" },
+    { id: "3", sector: "tech" },
+  ];
+  const r = detectPrimaryKey(TBL(["sector", "id"]), rows);
+  assert.equal(r.pk, "id");
+});
+
+test("detectPrimaryKey: prefers PK-like names among ties", () => {
+  // Both 'user_id' and 'token' are fully unique; should prefer 'user_id'.
+  const rows = [
+    { token: "x", user_id: "1" },
+    { token: "y", user_id: "2" },
+    { token: "z", user_id: "3" },
+  ];
+  const r = detectPrimaryKey(TBL(["token", "user_id"]), rows);
+  assert.equal(r.pk, "user_id");
+});
+
+test("detectPrimaryKey: returns null on empty rows array", () => {
+  const r = detectPrimaryKey(TBL(["a"]), []);
+  assert.equal(r.pk, null);
+  assert.equal(r.sampleSize, 0);
+});
+
+// ── formatPkDetectionError ───────────────────────────────────────────────────
+
+test("formatPkDetectionError: no-sample message mentions --pk-map and import-csv", () => {
+  const msg = formatPkDetectionError("my_table", { pk: null, candidates: [], sampleSize: 0 });
+  assert.match(msg, /my_table/);
+  assert.match(msg, /No sample data/);
+  assert.match(msg, /--pk-map my_table:<column>/);
+});
+
+test("formatPkDetectionError: with-sample message lists candidates and shows --pk-map example", () => {
+  const msg = formatPkDetectionError("ht_v2_industry_graph_en", {
+    pk: null,
+    candidates: [
+      { name: "company_abbr", cardinality: 97 },
+      { name: "vehicle_id", cardinality: 95 },
+      { name: "sector", cardinality: 5 },
+    ],
+    sampleSize: 100,
+  });
+  assert.match(msg, /No column has unique values in the 100-row sample/);
+  assert.match(msg, /company_abbr.*97 unique/);
+  assert.match(msg, /sector.*5 unique/);
+  assert.match(msg, /--pk-map ht_v2_industry_graph_en:<column>/);
+});
+
+// ── parsePkMap ───────────────────────────────────────────────────────────────
+
+test("parsePkMap: single entry", () => {
+  assert.deepEqual(parsePkMap("t1:f1"), { t1: "f1" });
+});
+
+test("parsePkMap: multiple entries", () => {
+  assert.deepEqual(
+    parsePkMap("t1:f1,t2:f2"),
+    { t1: "f1", t2: "f2" },
+  );
+});
+
+test("parsePkMap: trims whitespace", () => {
+  assert.deepEqual(
+    parsePkMap("  t1 : f1 , t2:f2 "),
+    { t1: "f1", t2: "f2" },
+  );
+});
+
+test("parsePkMap: rejects entry without colon", () => {
+  assert.throws(() => parsePkMap("t1"), /Invalid --pk-map entry/);
+});
+
+test("parsePkMap: rejects entry with empty table or field", () => {
+  assert.throws(() => parsePkMap(":f1"), /Invalid --pk-map entry/);
+  assert.throws(() => parsePkMap("t1:"), /Invalid --pk-map entry/);
+});
+
+// ── parseKnCreateFromDsArgs --pk-map ─────────────────────────────────────────
+
+test("parseKnCreateFromDsArgs: defaults pkMap to empty", () => {
+  const opts = parseKnCreateFromDsArgs(["ds-1", "--name", "kn-x"]);
+  assert.deepEqual(opts.pkMap, {});
+});
+
+test("parseKnCreateFromDsArgs: --pk-map populates pkMap", () => {
+  const opts = parseKnCreateFromDsArgs([
+    "ds-1",
+    "--name", "kn-x",
+    "--pk-map", "t1:f1,t2:f2",
+  ]);
+  assert.deepEqual(opts.pkMap, { t1: "f1", t2: "f2" });
+});
+
+// ── parseKnCreateFromCsvArgs --pk-map ────────────────────────────────────────
+
+test("parseKnCreateFromCsvArgs: --pk-map populates pkMap", () => {
+  const opts = parseKnCreateFromCsvArgs([
+    "ds-1",
+    "--files", "./a.csv",
+    "--name", "kn-x",
+    "--pk-map", "t1:f1",
+  ]);
+  assert.deepEqual(opts.pkMap, { t1: "f1" });
 });


### PR DESCRIPTION
## Summary

Closes #97 — `create-from-ds` was silently picking the first column as PK whenever auto-detection couldn't find a fully-unique column. For tables with low-cardinality leading columns (e.g. \`sector\` with only 5 unique values), this produced KNs with **~99.8% data loss** (5 indexed docs out of 2036 source rows) with no warning.

## Root cause

\`detectPrimaryKey\` 旧实现：
\`\`\`ts
for col in columns: if unique.size === rows.length: return col
return columns[0]  // silent fallback when nothing is unique
\`\`\`

两个失败模式：
1. **独立调用 \`create-from-ds\`** — 没有 sample，直接返回第一列
2. **链式调用** — sample 里没有列全唯一时，依然返回第一列

## Fix: fail-fast + explicit override

| Situation | Old behavior | New behavior |
|---|---|---|
| Sample has unique column | Pick first one | Pick highest-cardinality, prefer \`id\`/\`*_id\`/\`pk\` names |
| Sample has no unique column | Silent fallback to first column | **Fail with actionable error listing candidates** |
| No sample (standalone) | Silent fallback to first column | **Fail with hint to use \`--pk-map\` or chain with \`import-csv\`** |
| User supplies \`--pk-map\` | N/A | Use specified field, validate column exists |

Pre-flight runs BEFORE any backend side effect, so a PK ambiguity error never leaves a half-built KN behind.

### Error message example

\`\`\`
Cannot auto-detect primary key for table 'ht_v2_industry_graph_en'.
  No column has unique values in the 100-row sample.
  Top candidates by cardinality:
    company_abbr  97 unique
    vehicle_id    95 unique
    sector         5 unique

  Re-run with --pk-map to specify explicitly:
    --pk-map ht_v2_industry_graph_en:<column>
\`\`\`

## Why fail-fast over interactive prompt

- **Reproducible**: \`--pk-map\` lives in the command, scripts/CI rerun deterministically
- **Consistent**: same behavior in interactive and non-interactive modes
- **No \"oops, I pressed enter too fast\"**: forces an informed decision once

## Bonus: PR #101 followup

\`bkn create-from-csv\` was still passing \`--recreate\` to \`import-csv\`, but #101 already removed that flag downstream. Cleaned up here so the meaningless flag stops appearing in help text.

## Test plan

- [x] 15 new unit tests covering \`detectPrimaryKey\`, \`formatPkDetectionError\`, \`parsePkMap\`, and the new \`--pk-map\` argument parsing
- [x] All 813 tests pass locally
- [x] Pre-existing assert.equal(...businessDomain, \"bd_public\") tests now isolated via \`KWEAVERC_CONFIG_DIR\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)