### PR TITLE
fix(sdk): consume schema-declared PK in bkn create-from-ds (#112)

### DIFF
--- a/packages/typescript/src/api/datasources.ts
+++ b/packages/typescript/src/api/datasources.ts
@@ -301,7 +301,11 @@ export async function listTablesWithColumns(options: ListTablesWithColumnsOption
   }
 
   const base = rest.baseUrl.replace(/\/+$/, "");
-  const tables: Array<{ name: string; columns: Array<{ name: string; type: string; comment?: string }> }> = [];
+  const tables: Array<{
+    name: string;
+    columns: Array<{ name: string; type: string; comment?: string; isPrimaryKey?: boolean }>;
+    primaryKeys?: string[];
+  }> = [];
 
   for (const t of items) {
     const tableId = String(t.id ?? "");
@@ -320,16 +324,55 @@ export async function listTablesWithColumns(options: ListTablesWithColumnsOption
       columnsRaw = Array.isArray(colData) ? colData : (colData.entries ?? colData.data ?? []);
     }
 
-    const columns = columnsRaw.map((c) => ({
-      name: String(c.name ?? c.field_name ?? ""),
-      type: String(c.type ?? c.field_type ?? "varchar"),
-      comment: typeof c.comment === "string" ? c.comment : undefined,
-    }));
+    const tablePkArray = extractPrimaryKeys(t);
 
-    tables.push({ name: tableName, columns });
+    const columns = columnsRaw.map((c) => {
+      const name = String(c.name ?? c.field_name ?? "");
+      const flagged = isColumnPrimaryKey(c) || tablePkArray.includes(name);
+      return {
+        name,
+        type: String(c.type ?? c.field_type ?? "varchar"),
+        comment: typeof c.comment === "string" ? c.comment : undefined,
+        ...(flagged ? { isPrimaryKey: true } : {}),
+      };
+    });
+
+    // Reconcile: if backend gave per-column flags but no table-level array,
+    // synthesize one so downstream callers have a single PK source of truth.
+    const synthesizedPks = tablePkArray.length > 0
+      ? tablePkArray
+      : columns.filter((c) => c.isPrimaryKey).map((c) => c.name);
+
+    tables.push({
+      name: tableName,
+      columns,
+      ...(synthesizedPks.length > 0 ? { primaryKeys: synthesizedPks } : {}),
+    });
   }
 
   return JSON.stringify(tables);
+}
+
+// Two PK metadata shapes are recognized — both confirmed conventions:
+//   - per-column `is_primary_key: true` (data-connection metadata standard)
+//   - per-column `column_key === "PRI"` (MySQL INFORMATION_SCHEMA pass-through)
+//   - table-level `primary_keys: string[]` (composite-PK carrier)
+// Other plausible spellings (camelCase, singular keys, SQLite `pk` integer) are
+// intentionally NOT recognized here — adding them speculatively risks false
+// matches and creates code paths the test suite can't pin down. Extend only when
+// a real backend response demonstrates the need.
+function isColumnPrimaryKey(col: Record<string, unknown>): boolean {
+  if (col.is_primary_key === true) return true;
+  if (typeof col.column_key === "string" && col.column_key.toUpperCase() === "PRI") return true;
+  return false;
+}
+
+function extractPrimaryKeys(table: Record<string, unknown>): string[] {
+  const arr = table.primary_keys;
+  if (Array.isArray(arr)) {
+    return arr.filter((x): x is string => typeof x === "string");
+  }
+  return [];
 }
 
 export interface ScanMetadataOptions {

--- a/packages/typescript/src/commands/bkn-ops.ts
+++ b/packages/typescript/src/commands/bkn-ops.ts
@@ -40,10 +40,10 @@ import { resolveBusinessDomain } from "../config/store.js";
 import { runDsImportCsv } from "./ds.js";
 import {
   pollWithBackoff,
-  detectPrimaryKey,
   detectDisplayKey,
   formatPkDetectionError,
   parsePkMap,
+  resolvePrimaryKey,
   confirmYes,
 } from "./bkn-utils.js";
 
@@ -716,7 +716,8 @@ export async function runKnCreateFromDsCommand(
     const tableRetryDelayMs = 4000;
     let allTables: Array<{
       name: string;
-      columns: Array<{ name: string; type: string }>;
+      columns: Array<{ name: string; type: string; isPrimaryKey?: boolean }>;
+      primaryKeys?: string[];
     }> = [];
     let targetTables: typeof allTables = [];
     let scanAttempted = false;
@@ -725,7 +726,8 @@ export async function runKnCreateFromDsCommand(
       const tablesBody = await listTablesWithColumns({ ...base, id: options.dsId });
       allTables = JSON.parse(tablesBody) as Array<{
         name: string;
-        columns: Array<{ name: string; type: string }>;
+        columns: Array<{ name: string; type: string; isPrimaryKey?: boolean }>;
+        primaryKeys?: string[];
       }>;
 
       targetTables = options.tables.length > 0
@@ -785,21 +787,31 @@ export async function runKnCreateFromDsCommand(
     }
     for (const t of targetTables) {
       const override = options.pkMap[t.name];
-      if (override) {
-        if (!t.columns.some((c) => c.name === override)) {
-          throw new Error(
-            `--pk-map specifies '${override}' for table '${t.name}', but no such column. ` +
-              `Columns: ${t.columns.map((c) => c.name).join(", ")}`
-          );
-        }
-        tablePks[t.name] = override;
+      if (override && !t.columns.some((c) => c.name === override)) {
+        throw new Error(
+          `--pk-map specifies '${override}' for table '${t.name}', but no such column. ` +
+            `Columns: ${t.columns.map((c) => c.name).join(", ")}`
+        );
+      }
+      const resolution = resolvePrimaryKey(t, sampleRows?.[t.name], override);
+      if (resolution.pk) {
+        tablePks[t.name] = resolution.pk;
         continue;
       }
-      const result = detectPrimaryKey(t, sampleRows?.[t.name]);
-      if (!result.pk) {
-        throw new Error(formatPkDetectionError(t.name, result));
+      if (resolution.source === "ambiguous") {
+        const cols = (resolution.ambiguous ?? []).join(", ");
+        throw new Error(
+          `Table '${t.name}' has a composite PRIMARY KEY (${cols}). ` +
+            `BKN object types take a single primary key — pick one with --pk-map ${t.name}:<column>.`
+        );
       }
-      tablePks[t.name] = result.pk;
+      throw new Error(
+        formatPkDetectionError(t.name, {
+          pk: null,
+          candidates: resolution.candidates ?? [],
+          sampleSize: resolution.sampleSize ?? 0,
+        }),
+      );
     }
 
     // Phase 1: Create DataViews for each table. findDataView is idempotent;

--- a/packages/typescript/src/commands/bkn-utils.ts
+++ b/packages/typescript/src/commands/bkn-utils.ts
@@ -144,6 +144,71 @@ export function detectPrimaryKey(
   };
 }
 
+export interface PkResolution {
+  /** Resolved PK column name, or null when caller must fail-fast. */
+  pk: string | null;
+  /** Origin of the resolution — used by callers for messaging and warnings. */
+  source: "override" | "schema" | "sample" | "ambiguous";
+  /** For 'sample' source: cardinality candidates from `detectPrimaryKey`. */
+  candidates?: PkCandidate[];
+  /** For 'sample' source: rows seen, propagated for error formatting. */
+  sampleSize?: number;
+  /** For 'ambiguous' source: schema-declared composite PK columns. */
+  ambiguous?: string[];
+}
+
+/**
+ * Resolve a single PK for a BKN object type, in priority order:
+ *   1. caller-provided override (e.g. --pk-map)
+ *   2. schema-declared single PK from datasource metadata
+ *   3. sample-based detection (CSV / schemaless sources)
+ * Composite SQL PKs intentionally surface as `source: "ambiguous"` — BKN
+ * object types take a single PK, so the caller must pick via --pk-map.
+ */
+export function resolvePrimaryKey(
+  table: {
+    name: string;
+    columns: Array<{ name: string; type: string; isPrimaryKey?: boolean }>;
+    primaryKeys?: string[];
+  },
+  sampleRows?: Array<Record<string, string | null>>,
+  override?: string | null,
+): PkResolution {
+  if (override) {
+    return { pk: override, source: "override" };
+  }
+
+  const schemaPks = collectSchemaPks(table);
+  if (schemaPks.length === 1) {
+    return { pk: schemaPks[0]!, source: "schema" };
+  }
+  if (schemaPks.length > 1) {
+    return { pk: null, source: "ambiguous", ambiguous: schemaPks };
+  }
+
+  const sample = detectPrimaryKey(table, sampleRows);
+  return {
+    pk: sample.pk,
+    source: "sample",
+    candidates: sample.candidates,
+    sampleSize: sample.sampleSize,
+  };
+}
+
+function collectSchemaPks(table: {
+  columns: Array<{ name: string; isPrimaryKey?: boolean }>;
+  primaryKeys?: string[];
+}): string[] {
+  // Filter against the actual column list — schema metadata can drift (stale
+  // catalog, post-rename) and an unusable PK should fall through cleanly to
+  // sample/fail rather than poison downstream object-type creation.
+  const colNames = new Set(table.columns.map((c) => c.name));
+  if (Array.isArray(table.primaryKeys) && table.primaryKeys.length > 0) {
+    return table.primaryKeys.filter((n) => colNames.has(n));
+  }
+  return table.columns.filter((c) => c.isPrimaryKey === true).map((c) => c.name);
+}
+
 /** Format a user-facing error message when PK auto-detection fails. */
 export function formatPkDetectionError(tableName: string, result: PkDetectionResult): string {
   const lines = [`Cannot auto-detect primary key for table '${tableName}'.`];

--- a/packages/typescript/src/commands/ds.ts
+++ b/packages/typescript/src/commands/ds.ts
@@ -465,13 +465,20 @@ async function printDsConnectOutput(
   const tablesBody = await listTablesWithColumns({ ...base, id: dsId });
   const tables = JSON.parse(tablesBody) as Array<{
     name: string;
-    columns: Array<{ name: string; type: string; comment?: string }>;
+    columns: Array<{ name: string; type: string; comment?: string; isPrimaryKey?: boolean }>;
+    primaryKeys?: string[];
   }>;
   const output = {
     datasource_id: dsId,
     tables: tables.map((t) => ({
       name: t.name,
-      columns: t.columns.map((c) => ({ name: c.name, type: c.type, comment: c.comment })),
+      ...(t.primaryKeys && t.primaryKeys.length > 0 ? { primary_keys: t.primaryKeys } : {}),
+      columns: t.columns.map((c) => ({
+        name: c.name,
+        type: c.type,
+        comment: c.comment,
+        ...(c.isPrimaryKey ? { is_primary_key: true } : {}),
+      })),
     })),
   };
   console.log(JSON.stringify(output, null, 2));

--- a/packages/typescript/test/bkn-resolve-pk.test.ts
+++ b/packages/typescript/test/bkn-resolve-pk.test.ts
@@ -1,0 +1,158 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { resolvePrimaryKey } from "../src/commands/bkn-utils.js";
+
+// `resolvePrimaryKey` is the bug-fix entry point. Precedence:
+//   1. caller-provided override (--pk-map)
+//   2. schema-declared PK (per-column isPrimaryKey OR single-element table-level primaryKeys)
+//   3. sample-based detection
+//   4. fail-fast (null result, caller formats error)
+// Composite PKs intentionally fall through to sampling/error: BKN object types
+// take a single primary_key, so a 2-column SQL PK can't be auto-resolved without
+// an explicit pick.
+
+test("resolvePrimaryKey: --pk-map override wins over schema PK", () => {
+  const t = {
+    name: "skills",
+    primaryKeys: ["skill_id"],
+    columns: [
+      { name: "skill_id", type: "varchar", isPrimaryKey: true },
+      { name: "alt_id", type: "varchar" },
+    ],
+  };
+  const r = resolvePrimaryKey(t, undefined, "alt_id");
+  assert.equal(r.pk, "alt_id");
+  assert.equal(r.source, "override");
+});
+
+test("resolvePrimaryKey: schema per-column flag wins over sample heuristic", () => {
+  const t = {
+    name: "skills",
+    columns: [
+      { name: "skill_id", type: "varchar", isPrimaryKey: true },
+      { name: "label", type: "varchar" },
+    ],
+  };
+  // Sample shows 'label' is fully unique — heuristic alone would pick it.
+  const sample = [
+    { skill_id: "SK-A", label: "alpha" },
+    { skill_id: "SK-B", label: "bravo" },
+  ];
+  const r = resolvePrimaryKey(t, sample);
+  assert.equal(r.pk, "skill_id");
+  assert.equal(r.source, "schema");
+});
+
+test("resolvePrimaryKey: schema table-level single PK is used directly", () => {
+  const t = {
+    name: "skills",
+    primaryKeys: ["skill_id"],
+    columns: [
+      { name: "skill_id", type: "varchar" },
+      { name: "label", type: "varchar" },
+    ],
+  };
+  const r = resolvePrimaryKey(t, undefined);
+  assert.equal(r.pk, "skill_id");
+  assert.equal(r.source, "schema");
+});
+
+test("resolvePrimaryKey: empty table with schema PK works (no sample needed)", () => {
+  // The original failure mode: empty/sparsely-seeded DB tables couldn't be onboarded
+  // because sampling returned no rows. Schema PK eliminates that dependency.
+  const t = {
+    name: "skills",
+    columns: [
+      { name: "skill_id", type: "varchar", isPrimaryKey: true },
+      { name: "label", type: "varchar" },
+    ],
+  };
+  const r = resolvePrimaryKey(t, undefined);
+  assert.equal(r.pk, "skill_id");
+  assert.equal(r.source, "schema");
+});
+
+test("resolvePrimaryKey: composite schema PK falls through (caller decides via --pk-map)", () => {
+  // BKN object types are single-PK; for composite SQL PKs the caller must pick
+  // explicitly. We surface this by NOT auto-resolving — sample/fail flow takes over.
+  const t = {
+    name: "mat_skill",
+    primaryKeys: ["sku", "skill_id"],
+    columns: [
+      { name: "sku", type: "varchar", isPrimaryKey: true },
+      { name: "skill_id", type: "varchar", isPrimaryKey: true },
+    ],
+  };
+  const r = resolvePrimaryKey(t, undefined);
+  assert.equal(r.pk, null);
+  assert.equal(r.source, "ambiguous");
+  assert.deepEqual(r.ambiguous, ["sku", "skill_id"]);
+});
+
+test("resolvePrimaryKey: falls back to sample-based detection when schema lacks PK", () => {
+  const t = {
+    name: "csv_table",
+    columns: [
+      { name: "id", type: "varchar" },
+      { name: "label", type: "varchar" },
+    ],
+  };
+  const sample = [
+    { id: "1", label: "a" },
+    { id: "2", label: "a" },
+  ];
+  const r = resolvePrimaryKey(t, sample);
+  assert.equal(r.pk, "id");
+  assert.equal(r.source, "sample");
+});
+
+test("resolvePrimaryKey: ignores schema PK that doesn't exist in columns (defensive)", () => {
+  // Backend metadata occasionally drifts (stale catalog, cross-table mix-up).
+  // A schema-declared PK that isn't in the columns list is unusable — fall through
+  // to sample/fail so the user sees a clear error instead of a downstream
+  // "column not found" from BKN object-type creation.
+  const t = {
+    name: "skills",
+    primaryKeys: ["ghost_column"],
+    columns: [
+      { name: "skill_id", type: "varchar" },
+      { name: "label", type: "varchar" },
+    ],
+  };
+  const r = resolvePrimaryKey(t, undefined);
+  // No usable schema PK, no sample → null with sample source.
+  assert.equal(r.pk, null);
+  assert.equal(r.source, "sample");
+});
+
+test("resolvePrimaryKey: drops schema PK whose column was renamed/removed, keeps the rest", () => {
+  // Composite case where one PK column is missing — surviving ones still flow.
+  const t = {
+    name: "mat_skill",
+    primaryKeys: ["sku", "ghost_col", "skill_id"],
+    columns: [
+      { name: "sku", type: "varchar" },
+      { name: "skill_id", type: "varchar" },
+    ],
+  };
+  const r = resolvePrimaryKey(t, undefined);
+  assert.equal(r.pk, null);
+  assert.equal(r.source, "ambiguous");
+  assert.deepEqual(r.ambiguous, ["sku", "skill_id"]);
+});
+
+test("resolvePrimaryKey: returns null when neither schema nor sample yields a PK", () => {
+  const t = {
+    name: "csv_table",
+    columns: [
+      { name: "a", type: "string" },
+      { name: "b", type: "string" },
+    ],
+  };
+  const r = resolvePrimaryKey(t, undefined);
+  assert.equal(r.pk, null);
+  // Empty table, no schema → sample source so the existing "no sample data"
+  // error message still applies (preserves CSV path UX).
+  assert.equal(r.source, "sample");
+});

--- a/packages/typescript/test/datasources-pk-propagation.test.ts
+++ b/packages/typescript/test/datasources-pk-propagation.test.ts
@@ -1,0 +1,178 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { listTablesWithColumns } from "../src/api/datasources.js";
+
+const originalFetch = globalThis.fetch;
+
+function stubFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return handler(url, init);
+  }) as typeof fetch;
+}
+
+// ── Per-column PK propagation ─────────────────────────────────────────────────
+// The bug: `listTablesWithColumns` reduces every column to {name, type, comment},
+// silently dropping any PK indicator the backend exposes. The contract this test
+// fixes: when the raw column carries a PK indicator under any of the well-known
+// names, the SDK surfaces it as `isPrimaryKey: true`.
+
+test("listTablesWithColumns: propagates is_primary_key from backend column", async () => {
+  stubFetch((url) => {
+    if (url.includes("/data-connection/v1/metadata/data-source/ds-1")) {
+      return new Response(
+        JSON.stringify([
+          {
+            name: "skills",
+            columns: [
+              { name: "skill_id", type: "varchar", is_primary_key: true },
+              { name: "label", type: "varchar" },
+            ],
+          },
+        ]),
+        { status: 200 },
+      );
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    const body = await listTablesWithColumns({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "ds-1",
+    });
+    const tables = JSON.parse(body) as Array<{
+      name: string;
+      columns: Array<{ name: string; type: string; isPrimaryKey?: boolean }>;
+    }>;
+    assert.equal(tables.length, 1);
+    const cols = tables[0]!.columns;
+    assert.equal(cols.find((c) => c.name === "skill_id")!.isPrimaryKey, true);
+    assert.notEqual(cols.find((c) => c.name === "label")!.isPrimaryKey, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("listTablesWithColumns: propagates MySQL INFORMATION_SCHEMA column_key='PRI'", async () => {
+  stubFetch((url) => {
+    if (url.includes("/data-connection/v1/metadata/data-source/ds-1")) {
+      return new Response(
+        JSON.stringify([
+          {
+            name: "skills",
+            columns: [
+              { name: "skill_id", type: "varchar", column_key: "PRI" },
+              { name: "label", type: "varchar", column_key: "" },
+            ],
+          },
+        ]),
+        { status: 200 },
+      );
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    const body = await listTablesWithColumns({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "ds-1",
+    });
+    const tables = JSON.parse(body) as Array<{
+      name: string;
+      columns: Array<{ name: string; isPrimaryKey?: boolean }>;
+    }>;
+    assert.equal(tables[0]!.columns.find((c) => c.name === "skill_id")!.isPrimaryKey, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("listTablesWithColumns: propagates table-level primary_keys array", async () => {
+  // Composite-PK case: backend emits primary_keys at table level, not per column.
+  stubFetch((url) => {
+    if (url.includes("/data-connection/v1/metadata/data-source/ds-1")) {
+      return new Response(
+        JSON.stringify([
+          {
+            name: "mat_skill",
+            primary_keys: ["sku", "skill_id"],
+            columns: [
+              { name: "sku", type: "varchar" },
+              { name: "skill_id", type: "varchar" },
+              { name: "rank", type: "int" },
+            ],
+          },
+        ]),
+        { status: 200 },
+      );
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    const body = await listTablesWithColumns({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "ds-1",
+    });
+    const tables = JSON.parse(body) as Array<{
+      name: string;
+      primaryKeys?: string[];
+      columns: Array<{ name: string; isPrimaryKey?: boolean }>;
+    }>;
+    // Table-level array wins for composite PKs.
+    assert.deepEqual(tables[0]!.primaryKeys, ["sku", "skill_id"]);
+    // And the per-column flag is materialized so downstream callers can use either.
+    const byName = Object.fromEntries(tables[0]!.columns.map((c) => [c.name, c]));
+    assert.equal(byName.sku!.isPrimaryKey, true);
+    assert.equal(byName.skill_id!.isPrimaryKey, true);
+    assert.notEqual(byName.rank!.isPrimaryKey, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("listTablesWithColumns: leaves columns unflagged when backend returns no PK info", async () => {
+  // Regression guard: today's behavior must keep working — sample-based detection
+  // remains the fallback when backend doesn't expose PK metadata.
+  stubFetch((url) => {
+    if (url.includes("/data-connection/v1/metadata/data-source/ds-1")) {
+      return new Response(
+        JSON.stringify([
+          {
+            name: "skills",
+            columns: [
+              { name: "skill_id", type: "varchar" },
+              { name: "label", type: "varchar" },
+            ],
+          },
+        ]),
+        { status: 200 },
+      );
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    const body = await listTablesWithColumns({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "ds-1",
+    });
+    const tables = JSON.parse(body) as Array<{
+      name: string;
+      primaryKeys?: string[];
+      columns: Array<{ name: string; isPrimaryKey?: boolean }>;
+    }>;
+    assert.equal(tables[0]!.primaryKeys, undefined);
+    for (const c of tables[0]!.columns) {
+      assert.notEqual(c.isPrimaryKey, true);
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- Wire schema-declared primary-key metadata through the SDK so `bkn create-from-ds` no longer falls back to sample-based heuristics when the datasource exposes a PRIMARY KEY constraint.
- New `resolvePrimaryKey` helper with explicit precedence: `--pk-map` override > schema-declared PK > sample > fail. Composite SQL PKs surface `source: "ambiguous"` and fail fast instead of letting the heuristic randomly pick a column.
- `ds connect` JSON output now exposes `is_primary_key` / `primary_keys` so users can see what the SDK derived.

## Closes

#112

## Why now (and what's still missing)

The bug report (#112) calls for a two-layer fix — SDK + backend metadata. This PR is the SDK layer only. Verified against env `192.168.40.62`: the backend `/api/data-connection/v1/metadata/table/<id>` currently does **not** return PK fields, so end-to-end UX is unchanged until the backend starts querying `INFORMATION_SCHEMA.KEY_COLUMN_USAGE` (MySQL) / `pg_index` (Postgres). The SDK is now ready to consume that the moment it ships.

Independent value of this PR even before backend lands:
1. Composite-PK tables (e.g. `mat_skill(sku, skill_id)`) — once metadata reaches the SDK, the heuristic no longer randomly picks one column; we fail with a clear "use --pk-map" message.
2. Defensive: schema PK names are filtered against the actual column list — stale catalog / drift won't poison object-type creation downstream.
3. Behavior is byte-for-byte identical to before in environments without PK metadata.

## Recognized backend conventions

- per-column `is_primary_key: true`
- per-column `column_key === "PRI"` (MySQL INFORMATION_SCHEMA pass-through)
- table-level `primary_keys: string[]` (composite-PK carrier)

Other plausible spellings (camelCase, singular keys, SQLite `pk` integer) are intentionally **not** speculatively recognized — extend only when a real backend response demonstrates the need.

## Test plan

- [x] `npm test` — full suite 864/864 (13 new unit tests)
- [x] `npm run build` — clean
- [x] 4 propagation tests in `test/datasources-pk-propagation.test.ts` (is_primary_key / column_key=PRI / table-level primary_keys / no-PK regression guard)
- [x] 9 resolution tests in `test/bkn-resolve-pk.test.ts` (override > schema > sample precedence, composite-PK ambiguity, schema-drift defense, empty-table happy path)
- [ ] End-to-end on a backend that returns PK metadata — blocked on backend change; eval-side `EVAL_DB_PK_MAP` workaround stays in place until then

## Files

- `packages/typescript/src/api/datasources.ts` — `listTablesWithColumns` extracts PK from raw backend response
- `packages/typescript/src/commands/bkn-utils.ts` — new `resolvePrimaryKey` helper
- `packages/typescript/src/commands/bkn-ops.ts` — wired into `runKnCreateFromDsCommand`
- `packages/typescript/src/commands/ds.ts` — surface PK info in `ds connect` JSON output

## Follow-up (not in this PR)

- Backend ticket: data-connection metadata service should populate `column_key` / `primary_keys` from `INFORMATION_SCHEMA.KEY_COLUMN_USAGE` (MySQL) and `pg_index` (Postgres). When that lands, the eval-side `EVAL_DB_PK_MAP` constant (in `kweaver-eval` `tests/adp/conftest.py`) can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)