### PR TITLE
feat: add KWEAVER_PROFILE env var for per-profile state scoping (#107)

### DIFF
--- a/packages/python/src/kweaver/config/store.py
+++ b/packages/python/src/kweaver/config/store.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import shutil
 import sys
 from dataclasses import dataclass, field
@@ -23,9 +24,7 @@ def _default_kweaver_root() -> Path:
     return Path.home() / ".kweaver"
 
 
-import re as _re
-
-_PROFILE_NAME_RE = _re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 
 def _get_profile_name() -> str | None:

--- a/packages/python/src/kweaver/config/store.py
+++ b/packages/python/src/kweaver/config/store.py
@@ -23,6 +23,25 @@ def _default_kweaver_root() -> Path:
     return Path.home() / ".kweaver"
 
 
+import re as _re
+
+_PROFILE_NAME_RE = _re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _get_profile_name() -> str | None:
+    raw = os.environ.get("KWEAVER_PROFILE")
+    if not raw:
+        return None
+    trimmed = raw.strip()
+    if not trimmed:
+        return None
+    if not _PROFILE_NAME_RE.match(trimmed):
+        raise ValueError(
+            f"KWEAVER_PROFILE='{raw}' is invalid. Use 1-64 chars from [A-Za-z0-9_-]."
+        )
+    return trimmed
+
+
 def iso_z(dt: "datetime | None" = None) -> str:
     """Return UTC timestamp matching JS ``new Date().toISOString()``: ``YYYY-MM-DDTHH:MM:SS.sssZ``.
 
@@ -113,6 +132,9 @@ class PlatformStore:
         self._migrate_all_to_user_scoped()
 
     def _state_path(self) -> Path:
+        profile = _get_profile_name()
+        if profile:
+            return self._root / "profiles" / profile / "state.json"
         return self._root / "state.json"
 
     def _platform_dir(self, url: str) -> Path:

--- a/packages/python/tests/unit/test_config_store_profile.py
+++ b/packages/python/tests/unit/test_config_store_profile.py
@@ -1,0 +1,71 @@
+"""Tests for KWEAVER_PROFILE env-var scoping of state.json (Python SDK)."""
+
+from pathlib import Path
+
+import pytest
+
+from kweaver.config.store import PlatformStore
+
+
+def _make_store(tmp_path: Path) -> PlatformStore:
+    return PlatformStore(root=tmp_path / ".kweaver")
+
+
+def test_profile_invalid_name_raises(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("KWEAVER_PROFILE", "../evil")
+    store = _make_store(tmp_path)
+    with pytest.raises(ValueError, match="KWEAVER_PROFILE"):
+        store.use("https://x.example.com")
+
+
+def test_profile_safe_name_routes_state_into_profile_dir(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("KWEAVER_PROFILE", "acct-a_1")
+    store = _make_store(tmp_path)
+    store.use("https://x.example.com")
+    assert (tmp_path / ".kweaver" / "profiles" / "acct-a_1" / "state.json").exists()
+    assert not (tmp_path / ".kweaver" / "state.json").exists()
+
+
+def test_profile_unset_uses_root_state(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("KWEAVER_PROFILE", raising=False)
+    store = _make_store(tmp_path)
+    store.use("https://z.example.com")
+    assert (tmp_path / ".kweaver" / "state.json").exists()
+    assert not (tmp_path / ".kweaver" / "profiles").exists()
+
+
+def test_two_profiles_share_tokens_but_isolate_active_state(tmp_path: Path, monkeypatch):
+    url_x = "https://x.example.com"
+    url_y = "https://y.example.com"
+    token_x = {
+        "baseUrl": url_x,
+        "accessToken": "tok-x",
+        "tokenType": "bearer",
+        "scope": "openid",
+        "obtainedAt": "2026-04-29T00:00:00.000Z",
+    }
+    token_y = {**token_x, "baseUrl": url_y, "accessToken": "tok-y"}
+
+    monkeypatch.setenv("KWEAVER_PROFILE", "a")
+    store_a = _make_store(tmp_path)
+    store_a.save_token(url_x, token_x)
+    store_a.use(url_x)
+    assert store_a.get_active() == url_x
+
+    monkeypatch.setenv("KWEAVER_PROFILE", "b")
+    store_b = _make_store(tmp_path)
+    assert store_b.get_active() is None
+    # Shared platforms/ dir: profile B can still read profile A's token.
+    assert store_b.load_token(url_x)["accessToken"] == "tok-x"
+
+    store_b.save_token(url_y, token_y)
+    store_b.use(url_y)
+    assert store_b.get_active() == url_y
+
+    monkeypatch.setenv("KWEAVER_PROFILE", "a")
+    store_a_reload = _make_store(tmp_path)
+    assert store_a_reload.get_active() == url_x
+
+    assert (tmp_path / ".kweaver" / "profiles" / "a" / "state.json").exists()
+    assert (tmp_path / ".kweaver" / "profiles" / "b" / "state.json").exists()
+    assert not (tmp_path / ".kweaver" / "state.json").exists()

--- a/packages/typescript/src/cli.ts
+++ b/packages/typescript/src/cli.ts
@@ -140,7 +140,19 @@ Usage:
 Global options:
   --base-url <url>  Override platform base URL for this command (env: KWEAVER_BASE_URL)
   --token <value>   Override access token for this command (env: KWEAVER_TOKEN; disables write-to-disk commands)
-  --user <id|name>  Use a specific user's credentials for this command (env: KWEAVER_USER)
+  --user <id|name>  Use a specific user's credentials for this command, transient (env: KWEAVER_USER)
+
+Multi-shell account isolation:
+  KWEAVER_PROFILE=<name>     Scope state.json (active platform / active user) to a named
+                             profile. Tokens under platforms/ are still shared, so each
+                             profile reuses logins. Required for \`auth switch\` and
+                             \`auth use\` (use --global to override). Name must match
+                             [A-Za-z0-9_-]{1,64}.
+  KWEAVERC_CONFIG_DIR=<dir>  Override the entire config root (~/.kweaver by default).
+                             Use this for hard isolation (separate token store per shell).
+
+For agents / multi-terminal scripts: prefer \`--user <id>\` (transient, no persistence)
+over \`auth switch\` (persistent, requires KWEAVER_PROFILE).
   --pretty / --compact
                     Toggle pretty-printed JSON output. Supported by every
                     command that prints a JSON payload (default: pretty).

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -25,6 +25,22 @@ import {
   setCurrentPlatform,
   setPlatformAlias,
 } from "../config/store.js";
+import { readFile } from "node:fs/promises";
+import { decodeJwtPayload } from "../config/jwt.js";
+import { eacpModifyPassword } from "../auth/eacp-modify-password.js";
+import {
+  buildCopyCommand,
+  fetchEacpUserInfo,
+  formatHttpError,
+  InitialPasswordChangeRequiredError,
+  normalizeBaseUrl,
+  oauth2Login,
+  oauth2PasswordSigninLogin,
+  promptForUsername,
+  promptForPassword,
+  refreshTokenLogin,
+  resolveActivePlatform,
+} from "../auth/oauth.js";
 
 function consumeGlobalFlag(args: string[]): { args: string[]; isGlobal: boolean } {
   const idx = args.indexOf("--global");
@@ -47,22 +63,6 @@ function requireProfileOrGlobal(command: string, isGlobal: boolean): string | nu
     `  - Intentionally global (CI / single-user setup): re-run with \`--global\`.`
   );
 }
-import { readFile } from "node:fs/promises";
-import { decodeJwtPayload } from "../config/jwt.js";
-import { eacpModifyPassword } from "../auth/eacp-modify-password.js";
-import {
-  buildCopyCommand,
-  fetchEacpUserInfo,
-  formatHttpError,
-  InitialPasswordChangeRequiredError,
-  normalizeBaseUrl,
-  oauth2Login,
-  oauth2PasswordSigninLogin,
-  promptForUsername,
-  promptForPassword,
-  refreshTokenLogin,
-  resolveActivePlatform,
-} from "../auth/oauth.js";
 
 export async function runAuthCommand(args: string[]): Promise<number> {
   const target = args[0];
@@ -610,15 +610,15 @@ You can specify either the userId (sub claim) or the username (preferred_usernam
     console.error(refusal);
     return 1;
   }
-  args = switchArgs;
+  const cleanedArgs = switchArgs;
 
-  const userArg = readOption(args, "--user");
+  const userArg = readOption(cleanedArgs, "--user");
   if (!userArg) {
     console.error("Usage: kweaver auth switch [--global] [platform-url|alias] --user <userId|username>");
     return 1;
   }
 
-  const filteredArgs = args.filter((a) => a !== "--user" && a !== userArg);
+  const filteredArgs = cleanedArgs.filter((a) => a !== "--user" && a !== userArg);
   const platform = resolvePlatformArg(filteredArgs);
   if (!platform) {
     console.error("No active platform. Run `kweaver auth login <platform-url>` first.");

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -9,6 +9,7 @@ import {
   getConfigDir,
   getCurrentPlatform,
   getPlatformAlias,
+  getProfileName,
   hasPlatform,
   listPlatforms,
   listUserProfiles,
@@ -24,6 +25,28 @@ import {
   setCurrentPlatform,
   setPlatformAlias,
 } from "../config/store.js";
+
+function consumeGlobalFlag(args: string[]): { args: string[]; isGlobal: boolean } {
+  const idx = args.indexOf("--global");
+  if (idx === -1) return { args, isGlobal: false };
+  return { args: [...args.slice(0, idx), ...args.slice(idx + 1)], isGlobal: true };
+}
+
+function requireProfileOrGlobal(command: string, isGlobal: boolean): string | null {
+  if (isGlobal) return null;
+  try {
+    if (getProfileName()) return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  return (
+    `kweaver auth ${command} mutates the active account globally and would affect every shell using ~/.kweaver.\n` +
+    `Pick one:\n` +
+    `  - Transient: prepend \`--user <id|name>\` (or \`KWEAVER_USER=<id>\`) to the command you actually want to run; no persistent switch.\n` +
+    `  - Persistent (this shell only): \`export KWEAVER_PROFILE=<name>\`, then re-run.\n` +
+    `  - Intentionally global (CI / single-user setup): re-run with \`--global\`.`
+  );
+}
 import { readFile } from "node:fs/promises";
 import { decodeJwtPayload } from "../config/jwt.js";
 import { eacpModifyPassword } from "../auth/eacp-modify-password.js";
@@ -424,11 +447,17 @@ Login options:
   }
 
   if (target === "use") {
-    const resolvedTarget = args[1] ? resolvePlatformIdentifier(args[1]) : "";
+    const { args: useArgs, isGlobal } = consumeGlobalFlag(args);
+    const refusal = requireProfileOrGlobal("use", isGlobal);
+    if (refusal !== null) {
+      console.error(refusal);
+      return 1;
+    }
+    const resolvedTarget = useArgs[1] ? resolvePlatformIdentifier(useArgs[1]) : "";
     const useTarget =
       resolvedTarget && /^https?:\/\//.test(resolvedTarget) ? normalizeBaseUrl(resolvedTarget) : resolvedTarget;
     if (!useTarget) {
-      console.error("Usage: kweaver auth use <platform-url|alias>");
+      console.error("Usage: kweaver auth use [--global] <platform-url|alias>");
       return 1;
     }
     if (!hasPlatform(useTarget)) {
@@ -568,16 +597,24 @@ You can use either userId or username with --user in switch/logout/delete.`);
 
 function runAuthSwitchCommand(args: string[]): number {
   if (args[0] === "--help" || args[0] === "-h") {
-    console.log(`kweaver auth switch [platform-url|alias] --user <userId|username>
+    console.log(`kweaver auth switch [--global] [platform-url|alias] --user <userId|username>
 
 Switch the active user for a platform.
 You can specify either the userId (sub claim) or the username (preferred_username from id_token).`);
     return 0;
   }
 
+  const { args: switchArgs, isGlobal } = consumeGlobalFlag(args);
+  const refusal = requireProfileOrGlobal("switch", isGlobal);
+  if (refusal !== null) {
+    console.error(refusal);
+    return 1;
+  }
+  args = switchArgs;
+
   const userArg = readOption(args, "--user");
   if (!userArg) {
-    console.error("Usage: kweaver auth switch [platform-url|alias] --user <userId|username>");
+    console.error("Usage: kweaver auth switch [--global] [platform-url|alias] --user <userId|username>");
     return 1;
   }
 

--- a/packages/typescript/src/commands/auth.ts
+++ b/packages/typescript/src/commands/auth.ts
@@ -612,7 +612,7 @@ You can specify either the userId (sub claim) or the username (preferred_usernam
   }
   const cleanedArgs = switchArgs;
 
-  const userArg = readOption(cleanedArgs, "--user");
+  const userArg = readOption(cleanedArgs, "--user") ?? process.env.KWEAVER_USER;
   if (!userArg) {
     console.error("Usage: kweaver auth switch [--global] [platform-url|alias] --user <userId|username>");
     return 1;

--- a/packages/typescript/src/config/store.ts
+++ b/packages/typescript/src/config/store.ts
@@ -104,6 +104,21 @@ export interface PlatformSummary {
   displayName?: string;
 }
 
+const PROFILE_NAME_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+export function getProfileName(): string | null {
+  const raw = process.env.KWEAVER_PROFILE;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (!PROFILE_NAME_RE.test(trimmed)) {
+    throw new Error(
+      `KWEAVER_PROFILE='${raw}' is invalid. Use 1-64 chars from [A-Za-z0-9_-].`,
+    );
+  }
+  return trimmed;
+}
+
 function getConfigDirPath(): string {
   return process.env.KWEAVERC_CONFIG_DIR || join(homedir(), ".kweaver");
 }
@@ -113,6 +128,10 @@ function getPlatformsDirPath(): string {
 }
 
 function getStateFilePath(): string {
+  const profile = getProfileName();
+  if (profile) {
+    return join(getConfigDirPath(), "profiles", profile, "state.json");
+  }
   return join(getConfigDirPath(), "state.json");
 }
 

--- a/packages/typescript/test/auth-switch-enforcement.test.ts
+++ b/packages/typescript/test/auth-switch-enforcement.test.ts
@@ -99,3 +99,22 @@ test("auth switch --global succeeds without KWEAVER_PROFILE", async () => {
   assert.equal(existsSync(join(dir, "state.json")), true);
   assert.equal(existsSync(join(dir, "profiles")), false);
 });
+
+test("auth switch reads --user from KWEAVER_USER env when consumed by top-level CLI", async () => {
+  // The top-level CLI in src/cli.ts strips global `--user X` from argv
+  // and stuffs it into KWEAVER_USER before dispatching to subcommands. So
+  // by the time `auth switch` runs, the flag may already be gone — the
+  // env var is the canonical source.
+  const dir = createDir();
+  const url = "https://x.example.com";
+  seedPlatform(dir, url, "user-1");
+  const mod = await freshAuthCmd(dir, "shellA");
+  process.env.KWEAVER_USER = "user-1";
+  try {
+    const code = await mod.runAuthCommand(["switch", url]);
+    assert.equal(code, 0);
+    assert.equal(existsSync(join(dir, "profiles", "shellA", "state.json")), true);
+  } finally {
+    delete process.env.KWEAVER_USER;
+  }
+});

--- a/packages/typescript/test/auth-switch-enforcement.test.ts
+++ b/packages/typescript/test/auth-switch-enforcement.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+function createDir(): string {
+  return mkdtempSync(join(tmpdir(), "kweaver-enforce-"));
+}
+
+async function freshAuthCmd(configDir: string, profile?: string) {
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  if (profile === undefined) delete process.env.KWEAVER_PROFILE;
+  else process.env.KWEAVER_PROFILE = profile;
+  const url = pathToFileURL(join(process.cwd(), "src/commands/auth.ts")).href;
+  return import(`${url}?t=${Date.now()}-${Math.random()}`);
+}
+
+function seedPlatform(configDir: string, baseUrl: string, userId: string) {
+  // Build the on-disk shape the store expects so auth use / switch have
+  // something to operate on without a real OAuth flow.
+  const enc = Buffer.from(baseUrl, "utf8")
+    .toString("base64")
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  const userDir = join(configDir, "platforms", enc, "users", userId);
+  mkdirSync(userDir, { recursive: true });
+  writeFileSync(join(userDir, "token.json"), JSON.stringify({
+    baseUrl,
+    accessToken: "tok",
+    tokenType: "bearer",
+    scope: "openid",
+    obtainedAt: "2026-04-29T00:00:00.000Z",
+    idToken: "",
+  }));
+}
+
+function captureStderr(): { restore: () => string } {
+  const orig = process.stderr.write.bind(process.stderr);
+  let buf = "";
+  // @ts-expect-error stub
+  process.stderr.write = (chunk: any) => {
+    buf += typeof chunk === "string" ? chunk : chunk.toString();
+    return true;
+  };
+  return {
+    restore: () => {
+      process.stderr.write = orig;
+      return buf;
+    },
+  };
+}
+
+test("auth switch refuses without KWEAVER_PROFILE", async () => {
+  const dir = createDir();
+  const url = "https://x.example.com";
+  seedPlatform(dir, url, "user-1");
+  const mod = await freshAuthCmd(dir, undefined);
+  const cap = captureStderr();
+  const code = await mod.runAuthCommand(["switch", url, "--user", "user-1"]);
+  const err = cap.restore();
+  assert.equal(code, 1);
+  assert.match(err, /KWEAVER_PROFILE/);
+  assert.match(err, /--user/); // hint to use the transient flag
+  assert.match(err, /--global/); // hint to escape-hatch
+});
+
+test("auth use refuses without KWEAVER_PROFILE", async () => {
+  const dir = createDir();
+  const url = "https://x.example.com";
+  seedPlatform(dir, url, "user-1");
+  const mod = await freshAuthCmd(dir, undefined);
+  const cap = captureStderr();
+  const code = await mod.runAuthCommand(["use", url]);
+  const err = cap.restore();
+  assert.equal(code, 1);
+  assert.match(err, /KWEAVER_PROFILE/);
+});
+
+test("auth switch succeeds with KWEAVER_PROFILE set", async () => {
+  const dir = createDir();
+  const url = "https://x.example.com";
+  seedPlatform(dir, url, "user-1");
+  const mod = await freshAuthCmd(dir, "shellA");
+  const code = await mod.runAuthCommand(["switch", url, "--user", "user-1"]);
+  assert.equal(code, 0);
+  // State file landed under the profile dir.
+  assert.equal(existsSync(join(dir, "profiles", "shellA", "state.json")), true);
+});
+
+test("auth switch --global succeeds without KWEAVER_PROFILE", async () => {
+  const dir = createDir();
+  const url = "https://x.example.com";
+  seedPlatform(dir, url, "user-1");
+  const mod = await freshAuthCmd(dir, undefined);
+  const code = await mod.runAuthCommand(["switch", "--global", url, "--user", "user-1"]);
+  assert.equal(code, 0);
+  // State file at root (no profile dir).
+  assert.equal(existsSync(join(dir, "state.json")), true);
+  assert.equal(existsSync(join(dir, "profiles")), false);
+});

--- a/packages/typescript/test/profile-env.test.ts
+++ b/packages/typescript/test/profile-env.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+function createDir(): string {
+  return mkdtempSync(join(tmpdir(), "kweaver-profile-"));
+}
+
+async function importStore(configDir: string, profile?: string) {
+  process.env.KWEAVERC_CONFIG_DIR = configDir;
+  if (profile === undefined) delete process.env.KWEAVER_PROFILE;
+  else process.env.KWEAVER_PROFILE = profile;
+  const url = pathToFileURL(join(process.cwd(), "src/config/store.ts")).href;
+  return import(`${url}?t=${Date.now()}-${Math.random()}`);
+}
+
+test("KWEAVER_PROFILE rejects invalid names (path traversal)", async () => {
+  const dir = createDir();
+  const store = await importStore(dir, "../evil");
+  assert.throws(() => store.getCurrentPlatform(), /KWEAVER_PROFILE/);
+});
+
+test("KWEAVER_PROFILE accepts safe names", async () => {
+  const dir = createDir();
+  const store = await importStore(dir, "acct-a_1");
+  assert.equal(store.getCurrentPlatform(), null);
+});
+
+test("unset KWEAVER_PROFILE writes state.json at config-dir root", async () => {
+  const dir = createDir();
+  const store = await importStore(dir, undefined);
+  store.saveTokenConfig({
+    baseUrl: "https://z.example.com",
+    accessToken: "tok-z",
+    tokenType: "bearer",
+    scope: "openid",
+    obtainedAt: "2026-04-29T00:00:00.000Z",
+  });
+  store.setCurrentPlatform("https://z.example.com");
+  assert.equal(existsSync(join(dir, "state.json")), true);
+  assert.equal(existsSync(join(dir, "profiles")), false);
+});
+
+test("two profiles share tokens but isolate currentPlatform", async () => {
+  const dir = createDir();
+
+  const storeA = await importStore(dir, "a");
+  storeA.saveTokenConfig({
+    baseUrl: "https://x.example.com",
+    accessToken: "tok-x",
+    tokenType: "bearer",
+    scope: "openid",
+    obtainedAt: "2026-04-29T00:00:00.000Z",
+  });
+  storeA.setCurrentPlatform("https://x.example.com");
+
+  const storeB = await importStore(dir, "b");
+  // No current platform in profile B even though token store is shared.
+  assert.equal(storeB.getCurrentPlatform(), null);
+  // Profile B can still load profile A's token by URL (shared platforms/).
+  assert.equal(
+    storeB.loadTokenConfig("https://x.example.com")?.accessToken,
+    "tok-x",
+  );
+
+  storeB.saveTokenConfig({
+    baseUrl: "https://y.example.com",
+    accessToken: "tok-y",
+    tokenType: "bearer",
+    scope: "openid",
+    obtainedAt: "2026-04-29T00:00:00.000Z",
+  });
+  storeB.setCurrentPlatform("https://y.example.com");
+
+  // Profile A's currentPlatform unchanged.
+  const storeAReloaded = await importStore(dir, "a");
+  assert.equal(storeAReloaded.getCurrentPlatform(), "https://x.example.com");
+});

--- a/skills/kweaver-core/references/auth.md
+++ b/skills/kweaver-core/references/auth.md
@@ -71,6 +71,22 @@ kweaver bkn list
 KWEAVER_USER=alice python my_script.py
 ```
 
+### 多终端 / Agent 场景的账号切换规则
+
+`kweaver auth switch` 与 `kweaver auth use` 会改写 `~/.kweaver/state.json`，**默认是全局副作用**：另一个 terminal 或并发运行的 agent 都会立刻看到当前账号变了。为了防止 agent 把别人的会话改坏，从 vX.Y.Z 起，这两个命令在 `KWEAVER_PROFILE` 未设时**直接拒绝执行**。
+
+| 场景 | 该用什么 | 为什么 |
+|---|---|---|
+| Agent 跑一条命令需要换个账号 | `kweaver --user <id\|name> <cmd>` 或 `KWEAVER_USER=<id> <cmd>` | 完全 transient，不写 `state.json`，对其他 terminal 零影响 |
+| 用户想让某个 shell 长期挂在某个账号上 | `export KWEAVER_PROFILE=<name>`，然后 `kweaver auth switch ... --user <id>` | profile 把 `state.json` 路由到 `~/.kweaver/profiles/<name>/`，与其他 shell 完全隔离；`platforms/` 下的 token 仍共享，不用重登 |
+| CI / 单用户脚本明确要全局切换 | `kweaver auth switch --global ... --user <id>` | 显式 opt-in 旧的全局行为；不推荐日常使用 |
+
+**Agent 默认规则**：除非用户明确说"持久切到 X"且当前 shell 已设 `KWEAVER_PROFILE`，**永远用 `--user X` 而不是 `auth switch`**。
+
+**profile 名规范**：`[A-Za-z0-9_-]{1,64}`。建议命名风格：`agent-<task-id>`、`shellA`、`acct-prod`。
+
+**已登过的账号在新 profile 里能直接用吗？** 能。token 文件在 `~/.kweaver/platforms/<encoded-url>/users/<userId>/token.json`，跨 profile 共享。新 profile 第一次跑 `auth switch` 把指针指过去就行。
+
 ### 工作流示例
 
 ```bash
@@ -84,10 +100,11 @@ kweaver auth list
 #   ├── bob (bob-uuid) *
 #   └── alice (alice-uuid)
 
-# 用用户名切换（永久）
+# 持久切换（必须先 export KWEAVER_PROFILE，否则会被拒绝）
+export KWEAVER_PROFILE=shellA
 kweaver auth switch prod --user alice
 
-# 或单次使用其他用户的凭证
+# 单次使用其他用户的凭证（transient，推荐用于 agent / 一次性脚本）
 kweaver --user bob bkn list
 
 # 登出特定用户

--- a/skills/kweaver-core/references/auth.md
+++ b/skills/kweaver-core/references/auth.md
@@ -75,13 +75,32 @@ KWEAVER_USER=alice python my_script.py
 
 `kweaver auth switch` 与 `kweaver auth use` 会改写 `~/.kweaver/state.json`，**默认是全局副作用**：另一个 terminal 或并发运行的 agent 都会立刻看到当前账号变了。为了防止 agent 把别人的会话改坏，从 vX.Y.Z 起，这两个命令在 `KWEAVER_PROFILE` 未设时**直接拒绝执行**。
 
+#### Agent 默认规则（最重要，先读这条）
+
+**用户说"用账号 X 做 Y"、"以 X 身份跑 Y"、"切到 X 然后…" → 一律是 transient 场景，直接 `kweaver --user X <cmd>` 就完事。** 不要 export 任何东西，不要碰 `auth switch`，不要试图"先切再跑"。
+
+只有当用户**明确**说"我希望这个 shell 以后都默认用 X"、"持久绑定到 X"、"不想每次都加 --user" 时，才走持久切换流程。这种场景一年用不到几次。
+
+❌ **反模式**（agent 最容易踩，永远不要这么做）：
+```bash
+# 用户："用 alice 看一下 bkn 列表"
+export KWEAVER_PROFILE=tmp        # 多余
+kweaver auth switch prod --user alice   # 多余、且无 PROFILE 时会被拒绝
+kweaver bkn list                  # 改坏了 state.json，污染了别的 shell
+```
+
+✅ **正确做法**：
+```bash
+kweaver --user alice bkn list     # 一行搞定，零副作用
+```
+
+#### 三种场景速查表
+
 | 场景 | 该用什么 | 为什么 |
 |---|---|---|
-| Agent 跑一条命令需要换个账号 | `kweaver --user <id\|name> <cmd>` 或 `KWEAVER_USER=<id> <cmd>` | 完全 transient，不写 `state.json`，对其他 terminal 零影响 |
-| 用户想让某个 shell 长期挂在某个账号上 | `export KWEAVER_PROFILE=<name>`，然后 `kweaver auth switch ... --user <id>` | profile 把 `state.json` 路由到 `~/.kweaver/profiles/<name>/`，与其他 shell 完全隔离；`platforms/` 下的 token 仍共享，不用重登 |
+| **Agent 跑一条/几条命令需要换账号**（默认） | `kweaver --user <id\|name> <cmd>` 或 `KWEAVER_USER=<id> <cmd>` | 完全 transient，不写 `state.json`，对其他 terminal 零影响 |
+| 用户**明确**要让某个 shell 长期挂在某个账号上 | `export KWEAVER_PROFILE=<name>`，然后 `kweaver auth switch ... --user <id>` | profile 把 `state.json` 路由到 `~/.kweaver/profiles/<name>/`，与其他 shell 完全隔离；`platforms/` 下的 token 仍共享，不用重登 |
 | CI / 单用户脚本明确要全局切换 | `kweaver auth switch --global ... --user <id>` | 显式 opt-in 旧的全局行为；不推荐日常使用 |
-
-**Agent 默认规则**：除非用户明确说"持久切到 X"且当前 shell 已设 `KWEAVER_PROFILE`，**永远用 `--user X` 而不是 `auth switch`**。
 
 **profile 名规范**：`[A-Za-z0-9_-]{1,64}`。建议命名风格：`agent-<task-id>`、`shellA`、`acct-prod`。
 


### PR DESCRIPTION
## Summary

- Add `KWEAVER_PROFILE` env var (TS + Python) to scope `state.json` per profile, enabling parallel agents/sessions without cross-contamination on shared `~/.kweaver/`
- Require `KWEAVER_PROFILE` for `auth switch` / `auth use`; add `--global` escape hatch for explicit cross-profile mutation
- Fix `auth switch --user` to fall back to `KWEAVER_USER` env (so transient agent overrides work)
- Update `kweaver-core` skill docs to teach agents to use `--user` (transient, agent-default) instead of `auth switch` (mutates shared state)

Closes #107.

## Test plan

- [x] TS unit: \`packages/typescript/test/auth-switch-enforcement.test.ts\` (120 lines) — covers KWEAVER_PROFILE required, --global escape, --user env fallback
- [x] TS unit: \`packages/typescript/test/profile-env.test.ts\` (81 lines) — state.json isolation per profile
- [x] Python unit: \`packages/python/tests/unit/test_config_store_profile.py\` (71 lines) — mirror for Python config store
- [ ] Manual: spawn two shells with different \`KWEAVER_PROFILE\` values, verify each writes its own \`state.json\` and \`auth switch\` in one doesn't affect the other