### PR TITLE
fix(tool): OpenAPI path params in toolbox execute/debug envelope

### DIFF
--- a/packages/python/src/kweaver/resources/toolboxes.py
+++ b/packages/python/src/kweaver/resources/toolboxes.py
@@ -3,7 +3,8 @@
 Mirrors ``packages/typescript/src/api/toolboxes.ts``. The execute/debug
 endpoints expect an *envelope* JSON body — flat payloads cause the forwarder
 to drop downstream Authorization headers and the underlying tool answers with
-401 "token expired".
+401 "token expired". The envelope may include ``path`` for OpenAPI ``{param}``
+substitution.
 """
 
 from __future__ import annotations
@@ -34,6 +35,7 @@ def _build_envelope(
     body: Any,
     header: dict[str, Any] | None,
     query: dict[str, Any] | None,
+    path: dict[str, Any] | None,
     timeout: float | None,
 ) -> dict[str, Any]:
     envelope: dict[str, Any] = {}
@@ -41,6 +43,7 @@ def _build_envelope(
         envelope["timeout"] = timeout
     envelope["header"] = header or {}
     envelope["query"] = query or {}
+    envelope["path"] = path or {}
     envelope["body"] = body if body is not None else {}
     return envelope
 
@@ -185,6 +188,7 @@ class ToolboxesResource:
         body: Any = None,
         header: dict[str, Any] | None = None,
         query: dict[str, Any] | None = None,
+        path: dict[str, Any] | None = None,
         timeout: float | None = None,
         forward_auth: bool = True,
     ) -> Any:
@@ -200,6 +204,7 @@ class ToolboxesResource:
             body=body,
             header=header,
             query=query,
+            path=path,
             timeout=timeout,
             forward_auth=forward_auth,
         )
@@ -212,6 +217,7 @@ class ToolboxesResource:
         body: Any = None,
         header: dict[str, Any] | None = None,
         query: dict[str, Any] | None = None,
+        path: dict[str, Any] | None = None,
         timeout: float | None = None,
         forward_auth: bool = True,
     ) -> Any:
@@ -221,6 +227,7 @@ class ToolboxesResource:
             body=body,
             header=header,
             query=query,
+            path=path,
             timeout=timeout,
             forward_auth=forward_auth,
         )
@@ -229,11 +236,12 @@ class ToolboxesResource:
 
     def _invoke(
         self,
-        path: str,
+        route: str,
         *,
         body: Any,
         header: dict[str, Any] | None,
         query: dict[str, Any] | None,
+        path: dict[str, Any] | None,
         timeout: float | None,
         forward_auth: bool,
     ) -> Any:
@@ -243,5 +251,11 @@ class ToolboxesResource:
             bearer = auth_headers.get("Authorization") or auth_headers.get("authorization")
             if bearer:
                 merged_header["Authorization"] = bearer
-        envelope = _build_envelope(body=body, header=merged_header, query=query, timeout=timeout)
-        return _unwrap_data(self._http.post(path, json=envelope, timeout=timeout))
+        envelope = _build_envelope(
+            body=body,
+            header=merged_header,
+            query=query,
+            path=path,
+            timeout=timeout,
+        )
+        return _unwrap_data(self._http.post(route, json=envelope, timeout=timeout))

--- a/packages/python/tests/unit/test_toolboxes.py
+++ b/packages/python/tests/unit/test_toolboxes.py
@@ -93,6 +93,7 @@ def test_execute_posts_envelope_to_proxy_endpoint():
             "timeout": 42,
             "header": {"Authorization": "Bearer override"},
             "query": {"dry": "true"},
+            "path": {},
             "body": {"task_id": "x"},
         }
     finally:
@@ -131,6 +132,7 @@ def test_execute_auto_injects_authorization_header_from_session_token():
         assert envelope["header"] == {"Authorization": "tok-py"}  # type: ignore[index]
         assert envelope["body"] == {"k": 1}  # type: ignore[index]
         assert envelope["query"] == {}  # type: ignore[index]
+        assert envelope["path"] == {}  # type: ignore[index]
         assert "timeout" not in envelope  # type: ignore[operator]
     finally:
         client.close()
@@ -147,6 +149,25 @@ def test_execute_forward_auth_false_omits_authorization():
     try:
         client.toolboxes.execute("b1", "t1", body={}, forward_auth=False)
         assert captured["body"]["header"] == {}  # type: ignore[index]
+        assert captured["body"]["path"] == {}  # type: ignore[index]
+    finally:
+        client.close()
+
+
+def test_execute_and_debug_forward_path_parameter_into_envelope():
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={})
+
+    client = _client(handler)
+    try:
+        dv_id = "7028f2fa-0f7c-4249-b6f4-b08f87588d16"
+        client.toolboxes.execute("bg", "get_dataview_detail", path={"id": dv_id})
+        assert captured["body"]["path"] == {"id": dv_id}  # type: ignore[index]
+        client.toolboxes.debug("bq", "query_dataview_sql", path={"id": dv_id}, body={"limit": 3})
+        assert captured["body"]["path"] == {"id": dv_id}  # type: ignore[index]
     finally:
         client.close()
 
@@ -245,5 +266,6 @@ def test_execute_caller_provided_authorization_is_preserved():
         client.toolboxes.execute("b1", "t1", header={"authorization": "Bearer override"})
         # Case-insensitive: caller's lowercase key wins, no auto-injection above it.
         assert captured["body"]["header"] == {"authorization": "Bearer override"}  # type: ignore[index]
+        assert captured["body"]["path"] == {}  # type: ignore[index]
     finally:
         client.close()

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -193,7 +193,7 @@ kweaver context-loader search-schema|tool-call|kn-search|kn-schema-search <kn-id
 kweaver context-loader query-object-instance|query-instance-subgraph|get-logic-properties|get-action-info|find-skills <kn-id> ...
 kweaver context-loader config set/use/list/show                       (deprecated; <kn-id> may be omitted to fall back to saved config)
 kweaver toolbox create/list/publish/unpublish/delete
-kweaver tool upload/list/enable/disable
+kweaver tool upload/list/enable/disable/execute/debug (execute and debug accept --path for OpenAPI path params)
 kweaver call <path> [-X METHOD] [-d BODY] [-H header] [-F key=value]
 ```
 
@@ -242,6 +242,11 @@ kweaver tool upload --toolbox <BOX_ID> ./openapi.json
 # 3. Publish the toolbox and enable the tool
 kweaver toolbox publish <BOX_ID>
 kweaver tool enable --toolbox <BOX_ID> <TOOL_ID>
+
+# Invoke / debug: envelope supports `--header`, `--query`, `--body`, and **`--path`**
+# for OpenAPI `{param}` placeholders (required for paths like `/data-views/{id}`).
+kweaver tool debug --toolbox <BOX_ID> <TOOL_ID> \
+  --path '{"id":"<DATA_VIEW_UUID>"}' [--body '<json>']
 ```
 
 **No-auth platforms:** If OAuth is not enabled, use `kweaver auth <url> --no-auth` (or run a normal `auth login`; a **404** on `POST /oauth2/clients` switches to no-auth automatically). Credentials are still saved under `~/.kweaver/` and work with `auth use` / `auth list`. Optional: `KWEAVER_NO_AUTH=1` with `KWEAVER_BASE_URL` when no token env is set. SDK: `new KWeaverClient({ baseUrl, auth: false })` or `kweaver.configure({ baseUrl, auth: false })`.

--- a/packages/typescript/src/api/toolboxes.ts
+++ b/packages/typescript/src/api/toolboxes.ts
@@ -21,7 +21,7 @@ import { buildHeaders } from "./headers.js";
 //   POST   /tool-box/{box}/tool/{tool}/debug       debug tool (envelope JSON)
 //
 // Envelope shape required by /proxy and /debug:
-//   { "timeout": <s>, "header": {...}, "query": {...}, "body": {...} }
+//   { "timeout": <s>, "header": {...}, "query": {...}, "body": {...}, "path": {...} }
 // Flat-shape requests cause the forwarder to drop downstream Authorization
 // headers, which manifests as 401 "token expired" from the underlying tool.
 
@@ -222,6 +222,8 @@ export interface InvokeToolOptions extends BaseOpts {
   header?: Record<string, unknown>;
   /** Optional query params to forward. */
   query?: Record<string, unknown>;
+  /** Path parameter map for OpenAPI `{param}` placeholders (e.g. `{ id: "<uuid>" }`). */
+  path?: Record<string, unknown>;
   /** JSON body forwarded to the downstream tool. */
   body?: unknown;
   /** Per-call timeout in seconds; backend default applies when omitted. */
@@ -233,6 +235,7 @@ function buildEnvelope(opts: InvokeToolOptions): string {
   if (opts.timeout !== undefined) envelope.timeout = opts.timeout;
   envelope.header = opts.header ?? {};
   envelope.query = opts.query ?? {};
+  envelope.path = opts.path ?? {};
   envelope.body = opts.body ?? {};
   return JSON.stringify(envelope);
 }

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -117,7 +117,7 @@ Usage:
   kweaver tool enable|disable --toolbox <box-id> <tool-id>... [-bd value]
   kweaver tool execute|debug --toolbox <box-id> <tool-id>
                              [--body '<json>'|--body-file <path>]
-                             [--header '<json>'] [--query '<json>'] [--timeout <s>]
+                             [--header '<json>'] [--query '<json>'] [--path '<json>'] [--timeout <s>]
 
   kweaver vega health|stats|inspect
   kweaver vega catalog list|get|health|test-connection|discover|resources [options]

--- a/packages/typescript/src/commands/tool.ts
+++ b/packages/typescript/src/commands/tool.ts
@@ -13,8 +13,10 @@ Subcommands:
   enable --toolbox <box-id> <tool-id>...       Enable one or more tools
   disable --toolbox <box-id> <tool-id>...      Disable one or more tools
   execute --toolbox <box-id> <tool-id> [--body '<json>'|--body-file <path>]
+                                              [--header|--query|--path '<json>']
                                               Invoke a published+enabled tool
   debug   --toolbox <box-id> <tool-id> [--body '<json>'|--body-file <path>]
+                                              [--header|--query|--path '<json>']
                                               Invoke a tool (works on draft/disabled too)
 
 Options for execute/debug:
@@ -22,6 +24,9 @@ Options for execute/debug:
                           (Authorization is auto-injected from current session
                           when --header omits it; pass {} to send none)
   --query  '<json>'       Query params map forwarded to the downstream tool
+  --path   '<json>'       Path parameter map for OpenAPI path placeholders (e.g. {id})
+                          (JSON object: quote id and UUID, e.g. key id for get_dataview_detail /
+                          query_dataview_sql)
   --timeout <seconds>     Per-call timeout (backend default applies when omitted)
 
 Common options:
@@ -198,6 +203,7 @@ export interface ToolInvokeOptions {
   toolId: string;
   header?: Record<string, unknown>;
   query?: Record<string, unknown>;
+  path?: Record<string, unknown>;
   body?: unknown;
   bodyFile?: string;
   timeout?: number;
@@ -222,6 +228,7 @@ export function parseToolInvokeArgs(args: string[]): ToolInvokeOptions {
   let pretty = true;
   let header: Record<string, unknown> | undefined;
   let query: Record<string, unknown> | undefined;
+  let path: Record<string, unknown> | undefined;
   let body: unknown;
   let bodyProvided = false;
   let bodyFile: string | undefined;
@@ -232,6 +239,7 @@ export function parseToolInvokeArgs(args: string[]): ToolInvokeOptions {
     if (a === "--toolbox" && args[i + 1]) { boxId = args[++i]; continue; }
     if (a === "--header" && args[i + 1]) { header = parseJsonOption("--header", args[++i]); continue; }
     if (a === "--query" && args[i + 1]) { query = parseJsonOption("--query", args[++i]); continue; }
+    if (a === "--path" && args[i + 1]) { path = parseJsonOption("--path", args[++i]); continue; }
     if (a === "--body" && args[i + 1]) {
       const raw = args[++i];
       try { body = JSON.parse(raw); }
@@ -261,6 +269,7 @@ export function parseToolInvokeArgs(args: string[]): ToolInvokeOptions {
     toolId,
     header,
     query,
+    path,
     body: bodyProvided ? body : undefined,
     bodyFile,
     timeout,
@@ -305,6 +314,7 @@ async function runToolInvoke(args: string[], action: "execute" | "debug"): Promi
     toolId: opts.toolId,
     header,
     query: opts.query,
+    path: opts.path,
     body,
     timeout: opts.timeout,
   });

--- a/packages/typescript/src/resources/toolboxes.ts
+++ b/packages/typescript/src/resources/toolboxes.ts
@@ -17,6 +17,8 @@ export interface InvokeToolArgs {
    *  send no headers. */
   header?: Record<string, unknown>;
   query?: Record<string, unknown>;
+  /** Path parameters for OpenAPI `{name}` placeholders (e.g. `{ id: "<uuid>" }`). */
+  path?: Record<string, unknown>;
   body?: unknown;
   /** Per-call timeout in seconds (backend default applies when omitted). */
   timeout?: number;

--- a/packages/typescript/test/tool-execute.test.ts
+++ b/packages/typescript/test/tool-execute.test.ts
@@ -38,6 +38,7 @@ test("executeTool POSTs envelope JSON to /tool-box/{box}/proxy/{tool}", async ()
       timeout: 42,
       header: { Authorization: "Bearer abc" },
       query: { dry: "true" },
+      path: {},
       body: { task_id: "x" },
     });
   } finally { restore(); }
@@ -55,7 +56,7 @@ test("debugTool POSTs envelope JSON to /tool-box/{box}/tool/{tool}/debug", async
   } finally { restore(); }
 });
 
-test("envelope defaults: omitted timeout absent, header/query/body coerced to {}", async () => {
+test("envelope defaults: omitted timeout absent, header/query/path/body coerced to {}", async () => {
   let captured: any = null;
   const restore = mockFetch(async (_url, init) => {
     captured = JSON.parse(init?.body as string);
@@ -63,8 +64,36 @@ test("envelope defaults: omitted timeout absent, header/query/body coerced to {}
   });
   try {
     await executeTool({ baseUrl: BASE, accessToken: TOKEN, boxId: "b1", toolId: "t1" });
-    assert.deepEqual(captured, { header: {}, query: {}, body: {} });
+    assert.deepEqual(captured, { header: {}, query: {}, path: {}, body: {} });
     assert.ok(!("timeout" in captured));
+  } finally { restore(); }
+});
+
+test("executeTool and debugTool forward path in envelope (data view tools)", async () => {
+  const bodies: string[] = [];
+  const restore = mockFetch(async (_url, init) => {
+    bodies.push(init?.body as string);
+    return new Response("{}", { status: 200 });
+  });
+  try {
+    const id = "7028f2fa-0f7c-4249-b6f4-b08f87588d16";
+    await executeTool({
+      baseUrl: BASE,
+      accessToken: TOKEN,
+      boxId: "bg",
+      toolId: "get_dataview_detail",
+      path: { id },
+    });
+    await debugTool({
+      baseUrl: BASE,
+      accessToken: TOKEN,
+      boxId: "bq",
+      toolId: "query_dataview_sql",
+      path: { id },
+      body: { limit: 3, offset: 0 },
+    });
+    assert.deepEqual(JSON.parse(bodies[0]).path, { id });
+    assert.deepEqual(JSON.parse(bodies[1]).path, { id });
   } finally { restore(); }
 });
 
@@ -75,12 +104,13 @@ test("parseToolInvokeArgs requires --toolbox and a tool id", () => {
   assert.throws(() => parseToolInvokeArgs(["--toolbox", "b1"]), /tool-id/i);
 });
 
-test("parseToolInvokeArgs parses headers/query/body/timeout", () => {
+test("parseToolInvokeArgs parses headers/query/path/body/timeout", () => {
   const opts = parseToolInvokeArgs([
     "--toolbox", "b1", "t1",
     "--body", '{"k":1}',
     "--header", '{"X-Foo":"bar"}',
     "--query", '{"q":"v"}',
+    "--path", '{"id":"7028f2fa-0f7c-4249-b6f4-b08f87588d16"}',
     "--timeout", "30",
   ]);
   assert.equal(opts.boxId, "b1");
@@ -88,6 +118,7 @@ test("parseToolInvokeArgs parses headers/query/body/timeout", () => {
   assert.deepEqual(opts.body, { k: 1 });
   assert.deepEqual(opts.header, { "X-Foo": "bar" });
   assert.deepEqual(opts.query, { q: "v" });
+  assert.deepEqual(opts.path, { id: "7028f2fa-0f7c-4249-b6f4-b08f87588d16" });
   assert.equal(opts.timeout, 30);
 });
 

--- a/skills/kweaver-core/SKILL.md
+++ b/skills/kweaver-core/SKILL.md
@@ -75,7 +75,7 @@ kweaver [--base-url <url>] [--token <access-token>] [--user <userId|username>] <
 | `dataflow` | Dataflow 文档流程 | `dataflow list`, `dataflow run <dagId> --file <path>`, `dataflow run <dagId> --url <remote-url> --name <filename>`, `dataflow runs <dagId> [--since <date-like>]`, `dataflow logs <dagId> <instanceId> [--detail]` | `references/dataflow.md` |
 | `skill` | Skill 注册、市场查找、渐进式读取、下载与安装 | `skill list`、`market`、`register --zip-file`、`content`、`read-file`、`install` | `references/skill.md` |
 | `toolbox` | 平台工具箱（toolbox）管理 | `toolbox create --name <n> --service-url <url>`、`toolbox list`、`toolbox publish/unpublish <id>`、`toolbox delete <id> [-y]` | `references/toolbox.md` |
-| `tool` | 工具箱内 tool 注册与启停（OpenAPI） | `tool upload --toolbox <id> <openapi-spec>`、`tool list --toolbox <id>`、`tool enable/disable --toolbox <id> <tool-id>...` | `references/tool.md` |
+| `tool` | 工具箱内 tool 注册与启停（OpenAPI）；`execute`/`debug` 支持 `--path` 注入 `{param}` | `tool upload --toolbox <id> <openapi-spec>`、`tool list --toolbox <id>`、`tool enable/disable --toolbox <id> <tool-id>...`、`tool debug --toolbox <id> <tool-id> --path '{"id":"..."}'` | `references/tool.md` |
 | `vega` | Vega 可观测平台 | `vega health`, `vega catalog list`, `vega resource list`, `vega query execute -d <json>`, `vega sql --resource-type <t> --query "<sql>"` / `vega sql -d <json>` | `references/vega.md` |
 | `context-loader` | MCP 分层检索 | `context-loader tools <kn-id>`, `context-loader kn-search <kn-id> <query>`（也支持 `--kn-id <id>` flag；省略时回退到 deprecated 的 `context-loader config`） | `references/context-loader.md` |
 | `call` | 通用 API 调用 | `call <url> [-X POST] [-d '...']`（可用 `curl` 别名；支持 `--url`、`--data-raw` 等，见 `kweaver --help`） | `references/call.md` |

--- a/skills/kweaver-core/references/tool.md
+++ b/skills/kweaver-core/references/tool.md
@@ -12,10 +12,10 @@ kweaver tool list    --toolbox <box-id> [-bd value] [--pretty|--compact]
 kweaver tool enable  --toolbox <box-id> <tool-id>... [-bd value]
 kweaver tool disable --toolbox <box-id> <tool-id>... [-bd value]
 kweaver tool execute --toolbox <box-id> <tool-id> [--body '<json>'|--body-file <path>]
-                     [--header '<json>'] [--query '<json>'] [--timeout <s>]
+                     [--header '<json>'] [--query '<json>'] [--path '<json>'] [--timeout <s>]
                      [-bd value] [--pretty|--compact]
 kweaver tool debug   --toolbox <box-id> <tool-id> [--body '<json>'|--body-file <path>]
-                     [--header '<json>'] [--query '<json>'] [--timeout <s>]
+                     [--header '<json>'] [--query '<json>'] [--path '<json>'] [--timeout <s>]
                      [-bd value] [--pretty|--compact]
 ```
 
@@ -71,13 +71,15 @@ kweaver tool disable --toolbox 1234567890123456789 tool-c
   "timeout": 60,
   "header": { "Authorization": "Bearer ..." },
   "query":  { "key": "value" },
+  "path":   { "id": "<uuid-or-path-param>" },
   "body":   { "...": "..." }
 }
 ```
 
-- 若直接发"扁平 body"（不裹 `header/body/query`），转发器会因 `Headers == nil` 把下游 `Authorization` 丢掉，下游服务回 `401 token expired`。
+- 若直接发"扁平 body"（不裹 `header/body/query/path`），转发器会因 `Headers == nil` 把下游 `Authorization` 丢掉，下游服务回 `401 token expired`。
 - CLI 默认会把当前会话的 `Bearer <token>` 作为 `Authorization` 注入 `header`；如果需要匿名调用，传 `--header '{}'` 显式覆盖。
 - `--body` 与 `--body-file` 互斥；都不传则 `body` 为 `{}`。
+- **`--path`**：OpenAPI 路径占位符（如 `/data-views/{id}`）的取值映射；不传则为 `{}`。Data View 类工具（如 `get_dataview_detail`、`query_dataview_sql`）必须传入 **`--path '{"id":"<数据视图-id>"}'`**，否则下游 URL 会保留字面 `{id}`。
 - `--timeout` 单位为秒；不传走后端默认。
 
 ```bash
@@ -85,6 +87,18 @@ kweaver tool disable --toolbox 1234567890123456789 tool-c
 kweaver tool execute \
   --toolbox 1234567890123456789 tool-create-task \
   --body '{"task_id":"t-1","task_name":"demo"}'
+
+# Debug — Data View（路径参数 id；`<tool-id>` 用 `tool list` 返回的 UUID，下列 operationId 仅示意）
+kweaver tool debug \
+  --toolbox <box-get> <tool-id> \
+  --path '{"id":"7028f2fa-0f7c-4249-b6f4-b08f87588d16"}' \
+  -bd bd_public
+
+kweaver tool debug \
+  --toolbox <box-query> <tool-id> \
+  --path '{"id":"7028f2fa-0f7c-4249-b6f4-b08f87588d16"}' \
+  --body '{"limit":3,"offset":0,"need_total":false,"sql":"SELECT 1"}' \
+  --header '{"content-type":"application/json","x-http-method-override":"GET"}'
 
 # Debug (草稿/disabled 也能跑)
 kweaver tool debug \


### PR DESCRIPTION
## Summary
- Forward **`path`** in the toolbox proxy/debug JSON envelope so downstream OpenAPI tools can resolve `{param}` placeholders (aligned with backend behavior).
- **`kweaver tool execute`** and **`kweaver tool debug`**: new **`--path '<json>'`** flag; help/README/skills updated per CLI policy.
- **Python** `ToolboxesResource`: same `path=` argument on `execute_tool` / `debug_tool`; `_invoke` route vs envelope `path` naming clarified.

## Test plan
- [x] `make -C packages/python test`
- [x] `make -C packages/typescript test`

Made with [Cursor](https://cursor.com)