### PR TITLE
feat(sdk): migrate ds/bkn flows to vega catalogs (#114)

### DIFF
--- a/docs/superpowers/plans/2026-05-08-bkn-ds-vega-migration.md
+++ b/docs/superpowers/plans/2026-05-08-bkn-ds-vega-migration.md
@@ -1,0 +1,1339 @@
+# BKN create-from-ds → vega catalogs Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the two SDK functions that `bkn create-from-ds` depends on (`listTablesWithColumns`, `scanMetadata`) from data-connection to vega-backend catalogs, in both TypeScript and Python. Update `bkn create-from-ds` / `bkn create-from-csv` to expect a vega catalog id and reject legacy datasource UUIDs with a clear hint.
+
+**Architecture:** Thin adapter — keep public function signatures stable, swap underlying HTTP calls. Reuse the existing vega catalogs client (`api/vega.ts` / `resources/vega/catalogs.py`). `listTablesWithColumns` becomes `listVegaCatalogResources(category="table")` + concurrent `getVegaResource(rid)` × N. `scanMetadata` becomes `discoverVegaCatalog(wait=true)`. All other ds functions stay on data-connection.
+
+**Tech Stack:** TypeScript (Node, native test runner), Python (httpx, pytest), vega-backend `/api/vega-backend/v1/catalogs/*` & `/api/vega-backend/v1/resources/*`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-08-bkn-ds-vega-migration-design.md`](../specs/2026-05-08-bkn-ds-vega-migration-design.md)
+
+---
+
+## File Structure
+
+**Modify:**
+- `packages/typescript/src/api/datasources.ts` — replace impl of `listTablesWithColumns`, `scanMetadata`, `scanDatasourceMetadata`
+- `packages/python/src/kweaver/resources/datasources.py` — replace impl of `DataSourcesResource.list_tables`, `DataSourcesResource.scan_metadata`
+- `packages/typescript/src/commands/bkn-ops.ts` — add UUID-prevalidation in `parseKnCreateFromDsArgs` & `parseKnCreateFromCsvArgs`; update help/usage strings
+
+**Test (rewrite or add):**
+- `packages/typescript/test/datasources-pk-propagation.test.ts` — replace data-connection mocks with vega resources flow
+- `packages/typescript/test/datasources-scan.test.ts` — replace data-connection scan mocks with vega discover
+- `packages/typescript/test/bkn-create-from-ds.test.ts` — add UUID-rejection cases
+- `packages/python/tests/unit/test_datasources.py` — replace `test_list_tables` mocks; add scan_metadata test
+
+**Untouched** (kept on data-connection): `testDatasource`, `createDatasource`, `listDatasources`, `getDatasource`, `deleteDatasource`, `listTables` (TS) / Python `test`/`create`/`list`/`get`/`delete`. CLI subcommands `kweaver ds list/get/tables/connect/delete` unchanged.
+
+---
+
+## Task 1: Set up isolated worktree
+
+**Files:** none (workspace bootstrapping)
+
+- [ ] **Step 1.1: Create worktree off main**
+
+Run:
+
+```bash
+git -C /Users/xupeng/dev/github/kweaver-sdk worktree add -b feat/issue-114-bkn-ds-vega-migration ../kweaver-sdk-issue-114 main
+cd ../kweaver-sdk-issue-114
+```
+
+Expected: new directory `../kweaver-sdk-issue-114` with branch `feat/issue-114-bkn-ds-vega-migration`.
+
+- [ ] **Step 1.2: Verify clean baseline**
+
+Run:
+
+```bash
+cd ../kweaver-sdk-issue-114
+pnpm -C packages/typescript test 2>&1 | tail -20
+```
+
+Expected: existing tests pass on `main`.
+
+- [ ] **Step 1.3: Verify Python baseline**
+
+Run:
+
+```bash
+cd ../kweaver-sdk-issue-114/packages/python
+python -m pytest tests/unit/test_datasources.py -q 2>&1 | tail -10
+```
+
+Expected: existing datasource tests pass.
+
+---
+
+## Task 2: TS — Rewrite `scanMetadata` test for vega discover
+
+**Files:**
+- Test: `packages/typescript/test/datasources-scan.test.ts` (overwrite)
+
+- [ ] **Step 2.1: Replace test file**
+
+Overwrite `packages/typescript/test/datasources-scan.test.ts` with:
+
+```typescript
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { scanDatasourceMetadata, scanMetadata } from "../src/api/datasources.js";
+
+const originalFetch = globalThis.fetch;
+
+interface CallRecord {
+  method: string;
+  url: string;
+  body?: string;
+}
+
+function stubFetch(handler: (call: CallRecord) => Response | Promise<Response>) {
+  const calls: CallRecord[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const call: CallRecord = {
+      method: (init?.method ?? "GET").toUpperCase(),
+      url: typeof input === "string" ? input : input.toString(),
+      body: typeof init?.body === "string" ? init.body : undefined,
+    };
+    calls.push(call);
+    return handler(call);
+  }) as typeof fetch;
+  return calls;
+}
+
+test("scanMetadata: POSTs vega discover with wait=true", async () => {
+  const calls = stubFetch((c) => {
+    if (
+      c.method === "POST" &&
+      c.url.includes("/vega-backend/v1/catalogs/cat-1/discover")
+    ) {
+      return new Response(JSON.stringify({ task_id: "vega-task-9" }), { status: 200 });
+    }
+    throw new Error(`unexpected ${c.method} ${c.url}`);
+  });
+
+  try {
+    const body = await scanMetadata({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "cat-1",
+      businessDomain: "bd_public",
+    });
+    assert.ok(body.includes("vega-task-9"), "should return discover response body");
+    const discoverCall = calls.find((c) => c.url.includes("/discover"));
+    assert.ok(discoverCall, "must call vega discover");
+    const u = new URL(discoverCall!.url);
+    assert.equal(u.searchParams.get("wait"), "true", "wait must be true");
+    assert.equal(
+      calls.filter((c) => c.url.includes("/data-connection/")).length,
+      0,
+      "must not touch data-connection",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("scanDatasourceMetadata: delegates to vega discover (no GET-then-scan dance)", async () => {
+  const calls = stubFetch((c) => {
+    if (c.method === "POST" && c.url.includes("/vega-backend/v1/catalogs/cat-1/discover")) {
+      return new Response(JSON.stringify({ task_id: "vega-task-1" }), { status: 200 });
+    }
+    throw new Error(`unexpected ${c.method} ${c.url}`);
+  });
+
+  try {
+    const body = await scanDatasourceMetadata({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "cat-1",
+      businessDomain: "bd_public",
+    });
+    assert.ok(body.includes("vega-task-1"));
+    assert.equal(
+      calls.filter((c) => c.url.includes("/data-connection/")).length,
+      0,
+      "must not touch data-connection",
+    );
+    assert.equal(
+      calls.filter((c) => c.method === "GET" && c.url.includes("/datasource/")).length,
+      0,
+      "must not look up legacy ds_type",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("scanMetadata: surfaces vega 404 with HttpError", async () => {
+  stubFetch(() => new Response("not found", { status: 404, statusText: "Not Found" }));
+
+  try {
+    await assert.rejects(
+      () =>
+        scanMetadata({
+          baseUrl: "https://h.example",
+          accessToken: "tok",
+          id: "missing",
+          businessDomain: "bd_public",
+        }),
+      /404/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+```
+
+- [ ] **Step 2.2: Run, expect FAIL**
+
+Run:
+
+```bash
+pnpm -C packages/typescript exec node --test test/datasources-scan.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL — `scanMetadata` still hits `/data-connection/v1/metadata/scan`, so the unexpected-url branch throws.
+
+---
+
+## Task 3: TS — Implement migrated `scanMetadata` & simplify `scanDatasourceMetadata`
+
+**Files:**
+- Modify: `packages/typescript/src/api/datasources.ts:378-452`
+
+- [ ] **Step 3.1: Replace `scanMetadata` body and `scanDatasourceMetadata` body**
+
+In `packages/typescript/src/api/datasources.ts`, replace the block from `export interface ScanMetadataOptions {` (line ~378) through end of `scanDatasourceMetadata` (line ~452) with:
+
+```typescript
+import { discoverVegaCatalog } from "./vega.js";
+
+export interface ScanMetadataOptions {
+  baseUrl: string;
+  accessToken: string;
+  id: string;
+  /** Retained for signature compatibility; ignored — vega catalog already knows its connector_type. */
+  dsType?: string;
+  businessDomain?: string;
+}
+
+/**
+ * Trigger a metadata scan for a vega catalog and wait for completion.
+ * `id` is a **vega catalog id** (e.g. `d7nicrcjto2s73d9g67g`), not a legacy
+ * data-connection datasource UUID.
+ */
+export async function scanMetadata(options: ScanMetadataOptions): Promise<string> {
+  const { baseUrl, accessToken, id, businessDomain = "bd_public" } = options;
+  return discoverVegaCatalog({
+    baseUrl,
+    accessToken,
+    id,
+    wait: true,
+    businessDomain,
+  });
+}
+
+export interface ScanDatasourceMetadataOptions {
+  baseUrl: string;
+  accessToken: string;
+  id: string;
+  businessDomain?: string;
+}
+
+/**
+ * Trigger a metadata scan and wait for completion. `id` is a vega catalog id.
+ *
+ * Historically this looked up the legacy `ds_type` to build a data-connection
+ * scan body; vega catalogs already carry their own `connector_type`, so the
+ * lookup is gone.
+ */
+export async function scanDatasourceMetadata(
+  options: ScanDatasourceMetadataOptions,
+): Promise<string> {
+  return scanMetadata(options);
+}
+```
+
+Note: the `import { discoverVegaCatalog }` line goes at the top of the file with the other imports (don't keep it inline). If TS already had no `vega.js` import, add it next to the existing imports.
+
+- [ ] **Step 3.2: Run, expect PASS**
+
+Run:
+
+```bash
+pnpm -C packages/typescript exec node --test test/datasources-scan.test.ts 2>&1 | tail -20
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add packages/typescript/src/api/datasources.ts packages/typescript/test/datasources-scan.test.ts
+git commit -m "$(cat <<'EOF'
+feat(sdk-ts): migrate scanMetadata to vega discoverVegaCatalog
+
+scanMetadata and scanDatasourceMetadata now POST /api/vega-backend/v1/catalogs/{id}/discover?wait=true.
+Drops the legacy GET-datasource then POST-scan dance — vega catalogs carry
+their own connector_type. id semantics: now a vega catalog id, not a
+data-connection datasource UUID. Public signatures unchanged.
+
+Refs #114.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: TS — Rewrite `listTablesWithColumns` test for vega resources flow
+
+**Files:**
+- Test: `packages/typescript/test/datasources-pk-propagation.test.ts` (overwrite)
+
+- [ ] **Step 4.1: Replace test file**
+
+Overwrite `packages/typescript/test/datasources-pk-propagation.test.ts` with:
+
+```typescript
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { listTablesWithColumns } from "../src/api/datasources.js";
+
+const originalFetch = globalThis.fetch;
+
+function stubFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    return handler(url, init);
+  }) as typeof fetch;
+}
+
+// Vega resource detail shape — confirmed against admin platform 2026-05-08:
+// GET /api/vega-backend/v1/resources/{id} returns
+//   { id, name, category, source_metadata: { columns: [...] }, ... }
+// where each column has { name, type, orig_type, column_key, ... }.
+
+function resourceListResponse(catalogId: string, items: Array<{ id: string; name: string }>) {
+  return new Response(
+    JSON.stringify({
+      entries: items.map((it) => ({
+        id: it.id,
+        catalog_id: catalogId,
+        name: it.name,
+        category: "table",
+      })),
+      total_count: items.length,
+    }),
+    { status: 200 },
+  );
+}
+
+function resourceDetailResponse(
+  rid: string,
+  name: string,
+  columns: Array<Record<string, unknown>>,
+  extra: Record<string, unknown> = {},
+) {
+  return new Response(
+    JSON.stringify({
+      entries: [
+        {
+          id: rid,
+          name,
+          category: "table",
+          source_metadata: { columns },
+          ...extra,
+        },
+      ],
+    }),
+    { status: 200 },
+  );
+}
+
+test("listTablesWithColumns: vega resources list + per-resource detail → table shape", async () => {
+  stubFetch((url) => {
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources")) {
+      return resourceListResponse("cat-1", [{ id: "r1", name: "skills" }]);
+    }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse("r1", "skills", [
+        { name: "skill_id", type: "varchar", is_primary_key: true },
+        { name: "label", type: "varchar" },
+      ]);
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    const body = await listTablesWithColumns({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "cat-1",
+    });
+    const tables = JSON.parse(body) as Array<{
+      name: string;
+      columns: Array<{ name: string; type: string; isPrimaryKey?: boolean }>;
+      primaryKeys?: string[];
+    }>;
+    assert.equal(tables.length, 1);
+    assert.equal(tables[0]!.name, "skills");
+    const cols = tables[0]!.columns;
+    assert.equal(cols.find((c) => c.name === "skill_id")!.isPrimaryKey, true);
+    assert.notEqual(cols.find((c) => c.name === "label")!.isPrimaryKey, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("listTablesWithColumns: column_key='PRI' propagates as isPrimaryKey", async () => {
+  stubFetch((url) => {
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources")) {
+      return resourceListResponse("cat-1", [{ id: "r1", name: "skills" }]);
+    }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse("r1", "skills", [
+        { name: "skill_id", type: "varchar", column_key: "PRI" },
+        { name: "label", type: "varchar", column_key: "" },
+      ]);
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    const body = await listTablesWithColumns({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "cat-1",
+    });
+    const tables = JSON.parse(body);
+    const cols = tables[0].columns;
+    assert.equal(cols.find((c: { name: string }) => c.name === "skill_id").isPrimaryKey, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("listTablesWithColumns: table-level primary_keys[] surfaces as primaryKeys", async () => {
+  stubFetch((url) => {
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources")) {
+      return resourceListResponse("cat-1", [{ id: "r1", name: "orders" }]);
+    }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse(
+        "r1",
+        "orders",
+        [
+          { name: "order_id", type: "integer" },
+          { name: "tenant_id", type: "varchar" },
+        ],
+        { primary_keys: ["order_id", "tenant_id"] },
+      );
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    const body = await listTablesWithColumns({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "cat-1",
+    });
+    const tables = JSON.parse(body);
+    assert.deepEqual(tables[0].primaryKeys, ["order_id", "tenant_id"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("listTablesWithColumns: empty resources + autoScan triggers discover then re-lists", async () => {
+  let listCalls = 0;
+  let discoverCalls = 0;
+  stubFetch((url, init) => {
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources") && (init?.method ?? "GET") === "GET") {
+      listCalls += 1;
+      if (listCalls === 1) {
+        return resourceListResponse("cat-1", []);
+      }
+      return resourceListResponse("cat-1", [{ id: "r1", name: "skills" }]);
+    }
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/discover")) {
+      discoverCalls += 1;
+      return new Response(JSON.stringify({ task_id: "task-1" }), { status: 200 });
+    }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse("r1", "skills", [{ name: "skill_id", type: "varchar" }]);
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    const body = await listTablesWithColumns({
+      baseUrl: "https://h.example",
+      accessToken: "tok",
+      id: "cat-1",
+      autoScan: true,
+    });
+    const tables = JSON.parse(body);
+    assert.equal(tables.length, 1);
+    assert.equal(discoverCalls, 1, "discover called exactly once");
+    assert.equal(listCalls, 2, "resources list called twice (initial + post-scan)");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("listTablesWithColumns: per-resource fetch failure surfaces (not silently dropped)", async () => {
+  stubFetch((url) => {
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources")) {
+      return resourceListResponse("cat-1", [
+        { id: "r1", name: "skills" },
+        { id: "r2", name: "orders" },
+      ]);
+    }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse("r1", "skills", [{ name: "id", type: "integer" }]);
+    }
+    if (url.includes("/vega-backend/v1/resources/r2")) {
+      return new Response("boom", { status: 500, statusText: "Internal Server Error" });
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        listTablesWithColumns({
+          baseUrl: "https://h.example",
+          accessToken: "tok",
+          id: "cat-1",
+        }),
+      /500|r2/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+```
+
+- [ ] **Step 4.2: Run, expect FAIL**
+
+Run:
+
+```bash
+pnpm -C packages/typescript exec node --test test/datasources-pk-propagation.test.ts 2>&1 | tail -30
+```
+
+Expected: FAIL — `listTablesWithColumns` still hits `/data-connection/v1/metadata/data-source/...`.
+
+---
+
+## Task 5: TS — Implement migrated `listTablesWithColumns`
+
+**Files:**
+- Modify: `packages/typescript/src/api/datasources.ts:275-376` (replace `listTablesWithColumns` body, retain `isColumnPrimaryKey` & `extractPrimaryKeys` helpers)
+
+- [ ] **Step 5.1: Replace `listTablesWithColumns` body**
+
+In `packages/typescript/src/api/datasources.ts`, replace the entire `listTablesWithColumns` function (line ~275 through ~354) with the implementation below. Keep the `isColumnPrimaryKey` and `extractPrimaryKeys` helpers (they sit just below the function).
+
+Add a `listVegaCatalogResources, getVegaResource` import from `./vega.js` at the top of the file (next to the existing imports; merge with the `discoverVegaCatalog` import added in Task 3).
+
+```typescript
+export interface ListTablesWithColumnsOptions {
+  baseUrl: string;
+  accessToken: string;
+  /** A vega catalog id, not a legacy data-connection datasource UUID. */
+  id: string;
+  keyword?: string;
+  limit?: number;
+  offset?: number;
+  businessDomain?: string;
+  autoScan?: boolean;
+}
+
+interface VegaResourceListEntry {
+  id: string;
+  name: string;
+  category?: string;
+}
+
+interface VegaResourceDetail {
+  id: string;
+  name: string;
+  source_metadata?: { columns?: Array<Record<string, unknown>> };
+  primary_keys?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * List tables with column details from a vega catalog.
+ *
+ * Two-stage fetch:
+ *   1. GET /api/vega-backend/v1/catalogs/{id}/resources?category=table — list summaries
+ *   2. For each resource: GET /api/vega-backend/v1/resources/{rid} — pull source_metadata.columns
+ *
+ * If the catalog has no resources and `autoScan=true`, triggers a discover and
+ * retries the list once.
+ *
+ * `id` is a **vega catalog id**.
+ */
+export async function listTablesWithColumns(
+  options: ListTablesWithColumnsOptions,
+): Promise<string> {
+  const {
+    baseUrl,
+    accessToken,
+    id,
+    keyword,
+    limit,
+    offset,
+    businessDomain = "bd_public",
+    autoScan = true,
+  } = options;
+
+  async function listResourceSummaries(): Promise<VegaResourceListEntry[]> {
+    const body = await listVegaCatalogResources({
+      baseUrl,
+      accessToken,
+      id,
+      category: "table",
+      limit,
+      offset,
+      businessDomain,
+    });
+    const parsed = JSON.parse(body) as
+      | Array<VegaResourceListEntry>
+      | { entries?: VegaResourceListEntry[]; data?: VegaResourceListEntry[] };
+    let items = Array.isArray(parsed) ? parsed : (parsed.entries ?? parsed.data ?? []);
+    if (keyword) {
+      const k = keyword.toLowerCase();
+      items = items.filter((it) => it.name.toLowerCase().includes(k));
+    }
+    return items;
+  }
+
+  let summaries = await listResourceSummaries();
+  if (summaries.length === 0 && autoScan) {
+    await scanMetadata({ baseUrl, accessToken, id, businessDomain });
+    summaries = await listResourceSummaries();
+  }
+
+  const details = await Promise.all(
+    summaries.map(async (s) => {
+      const body = await getVegaResource({
+        baseUrl,
+        accessToken,
+        id: s.id,
+        businessDomain,
+      });
+      const parsed = JSON.parse(body) as
+        | VegaResourceDetail
+        | { entries?: VegaResourceDetail[]; data?: VegaResourceDetail[] };
+      if (Array.isArray((parsed as { entries?: unknown }).entries)) {
+        const arr = (parsed as { entries: VegaResourceDetail[] }).entries;
+        if (arr.length === 0) {
+          throw new Error(`vega resource ${s.id} returned empty entries`);
+        }
+        return arr[0]!;
+      }
+      if (Array.isArray((parsed as { data?: unknown }).data)) {
+        const arr = (parsed as { data: VegaResourceDetail[] }).data;
+        if (arr.length === 0) {
+          throw new Error(`vega resource ${s.id} returned empty data`);
+        }
+        return arr[0]!;
+      }
+      return parsed as VegaResourceDetail;
+    }),
+  );
+
+  const tables: Array<{
+    name: string;
+    columns: Array<{ name: string; type: string; comment?: string; isPrimaryKey?: boolean }>;
+    primaryKeys?: string[];
+  }> = [];
+
+  for (const d of details) {
+    const columnsRaw = (d.source_metadata?.columns ?? []) as Array<Record<string, unknown>>;
+    const tablePkArray = extractPrimaryKeys(d as unknown as Record<string, unknown>);
+    const columns = columnsRaw.map((c) => {
+      const name = String(c.name ?? c.field_name ?? "");
+      const flagged = isColumnPrimaryKey(c) || tablePkArray.includes(name);
+      return {
+        name,
+        type: String(c.type ?? c.field_type ?? "varchar"),
+        comment: typeof c.description === "string"
+          ? c.description
+          : (typeof c.comment === "string" ? c.comment : undefined),
+        ...(flagged ? { isPrimaryKey: true } : {}),
+      };
+    });
+    const synthesizedPks = tablePkArray.length > 0
+      ? tablePkArray
+      : columns.filter((c) => c.isPrimaryKey).map((c) => c.name);
+
+    tables.push({
+      name: d.name,
+      columns,
+      ...(synthesizedPks.length > 0 ? { primaryKeys: synthesizedPks } : {}),
+    });
+  }
+
+  return JSON.stringify(tables);
+}
+```
+
+The original `listTables` function (data-connection) stays intact — `kweaver ds tables` still uses it.
+
+- [ ] **Step 5.2: Run, expect PASS**
+
+Run:
+
+```bash
+pnpm -C packages/typescript exec node --test test/datasources-pk-propagation.test.ts 2>&1 | tail -30
+```
+
+Expected: 5 tests pass.
+
+- [ ] **Step 5.3: Run full TS test suite**
+
+Run:
+
+```bash
+pnpm -C packages/typescript test 2>&1 | tail -30
+```
+
+Expected: all tests pass. Existing tests in `bkn-create-from-ds.test.ts`, `ds-connect-dedup.test.ts`, `ds-import-csv.test.ts` should still pass (they don't depend on the migrated functions' wire format).
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add packages/typescript/src/api/datasources.ts packages/typescript/test/datasources-pk-propagation.test.ts
+git commit -m "$(cat <<'EOF'
+feat(sdk-ts): migrate listTablesWithColumns to vega catalogs
+
+Two-stage fetch: GET /catalogs/{id}/resources?category=table then per-resource
+GET /resources/{rid}, extracting source_metadata.columns. Concurrent N+1 with
+Promise.all. PK extraction logic (is_primary_key / column_key=PRI / table-level
+primary_keys[]) preserved verbatim. id is now a vega catalog id; return shape
+unchanged for downstream parity.
+
+Refs #114.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Python — Migrate `DataSourcesResource.scan_metadata` (TDD)
+
+**Files:**
+- Modify: `packages/python/src/kweaver/resources/datasources.py` — `scan_metadata` method (lines ~114-139)
+- Test: `packages/python/tests/unit/test_datasources.py` — add scan_metadata test
+
+- [ ] **Step 6.1: Add failing test**
+
+Append to `packages/python/tests/unit/test_datasources.py`:
+
+```python
+def test_scan_metadata_calls_vega_discover(capture: RequestCapture):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and "/vega-backend/v1/catalogs/cat-1/discover" in str(req.url):
+            return httpx.Response(200, json={"task_id": "vega-task-1"})
+        raise AssertionError(f"unexpected {req.method} {req.url}")
+
+    client = make_client(handler, capture)
+    result = client.datasources.scan_metadata("cat-1")
+    assert "vega-task-1" in result or result == "vega-task-1" or "task_id" in result
+    # wait=true must be in the query
+    last_url = capture.last_url()
+    assert "wait=true" in last_url, f"expected wait=true in {last_url}"
+    # must NOT touch data-connection
+    for call in capture.all_urls():
+        assert "/data-connection/" not in call, f"unexpected data-connection call: {call}"
+```
+
+If `RequestCapture` doesn't have `all_urls()`, inspect `tests/conftest.py` and add the helper, or replace the assertion with iterating `capture.records` (the existing capture pattern).
+
+- [ ] **Step 6.2: Run, expect FAIL**
+
+Run:
+
+```bash
+cd packages/python && python -m pytest tests/unit/test_datasources.py::test_scan_metadata_calls_vega_discover -xvs 2>&1 | tail -20
+```
+
+Expected: FAIL — current `scan_metadata` calls `/api/data-connection/v1/datasource/...` first.
+
+- [ ] **Step 6.3: Replace `scan_metadata` impl**
+
+In `packages/python/src/kweaver/resources/datasources.py`, replace the `scan_metadata` method (lines ~114-139) with:
+
+```python
+    def scan_metadata(self, id: str, *, ds_type: str = "mysql") -> str:
+        """Trigger a metadata scan for a vega catalog and wait for completion.
+
+        `id` is a **vega catalog id** (e.g. ``d7nicrcjto2s73d9g67g``), not a
+        legacy data-connection datasource UUID. ``ds_type`` is retained for
+        signature compatibility but ignored — vega catalogs carry their own
+        ``connector_type``.
+
+        Returns the discover endpoint's response body as a JSON string.
+        """
+        import json as _json
+
+        result = self._http.post(
+            f"/api/vega-backend/v1/catalogs/{id}/discover",
+            params={"wait": "true"},
+        )
+        if isinstance(result, str):
+            return result
+        return _json.dumps(result)
+```
+
+If `self._http.post` already returns dict on JSON responses, the conversion at the end yields a JSON string — matching the TS function's `Promise<string>` return for parity.
+
+If the test asserts on `"task_id" in result`, the JSON-stringified payload satisfies it.
+
+- [ ] **Step 6.4: Run, expect PASS**
+
+Run:
+
+```bash
+cd packages/python && python -m pytest tests/unit/test_datasources.py::test_scan_metadata_calls_vega_discover -xvs 2>&1 | tail -10
+```
+
+Expected: PASS.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add packages/python/src/kweaver/resources/datasources.py packages/python/tests/unit/test_datasources.py
+git commit -m "$(cat <<'EOF'
+feat(sdk-py): migrate DataSourcesResource.scan_metadata to vega discover
+
+POSTs /api/vega-backend/v1/catalogs/{id}/discover?wait=true. Drops the legacy
+get-then-scan dance — vega catalogs carry their own connector_type. id is now
+a vega catalog id. ds_type kwarg retained for signature compatibility but
+ignored.
+
+Refs #114.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Python — Migrate `DataSourcesResource.list_tables` (TDD)
+
+**Files:**
+- Modify: `packages/python/src/kweaver/resources/datasources.py` — `list_tables` method (lines ~141-200)
+- Test: `packages/python/tests/unit/test_datasources.py` — replace `test_list_tables`
+
+- [ ] **Step 7.1: Replace existing `test_list_tables` and add new cases**
+
+In `packages/python/tests/unit/test_datasources.py`, replace `test_list_tables` (and any other list_tables tests) with:
+
+```python
+def test_list_tables_via_vega_resources(capture: RequestCapture):
+    def handler(req: httpx.Request) -> httpx.Response:
+        url = str(req.url)
+        if "/vega-backend/v1/catalogs/cat-1/resources" in url and req.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {"id": "r1", "catalog_id": "cat-1", "name": "skills", "category": "table"},
+                        {"id": "r2", "catalog_id": "cat-1", "name": "orders", "category": "table"},
+                    ],
+                    "total_count": 2,
+                },
+            )
+        if "/vega-backend/v1/resources/r1" in url:
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "id": "r1",
+                            "name": "skills",
+                            "category": "table",
+                            "source_metadata": {
+                                "columns": [
+                                    {"name": "skill_id", "type": "varchar"},
+                                    {"name": "label", "type": "varchar"},
+                                ]
+                            },
+                        }
+                    ]
+                },
+            )
+        if "/vega-backend/v1/resources/r2" in url:
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "id": "r2",
+                            "name": "orders",
+                            "category": "table",
+                            "source_metadata": {"columns": []},
+                        }
+                    ]
+                },
+            )
+        raise AssertionError(f"unexpected {req.method} {req.url}")
+
+    client = make_client(handler, capture)
+    tables = client.datasources.list_tables("cat-1", auto_scan=False)
+    names = sorted(t.name for t in tables)
+    assert names == ["orders", "skills"]
+    skills = next(t for t in tables if t.name == "skills")
+    assert [c.name for c in skills.columns] == ["skill_id", "label"]
+    # must NOT touch data-connection
+    for call in capture.all_urls():
+        assert "/data-connection/" not in call, f"leak: {call}"
+
+
+def test_list_tables_empty_with_auto_scan_triggers_discover(capture: RequestCapture):
+    list_calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        url = str(req.url)
+        if "/vega-backend/v1/catalogs/cat-1/resources" in url and req.method == "GET":
+            list_calls["n"] += 1
+            if list_calls["n"] == 1:
+                return httpx.Response(200, json={"entries": [], "total_count": 0})
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {"id": "r1", "catalog_id": "cat-1", "name": "skills", "category": "table"}
+                    ],
+                    "total_count": 1,
+                },
+            )
+        if "/vega-backend/v1/catalogs/cat-1/discover" in url and req.method == "POST":
+            return httpx.Response(200, json={"task_id": "t1"})
+        if "/vega-backend/v1/resources/r1" in url:
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "id": "r1",
+                            "name": "skills",
+                            "source_metadata": {
+                                "columns": [{"name": "id", "type": "integer"}]
+                            },
+                        }
+                    ]
+                },
+            )
+        raise AssertionError(f"unexpected {req.method} {req.url}")
+
+    client = make_client(handler, capture)
+    tables = client.datasources.list_tables("cat-1", auto_scan=True)
+    assert len(tables) == 1
+    assert list_calls["n"] == 2
+```
+
+If `RequestCapture` lacks `all_urls()`, add it next to the existing helpers in `tests/conftest.py`:
+
+```python
+def all_urls(self) -> list[str]:
+    return [str(r.url) for r in self.records]
+```
+
+- [ ] **Step 7.2: Run, expect FAIL**
+
+Run:
+
+```bash
+cd packages/python && python -m pytest tests/unit/test_datasources.py -k "list_tables" -xvs 2>&1 | tail -20
+```
+
+Expected: FAIL on the new tests — current impl hits `/data-connection/`.
+
+- [ ] **Step 7.3: Replace `list_tables` impl**
+
+In `packages/python/src/kweaver/resources/datasources.py`, replace the `list_tables` method (lines ~141-200) with:
+
+```python
+    def list_tables(
+        self,
+        id: str,
+        *,
+        keyword: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        auto_scan: bool = True,
+    ) -> list[Table]:
+        """List tables with columns from a **vega catalog**.
+
+        Two-stage fetch:
+          1. GET /api/vega-backend/v1/catalogs/{id}/resources?category=table
+          2. For each resource: GET /api/vega-backend/v1/resources/{rid}, pulling source_metadata.columns
+
+        If the catalog has no table resources and `auto_scan=True`, triggers a
+        discover and retries the list once.
+
+        `id` is a **vega catalog id**.
+        """
+
+        def _list_summaries() -> list[dict[str, Any]]:
+            params: dict[str, Any] = {"category": "table"}
+            if limit is not None:
+                params["limit"] = limit
+            if offset is not None:
+                params["offset"] = offset
+            data = self._http.get(
+                f"/api/vega-backend/v1/catalogs/{id}/resources",
+                params=params,
+            )
+            items = (
+                data
+                if isinstance(data, list)
+                else (data.get("entries") or data.get("data") or [])
+            )
+            if keyword:
+                k = keyword.lower()
+                items = [it for it in items if k in str(it.get("name", "")).lower()]
+            return items
+
+        summaries = _list_summaries()
+        if not summaries and auto_scan:
+            self.scan_metadata(id)
+            summaries = _list_summaries()
+
+        tables: list[Table] = []
+        for s in summaries:
+            rid = s.get("id", "")
+            if not rid:
+                continue
+            detail_raw = self._http.get(f"/api/vega-backend/v1/resources/{rid}")
+            detail = detail_raw
+            if isinstance(detail_raw, dict):
+                entries = detail_raw.get("entries") or detail_raw.get("data")
+                if isinstance(entries, list) and entries:
+                    detail = entries[0]
+            if not isinstance(detail, dict):
+                continue
+            columns_raw = (detail.get("source_metadata") or {}).get("columns") or []
+            tables.append(
+                Table(
+                    name=detail.get("name", s.get("name", "")),
+                    columns=[
+                        Column(
+                            name=c.get("name", c.get("field_name", "")),
+                            type=c.get("type", c.get("field_type", "varchar")),
+                            comment=c.get("description") or c.get("comment"),
+                        )
+                        for c in columns_raw
+                    ],
+                )
+            )
+        return tables
+```
+
+- [ ] **Step 7.4: Run, expect PASS**
+
+Run:
+
+```bash
+cd packages/python && python -m pytest tests/unit/test_datasources.py -xvs 2>&1 | tail -30
+```
+
+Expected: all tests in `test_datasources.py` pass — old `test_list_tables` was replaced; create / list / get / delete / test connectivity tests still pass (they touch the unmigrated paths).
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add packages/python/src/kweaver/resources/datasources.py packages/python/tests/unit/test_datasources.py packages/python/tests/conftest.py
+git commit -m "$(cat <<'EOF'
+feat(sdk-py): migrate DataSourcesResource.list_tables to vega catalogs
+
+Two-stage fetch: GET /catalogs/{id}/resources?category=table then per-resource
+GET /resources/{rid}, extracting source_metadata.columns. id is now a vega
+catalog id; return shape unchanged.
+
+Refs #114.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: TS — Add UUID-rejection guard for `bkn create-from-ds` and `bkn create-from-csv` (TDD)
+
+**Files:**
+- Test: `packages/typescript/test/bkn-create-from-ds.test.ts` (append cases)
+- Modify: `packages/typescript/src/commands/bkn-ops.ts` — `parseKnCreateFromDsArgs` (~L588), `parseKnCreateFromCsvArgs` (~L985), and any usage / help banner
+
+- [ ] **Step 8.1: Append failing tests**
+
+Append to `packages/typescript/test/bkn-create-from-ds.test.ts`:
+
+```typescript
+test("parseKnCreateFromDsArgs: rejects legacy datasource UUID", () => {
+  const uuid = "dfaf719c-4c41-4661-9ec9-25c263ff8c46";
+  assert.throws(
+    () =>
+      parseKnCreateFromDsArgs([
+        uuid,
+        "--name",
+        "kn1",
+      ]),
+    /vega catalog id/i,
+  );
+});
+
+test("parseKnCreateFromDsArgs: accepts short vega catalog id", () => {
+  const opts = parseKnCreateFromDsArgs([
+    "d7nicrcjto2s73d9g67g",
+    "--name",
+    "kn1",
+  ]);
+  assert.equal(opts.dsId, "d7nicrcjto2s73d9g67g");
+});
+
+test("parseKnCreateFromCsvArgs: rejects legacy datasource UUID", () => {
+  const uuid = "dfaf719c-4c41-4661-9ec9-25c263ff8c46";
+  assert.throws(
+    () =>
+      parseKnCreateFromCsvArgs([
+        uuid,
+        "--name",
+        "kn1",
+        "--files",
+        "/tmp/a.csv",
+      ]),
+    /vega catalog id/i,
+  );
+});
+```
+
+- [ ] **Step 8.2: Run, expect FAIL**
+
+Run:
+
+```bash
+pnpm -C packages/typescript exec node --test test/bkn-create-from-ds.test.ts 2>&1 | tail -20
+```
+
+Expected: 3 new tests fail (UUIDs are accepted today).
+
+- [ ] **Step 8.3: Add helper + wire into both parsers**
+
+In `packages/typescript/src/commands/bkn-ops.ts`, near the top of the file (after imports), add:
+
+```typescript
+const UUID_V4_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+function assertVegaCatalogId(id: string): void {
+  if (UUID_V4_RE.test(id)) {
+    throw new Error(
+      `bkn create-from-ds expects a vega catalog id, got UUID '${id}'. ` +
+      `This looks like a legacy data-connection datasource UUID. ` +
+      `Run \`kweaver vega catalog list --keyword <name>\` to find the corresponding catalog id.`,
+    );
+  }
+}
+```
+
+Then in `parseKnCreateFromDsArgs` (the function around line ~588), after `dsId` is finalized and before the final `return`, add:
+
+```typescript
+  assertVegaCatalogId(dsId);
+```
+
+Same line in `parseKnCreateFromCsvArgs` (around line ~985), after its `dsId` is finalized:
+
+```typescript
+  assertVegaCatalogId(dsId);
+```
+
+- [ ] **Step 8.4: Run, expect PASS**
+
+Run:
+
+```bash
+pnpm -C packages/typescript exec node --test test/bkn-create-from-ds.test.ts 2>&1 | tail -20
+```
+
+Expected: all tests including new 3 pass.
+
+- [ ] **Step 8.5: Update CLI usage / help string**
+
+In `packages/typescript/src/commands/bkn-ops.ts`, locate the usage string for `kweaver bkn create-from-ds` (and `create-from-csv`) — typically a multi-line template literal printed when `--help` is passed or args are missing. Update the description of the positional argument from "datasource id" / "ds_id" to:
+
+> vega catalog id (use `kweaver vega catalog list` to find one; legacy data-connection datasource UUIDs are no longer accepted)
+
+Also check `packages/typescript/src/cli.ts` if it has help text for `bkn create-from-ds`/`create-from-csv` and update accordingly.
+
+- [ ] **Step 8.6: Run full TS suite**
+
+Run:
+
+```bash
+pnpm -C packages/typescript test 2>&1 | tail -30
+```
+
+Expected: all pass.
+
+- [ ] **Step 8.7: Commit**
+
+```bash
+git add packages/typescript/src/commands/bkn-ops.ts packages/typescript/src/cli.ts packages/typescript/test/bkn-create-from-ds.test.ts
+git commit -m "$(cat <<'EOF'
+feat(bkn-ops): require vega catalog id for create-from-ds/create-from-csv
+
+Adds UUID-shape prevalidation in both arg parsers. Rejects legacy
+data-connection datasource UUIDs with a hint pointing users to
+'kweaver vega catalog list'. Help text updated accordingly.
+
+Refs #114.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: E2E validation on admin platform
+
+**Files:** none (validation only)
+
+- [ ] **Step 9.1: Authenticate**
+
+Run:
+
+```bash
+kweaver auth use admin
+kweaver auth whoami admin
+```
+
+Expected: token present, user `admin` on `https://115.190.186.186`.
+
+- [ ] **Step 9.2: Pick a test catalog**
+
+Run:
+
+```bash
+kweaver vega catalog list --limit 20 2>&1 | grep -E '"id"|"name"|"connector_type"|"type"' | head -40
+```
+
+Expected: pick a `type: physical` catalog with `connector_type: postgresql` or `mysql`. Note its `id`. The probed catalog `d7nicrcjto2s73d9g67g` (postgres_172_31_12_93) is a known working baseline.
+
+- [ ] **Step 9.3: Run end-to-end via the migrated SDK**
+
+Build the local TS SDK then invoke through the CLI in this worktree:
+
+```bash
+pnpm -C packages/typescript build
+node packages/typescript/dist/cli.js bkn create-from-ds d7nicrcjto2s73d9g67g --name e2e_issue114_$(date +%s) --pretty 2>&1 | tail -40
+```
+
+Expected: BKN created, no `data-connection` URL appears in any verbose log path. If anything 404s, capture the exact URL and re-check the migration.
+
+- [ ] **Step 9.4: Negative case — pass legacy UUID**
+
+```bash
+node packages/typescript/dist/cli.js bkn create-from-ds dfaf719c-4c41-4661-9ec9-25c263ff8c46 --name should_fail 2>&1 | tail -5
+```
+
+Expected: exits non-zero with the "looks like a legacy data-connection datasource UUID" hint.
+
+- [ ] **Step 9.5: Python parity smoke**
+
+```bash
+cd packages/python
+python -c "
+from kweaver import KWeaverClient
+import os
+c = KWeaverClient(base_url=os.environ['KWEAVER_BASE_URL'], token=os.environ['KWEAVER_TOKEN'])
+tables = c.datasources.list_tables('d7nicrcjto2s73d9g67g', auto_scan=False)
+print(f'fetched {len(tables)} tables; first column of first table:', tables[0].columns[0].name if tables and tables[0].columns else 'n/a')
+"
+```
+
+Expected: prints non-empty table count and a column name. (Set `KWEAVER_BASE_URL` / `KWEAVER_TOKEN` from `~/.kweaver/state.json` first; refer to the credentials memory.)
+
+- [ ] **Step 9.6: Verify untouched paths still work**
+
+```bash
+node packages/typescript/dist/cli.js ds list --limit 3 2>&1 | tail -20
+node packages/typescript/dist/cli.js ds tables dfaf719c-4c41-4661-9ec9-25c263ff8c46 2>&1 | tail -10
+```
+
+Expected: both succeed against data-connection (these were intentionally not migrated).
+
+- [ ] **Step 9.7: No commit; record results in PR description**
+
+E2E results go in the PR body. If anything fails, file a bug back to whichever task introduced the regression and re-execute.
+
+---
+
+## Task 10: Open PR
+
+**Files:** none
+
+- [ ] **Step 10.1: Push branch**
+
+```bash
+git push -u origin feat/issue-114-bkn-ds-vega-migration
+```
+
+- [ ] **Step 10.2: Open PR linking #114**
+
+```bash
+gh pr create --title "feat(sdk): migrate bkn create-from-ds path to vega catalogs (#114)" --body "$(cat <<'EOF'
+## Summary
+- Migrates the SDK functions `bkn create-from-ds` depends on (`listTablesWithColumns`, `scanMetadata`, and Python equivalents) from `data-connection` to `vega-backend` catalogs.
+- `bkn create-from-ds` and `bkn create-from-csv` now expect a vega catalog id; legacy datasource UUIDs are rejected with a clear hint.
+- Other ds subcommands (`ds list/get/connect/tables/delete`) intentionally remain on data-connection — see the spec for rationale.
+
+## Test plan
+- [ ] TS unit: `pnpm -C packages/typescript test`
+- [ ] Python unit: `cd packages/python && python -m pytest tests/unit/test_datasources.py`
+- [ ] E2E: `bkn create-from-ds <vega-catalog-id> --name e2e_…` on admin platform succeeds end-to-end with no data-connection traffic
+- [ ] Negative: passing a UUID exits with the migration hint
+- [ ] Untouched: `ds list` and `ds tables <legacy-uuid>` still work
+
+Closes #114 (partial — see spec for the deliberately-deferred remainder).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 10.3: Cleanup worktree (optional, after merge)**
+
+```bash
+cd /Users/xupeng/dev/github/kweaver-sdk
+git worktree remove ../kweaver-sdk-issue-114
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: every spec section maps to a task — `listTablesWithColumns` → Tasks 4-5, `scanMetadata` → Tasks 2-3, Python parity → Tasks 6-7, `bkn-ops` UUID guard → Task 8, E2E → Task 9.
+- No placeholders: every step contains exact code or commands.
+- Type consistency: `assertVegaCatalogId` and `UUID_V4_RE` defined once in Task 8; `listVegaCatalogResources`/`getVegaResource`/`discoverVegaCatalog` are imported from the existing `api/vega.ts` (not redefined).
+- Out of scope (per spec): `testDatasource`/`createDatasource`/`listDatasources`/`getDatasource`/`deleteDatasource`/`listTables`/`ds CLI` paths and `_crypto`/`makeBinData` are left untouched; no task modifies them.

--- a/docs/superpowers/specs/2026-05-08-bkn-ds-vega-migration-design.md
+++ b/docs/superpowers/specs/2026-05-08-bkn-ds-vega-migration-design.md
@@ -1,0 +1,144 @@
+# BKN create-from-ds 链路向 vega-backend catalogs 的最小迁移
+
+- 日期：2026-05-08
+- 关联 issue：[kweaver-sdk#114](https://github.com/kweaver-ai/kweaver-sdk/issues/114)
+- 上游遗留：[kweaver-sdk#57](https://github.com/kweaver-ai/kweaver-sdk/issues/57)（标 COMPLETED 但实际未做）
+
+## 背景
+
+`packages/typescript/src/api/datasources.ts` 与 `packages/python/src/kweaver/resources/datasources.py` 当前 100% 调用 `/api/data-connection/v1/...`。该 Java 服务计划下线，且不支持 no-auth 模式。
+
+本次范围**不**做 ds 命令的整体迁移（A 方案）。原因：
+
+1. data-connection 与 vega-backend 是两套独立存储 —— 同一物理库在两个服务上 ID 完全不同（已实测：`postgres_172_31_12_93` 在 data-connection 是 UUID `dfaf719c-…`，在 vega 是 `d7nicrcjto2s73d9g67g`）。整体迁移必然带来历史 datasource id 不可继续使用的兼容性破坏。
+2. data-connection 服务下线时间未定，目前仍可用。
+3. 真正阻塞下游的是 `bkn create-from-ds` 路径 —— kweaver-eval 当前用 `EVAL_DB_PK_MAP` 兜底也是因为这条链路在 no-auth/服务异常时 PK 拿不到。
+
+因此本 spec 只迁移 `bkn create-from-ds` 实际依赖的两条 SDK 函数（`listTablesWithColumns`、`scanMetadata`），其余 ds 子命令保留在 data-connection 直到该服务真要下线。
+
+## 范围
+
+### 改动
+
+- `packages/typescript/src/api/datasources.ts`
+  - `listTablesWithColumns` —— 重写为基于 vega-backend catalogs 的实现
+  - `scanMetadata` —— 重写为 `discoverVegaCatalog` 包装（`scanDatasourceMetadata` 是其薄包装，自动随之改）
+- `packages/python/src/kweaver/resources/datasources.py`
+  - 对应两个方法的 Python 等价改造
+- `packages/typescript/src/commands/bkn-ops.ts`
+  - 入参文案与帮助说明：`bkn create-from-ds` 现在期望 **vega catalog id**
+  - UUID 风格输入的前置校验与提示文案
+
+### 保持不变（继续走 data-connection）
+
+- `testDatasource` / `createDatasource` / `listDatasources` / `getDatasource` / `deleteDatasource` / `listTables`
+- `kweaver ds list/get/tables/connect/delete` 全部 CLI 子命令
+- `packages/typescript/src/utils/crypto.ts`、`packages/python/src/kweaver/_crypto.py`
+- `_client.py` / `client.ts` 的 `DataSources*` 资源对外签名
+
+### 不在范围
+
+- `data-connection` 全量替换（即原 issue 描述的 ds list/get/connect 等迁移）—— 留待 data-connection 真要下线时一次性处理
+- vega-backend `/api/vega-backend/in/v1/` no-auth 内部路由切换 —— SDK 现有 `isNoAuth` 头部省略机制配合 `/v1/` 端点已能在 no-auth 模式下工作；如实测仍有 401 再开 follow-up
+- `_crypto` / `makeBinData` 删除 —— 仅在被迁移函数路径上变为死代码引用，本次不删除模块以避免影响其他调用方
+
+## 设计
+
+### 函数级改造
+
+#### `listTablesWithColumns(id, …)`
+
+- `id` 语义变更：现在是 **vega catalog id**（不再是 data-connection datasource UUID）
+- 实现流程：
+  1. `listVegaCatalogResources(id, category="table")` —— 拿表清单（vega 返回 `entries[]` 仅含 `{id, name, category, …}`，不含字段）
+  2. 对每个 resource 并发 `getVegaResource(rid)` —— 从响应的 `source_metadata.columns[]` 抽字段
+  3. 字段映射保留现有 `isColumnPrimaryKey` 判定（`is_primary_key=true` / `column_key="PRI"`）和 table-level `primary_keys[]` 合成逻辑
+- 返回 shape **完全不变**：`Array<{ name, columns: [{name, type, comment?, isPrimaryKey?}], primaryKeys? }>`
+- `autoScan=true` 且 `entries[]` 为空时，仍走 `scanMetadata` → 重新 listResources 的二次尝试逻辑（但底层换成 vega `discover`）
+
+#### `scanMetadata(id, …)`
+
+- `id` 语义变更：现在是 **vega catalog id**
+- 实现：`discoverVegaCatalog(id, wait=true)` —— 异步轮询逻辑收敛到 vega 同步等待
+- 入参 `dsType` 字段不再使用（vega catalog 自带 `connector_type`），但为减少签名变动保留并忽略
+
+### 调用方契约：`bkn create-from-ds`
+
+- 入参语义：`--ds-id` / 位置参数 现期望 **vega catalog id**
+- 帮助文案更新：明确说明传 vega catalog id（用 `kweaver vega catalog list --keyword <name>` 查得）
+- 前置校验：若入参匹配 UUID v4 模式（含 4 段 dash 的 36 字符），输出明确错误并终止：
+
+  > 检测到 legacy datasource UUID。`bkn create-from-ds` 现在使用 vega catalog id —— 请运行 `kweaver vega catalog list --keyword <name>` 找到对应 id 后再传入。
+- 此校验仅用于把误用引导到正路上，不做"自动反查 / fallback 到 data-connection"（避免 data-connection 不可用时的链路撕裂）
+
+### 错误处理
+
+- vega 返回 404 —— 透传 `HttpError`，在 `bkn-ops.ts` 调用层补一句 "请确认 id 是 vega catalog id" 的 hint
+- `discoverVegaCatalog(wait=true)` 失败 —— 直接抛出 vega 返回的错误信息，不做翻译
+- 并发 `getVegaResource` 任一失败 —— 收集所有失败后整体抛错；不静默吞错；信息至少包含失败的 resource id
+
+### 数据流
+
+```
+bkn create-from-ds <catalog_id>
+  └─ commands/bkn-ops.ts
+       ├─ pre-check: catalog_id 不是 UUID
+       ├─ listTablesWithColumns(catalog_id)
+       │    ├─ vega.listVegaCatalogResources(catalog_id, category="table")
+       │    └─ for each resource: vega.getVegaResource(rid) [并发]
+       │         └─ source_metadata.columns[] → {name, type, isPrimaryKey?}
+       └─ scanMetadata(catalog_id)            [仅当 listResources 为空且 autoScan]
+            └─ vega.discoverVegaCatalog(catalog_id, wait=true)
+```
+
+## 测试
+
+memory 已确认：SDK 必须用真实端点，e2e 是真正的质量门，单 mock 无意义。
+
+### Unit（mock transport）
+
+- `listTablesWithColumns`：
+  - listResources 返回多表 + 每表 getResource 返回 `source_metadata.columns[]` → 断言输出 shape 与旧实现等价
+  - 不同 PK 形状（`is_primary_key=true` / `column_key="PRI"` / 表级 `primary_keys[]`）的提取
+  - getResource 单条失败 → 整体抛错
+  - listResources 空 + `autoScan=true` → 触发 discover → 重新 list 的二次尝试
+- `scanMetadata`：discover 调用与 wait 参数透传
+- `bkn-ops.ts`：UUID 风格入参 → 前置错误抛出；短 id 入参 → 正常进流程
+
+### E2E
+
+在 `https://115.190.186.186` admin 平台上：
+
+```bash
+kweaver bkn create-from-ds --catalog-id d7nicrcjto2s73d9g67g <其他参数>
+```
+
+确认：
+- 端到端无 data-connection 调用（可 wireshark / SDK debug 日志）
+- 输出 BKN 与旧链路结果一致
+- 至少覆盖 1 个 mysql、1 个 postgresql catalog
+
+旧的 unit tests（如有）与 data-connection mock 一并按新实现重写。
+
+## 实施顺序建议
+
+1. TS 端 `listTablesWithColumns` + `scanMetadata` 改造与单测
+2. Python 端 `DataSourcesResource` 对应方法改造与单测
+3. `bkn-ops.ts` 入参校验与文案
+4. E2E 跑通后再 commit/PR
+
+实际拆分由 writing-plans 阶段决定。
+
+## 风险与已知 trade-off
+
+- `kweaver ds tables <legacy-uuid>` 仍走 data-connection，与 `bkn create-from-ds` 用 vega 形成命令面不一致 —— 已接受作为最小改动代价
+- N+1 `getVegaResource` 比原 list-tables 单次调用慢 —— 用并发缓解；表数量极大（>1000）时可能成为瓶颈，作为已知约束
+- data-connection 服务真下线时，`ds list/get/tables` 等仍会断 —— 留待届时整体迁移
+
+## 验证清单
+
+- [ ] TS 单测全过 + Python 单测全过
+- [ ] E2E `bkn create-from-ds --catalog-id <vega-id>` 输出与旧实现 BKN 等价
+- [ ] CLI 帮助文案显示新入参语义
+- [ ] UUID 输入触发明确的引导错误
+- [ ] 没有改动 ds list/get/connect/tables/delete 任一子命令的行为

--- a/docs/superpowers/specs/2026-05-08-bkn-ds-vega-migration-design.md
+++ b/docs/superpowers/specs/2026-05-08-bkn-ds-vega-migration-design.md
@@ -32,7 +32,7 @@
 ### 保持不变（继续走 data-connection）
 
 - `testDatasource` / `createDatasource` / `listDatasources` / `getDatasource` / `deleteDatasource` / `listTables`
-- `kweaver ds list/get/tables/connect/delete` 全部 CLI 子命令
+- `kweaver ds list/get/connect/delete` CLI 子命令
 - `packages/typescript/src/utils/crypto.ts`、`packages/python/src/kweaver/_crypto.py`
 - `_client.py` / `client.ts` 的 `DataSources*` 资源对外签名
 
@@ -62,7 +62,7 @@
 - 实现：`discoverVegaCatalog(id, wait=true)` —— 异步轮询逻辑收敛到 vega 同步等待
 - 入参 `dsType` 字段不再使用（vega catalog 自带 `connector_type`），但为减少签名变动保留并忽略
 
-### 调用方契约：`bkn create-from-ds`
+### 调用方契约：`bkn create-from-ds` 与 `ds tables`
 
 - 入参语义：`--ds-id` / 位置参数 现期望 **vega catalog id**
 - 帮助文案更新：明确说明传 vega catalog id（用 `kweaver vega catalog list --keyword <name>` 查得）
@@ -70,6 +70,8 @@
 
   > 检测到 legacy datasource UUID。`bkn create-from-ds` 现在使用 vega catalog id —— 请运行 `kweaver vega catalog list --keyword <name>` 找到对应 id 后再传入。
 - 此校验仅用于把误用引导到正路上，不做"自动反查 / fallback 到 data-connection"（避免 data-connection 不可用时的链路撕裂）
+
+`kweaver ds tables <vega-catalog-id>` 也走 vega catalogs（与 `bkn create-from-ds` 共享 `listTablesWithColumns` 实现）。`kweaver ds list/get` 仍读 data-connection，所以日常浏览旧数据源的入口仍在，但浏览到的 datasource UUID 不能直接传给 `ds tables` —— 用 `kweaver vega catalog list --keyword <name>` 反查 vega 端 id。
 
 ### 错误处理
 
@@ -131,7 +133,7 @@ kweaver bkn create-from-ds --catalog-id d7nicrcjto2s73d9g67g <其他参数>
 
 ## 风险与已知 trade-off
 
-- `kweaver ds tables <legacy-uuid>` 仍走 data-connection，与 `bkn create-from-ds` 用 vega 形成命令面不一致 —— 已接受作为最小改动代价
+- `kweaver ds list` / `ds get` 走 data-connection（输出 UUID），`ds tables` / `bkn create-from-ds` 走 vega（要 catalog id）—— 命令面有 ID 风格的不一致，但更小的改动面下没有更好的折中。
 - N+1 `getVegaResource` 比原 list-tables 单次调用慢 —— 用并发缓解；表数量极大（>1000）时可能成为瓶颈，作为已知约束
 - data-connection 服务真下线时，`ds list/get/tables` 等仍会断 —— 留待届时整体迁移
 
@@ -141,4 +143,4 @@ kweaver bkn create-from-ds --catalog-id d7nicrcjto2s73d9g67g <其他参数>
 - [ ] E2E `bkn create-from-ds --catalog-id <vega-id>` 输出与旧实现 BKN 等价
 - [ ] CLI 帮助文案显示新入参语义
 - [ ] UUID 输入触发明确的引导错误
-- [ ] 没有改动 ds list/get/connect/tables/delete 任一子命令的行为
+- [ ] 没有改动 ds list/get/connect/delete 任一子命令的行为（ds tables 已纳入迁移范围）

--- a/docs/superpowers/specs/2026-05-08-bkn-ds-vega-migration-design.md
+++ b/docs/superpowers/specs/2026-05-08-bkn-ds-vega-migration-design.md
@@ -20,14 +20,17 @@
 
 ### 改动
 
+- `packages/typescript/src/api/vega.ts`
+  - 新增 `listTablesWithColumns` —— 基于 vega-backend catalogs 的实现
+  - 新增 `scanMetadata` —— `discoverVegaCatalog` 包装；`scanDatasourceMetadata` 同步迁入并保留为薄包装
 - `packages/typescript/src/api/datasources.ts`
-  - `listTablesWithColumns` —— 重写为基于 vega-backend catalogs 的实现
-  - `scanMetadata` —— 重写为 `discoverVegaCatalog` 包装（`scanDatasourceMetadata` 是其薄包装，自动随之改）
+  - 移除上述三个函数的旧实现；改为从 `./vega.js` re-export，保持调用方导入路径兼容
+- `packages/python/src/kweaver/resources/vega/catalogs.py`
+  - `VegaCatalogsResource` 新增 `scan_metadata` / `list_tables`，承载真实实现
 - `packages/python/src/kweaver/resources/datasources.py`
-  - 对应两个方法的 Python 等价改造
-- `packages/typescript/src/commands/bkn-ops.ts`
-  - 入参文案与帮助说明：`bkn create-from-ds` 现在期望 **vega catalog id**
-  - UUID 风格输入的前置校验与提示文案
+  - `DataSourcesResource.scan_metadata` / `list_tables` 改为对 `VegaCatalogsResource` 的薄委托，签名保持不变
+- `packages/typescript/src/commands/bkn-ops.ts` / `src/commands/ds.ts` / `src/resources/datasources.ts`
+  - 直接从 `../api/vega.js` 导入新位置；`bkn create-from-ds` 帮助文案与 UUID 前置校验保持本 spec 既定行为
 
 ### 保持不变（继续走 data-connection）
 
@@ -43,6 +46,10 @@
 - `_crypto` / `makeBinData` 删除 —— 仅在被迁移函数路径上变为死代码引用，本次不删除模块以避免影响其他调用方
 
 ## 设计
+
+### 模块归属
+
+迁移后这三个函数在物理上属于 vega 模块（`api/vega.ts`、`resources/vega/catalogs.py`），因为它们 100% 调用 vega-backend。`api/datasources.ts` / `resources/datasources.py` 仅保留向后兼容的 re-export 与委托层 —— 旧调用方（`commands/ds.ts`、`commands/bkn-ops.ts`、`resources/DataSourcesResource`、单测）可以选择继续从 `datasources` 导入或直接迁到 `vega`，本次实施已让现役调用方都改导自 vega 以避免后续误用。
 
 ### 函数级改造
 

--- a/packages/python/src/kweaver/resources/datasources.py
+++ b/packages/python/src/kweaver/resources/datasources.py
@@ -1,8 +1,12 @@
-"""SDK resource: data sources (data-connection service)."""
+"""SDK resource: data sources (data-connection service).
+
+scan_metadata / list_tables have been moved to
+``kweaver.resources.vega.catalogs.VegaCatalogsResource``; the methods here
+are thin delegation stubs kept for backward compatibility.
+"""
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING, Any
 
 from kweaver._crypto import encrypt_password
@@ -114,21 +118,22 @@ class DataSourcesResource:
     def scan_metadata(self, id: str, *, ds_type: str = "mysql") -> str:
         """Trigger a metadata scan for a vega catalog and wait for completion.
 
-        ``id`` is a vega catalog id (e.g. ``d7nicrcjto2s73d9g67g``), not a
-        legacy data-connection datasource UUID. ``ds_type`` is retained for
-        signature compatibility but ignored — vega catalogs carry their own
-        ``connector_type``.
+        .. deprecated::
+            Use ``client.vega.catalogs.scan_metadata(id)`` directly. This
+            method delegates to the vega catalogs resource for backward
+            compatibility.
 
-        Returns the discover endpoint's response body as a JSON string.
+        ``id`` is a vega catalog id. ``ds_type`` is ignored (retained for
+        signature compatibility).
+
+        Returns the discover response as a JSON string.
         """
-        del ds_type  # retained for backward compat, intentionally unused
-        result = self._http.post(
-            f"/api/vega-backend/v1/catalogs/{id}/discover",
-            params={"wait": "true"},
-        )
-        if isinstance(result, str):
-            return result
-        return json.dumps(result)
+        import json as _json
+        del ds_type
+        from kweaver.resources.vega.catalogs import VegaCatalogsResource
+        vega_cats = VegaCatalogsResource(self._http)
+        result = vega_cats.scan_metadata(id)
+        return _json.dumps(result) if isinstance(result, dict) else str(result)
 
     def list_tables(
         self,
@@ -141,78 +146,22 @@ class DataSourcesResource:
     ) -> list[Table]:
         """List tables with columns from a vega catalog.
 
-        Two-stage fetch:
-          1. ``GET /api/vega-backend/v1/catalogs/{id}/resources?category=table``
-          2. For each resource: ``GET /api/vega-backend/v1/resources/{rid}``,
-             extracting ``source_metadata.columns``.
+        .. deprecated::
+            Use ``client.vega.catalogs.list_tables(id, ...)`` directly.
 
-        If the catalog has no table resources and ``auto_scan=True``, triggers
-        a discover and retries the list once. The optional ``keyword`` filters
-        summaries client-side before the per-resource detail fetches, narrowing
-        N+1 to k+1.
-
-        ``id`` is a vega catalog id, not a legacy data-connection datasource UUID.
+        ``id`` is a vega catalog id, not a legacy data-connection datasource
+        UUID.
         """
+        from kweaver.resources.vega.catalogs import VegaCatalogsResource
+        vega_cats = VegaCatalogsResource(self._http)
+        return vega_cats.list_tables(
+            id,
+            keyword=keyword,
+            limit=limit,
+            offset=offset,
+            auto_scan=auto_scan,
+        )
 
-        def _list_summaries_raw() -> list[dict[str, Any]]:
-            params: dict[str, Any] = {"category": "table"}
-            if limit is not None:
-                params["limit"] = limit
-            if offset is not None:
-                params["offset"] = offset
-            data = self._http.get(
-                f"/api/vega-backend/v1/catalogs/{id}/resources",
-                params=params,
-            )
-            return (
-                data
-                if isinstance(data, list)
-                else (data.get("entries") or data.get("data") or [])
-            )
-
-        summaries = _list_summaries_raw()
-        if not summaries and auto_scan:
-            self.scan_metadata(id)
-            summaries = _list_summaries_raw()
-
-        if keyword:
-            k = keyword.lower()
-            summaries = [it for it in summaries if k in str(it.get("name", "")).lower()]
-
-        tables: list[Table] = []
-        for s in summaries:
-            rid = s.get("id", "")
-            if not rid:
-                continue
-            try:
-                detail_raw = self._http.get(f"/api/vega-backend/v1/resources/{rid}")
-            except Exception as exc:
-                raise RuntimeError(
-                    f"vega resource {rid} fetch failed: {exc}"
-                ) from exc
-
-            detail = detail_raw
-            if isinstance(detail_raw, dict):
-                entries = detail_raw.get("entries") or detail_raw.get("data")
-                if isinstance(entries, list) and entries:
-                    detail = entries[0]
-            if not isinstance(detail, dict):
-                continue
-            columns_raw = (detail.get("source_metadata") or {}).get("columns") or []
-            tables.append(
-                Table(
-                    name=detail.get("name", s.get("name", "")),
-                    columns=[
-                        Column(
-                            name=c.get("name", c.get("field_name", "")),
-                            type=c.get("type", c.get("field_type", "varchar")),
-                            comment=c.get("description") or c.get("comment"),
-                        )
-                        for c in columns_raw
-                    ],
-                )
-            )
-        return tables
 
 
 def _parse_datasource(d: Any) -> DataSource:

--- a/packages/python/src/kweaver/resources/datasources.py
+++ b/packages/python/src/kweaver/resources/datasources.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import time
+import json
 from typing import TYPE_CHECKING, Any
 
 from kweaver._crypto import encrypt_password
@@ -112,31 +112,23 @@ class DataSourcesResource:
         self._http.delete(f"/api/data-connection/v1/datasource/{id}")
 
     def scan_metadata(self, id: str, *, ds_type: str = "mysql") -> str:
-        """Trigger a metadata scan for a datasource and wait for completion.
+        """Trigger a metadata scan for a vega catalog and wait for completion.
 
-        Returns the scan task ID.
+        ``id`` is a vega catalog id (e.g. ``d7nicrcjto2s73d9g67g``), not a
+        legacy data-connection datasource UUID. ``ds_type`` is retained for
+        signature compatibility but ignored — vega catalogs carry their own
+        ``connector_type``.
+
+        Returns the discover endpoint's response body as a JSON string.
         """
-        ds = self.get(id)
-        scan_name = f"sdk_scan_{id[:8]}"
+        del ds_type  # retained for backward compat, intentionally unused
         result = self._http.post(
-            "/api/data-connection/v1/metadata/scan",
-            json={
-                "scan_name": scan_name,
-                "type": 0,
-                "ds_info": {"ds_id": id, "ds_type": ds_type or ds.type or "mysql"},
-                "use_default_template": True,
-                "use_multi_threads": True,
-                "status": "open",
-            },
+            f"/api/vega-backend/v1/catalogs/{id}/discover",
+            params={"wait": "true"},
         )
-        task_id = result.get("id", "")
-        # Poll until scan completes with exponential backoff
-        for attempt in range(30):
-            time.sleep(min(2 * (1.5 ** attempt), 15))
-            status = self._http.get(f"/api/data-connection/v1/metadata/scan/{task_id}")
-            if status.get("status") in ("success", "fail"):
-                break
-        return task_id
+        if isinstance(result, str):
+            return result
+        return json.dumps(result)
 
     def list_tables(
         self,

--- a/packages/python/src/kweaver/resources/datasources.py
+++ b/packages/python/src/kweaver/resources/datasources.py
@@ -139,51 +139,72 @@ class DataSourcesResource:
         offset: int | None = None,
         auto_scan: bool = True,
     ) -> list[Table]:
-        params: dict[str, Any] = {"limit": -1}
-        if keyword:
-            params["keyword"] = keyword
-        if limit is not None:
-            params["limit"] = limit
-        if offset is not None:
-            params["offset"] = offset
-        data = self._http.get(
-            f"/api/data-connection/v1/metadata/data-source/{id}",
-            params=params,
-        )
-        items = data if isinstance(data, list) else (data.get("entries") or data.get("data") or [])
+        """List tables with columns from a vega catalog.
 
-        # Auto-trigger metadata scan if no tables found
-        if not items and auto_scan:
-            self.scan_metadata(id)
+        Two-stage fetch:
+          1. ``GET /api/vega-backend/v1/catalogs/{id}/resources?category=table``
+          2. For each resource: ``GET /api/vega-backend/v1/resources/{rid}``,
+             extracting ``source_metadata.columns``.
+
+        If the catalog has no table resources and ``auto_scan=True``, triggers
+        a discover and retries the list once. The optional ``keyword`` filters
+        summaries client-side before the per-resource detail fetches, narrowing
+        N+1 to k+1.
+
+        ``id`` is a vega catalog id, not a legacy data-connection datasource UUID.
+        """
+
+        def _list_summaries() -> list[dict[str, Any]]:
+            params: dict[str, Any] = {"category": "table"}
+            if limit is not None:
+                params["limit"] = limit
+            if offset is not None:
+                params["offset"] = offset
             data = self._http.get(
-                f"/api/data-connection/v1/metadata/data-source/{id}",
+                f"/api/vega-backend/v1/catalogs/{id}/resources",
                 params=params,
             )
-            items = data if isinstance(data, list) else (data.get("entries") or data.get("data") or [])
+            items = (
+                data
+                if isinstance(data, list)
+                else (data.get("entries") or data.get("data") or [])
+            )
+            if keyword:
+                k = keyword.lower()
+                items = [it for it in items if k in str(it.get("name", "")).lower()]
+            return items
+
+        summaries = _list_summaries()
+        if not summaries and auto_scan:
+            self.scan_metadata(id)
+            summaries = _list_summaries()
 
         tables: list[Table] = []
-        for t in items:
-            table_id = t.get("id", "")
-            table_name = t.get("name", "")
-            # Fetch column details if not inline
-            columns_raw = t.get("columns", t.get("fields", []))
-            if not columns_raw and table_id:
-                col_data = self._http.get(
-                    f"/api/data-connection/v1/metadata/table/{table_id}",
-                    params={"limit": -1},
-                )
-                columns_raw = (
-                    col_data if isinstance(col_data, list)
-                    else (col_data.get("entries") or col_data.get("data") or [])
-                )
+        for s in summaries:
+            rid = s.get("id", "")
+            if not rid:
+                continue
+            try:
+                detail_raw = self._http.get(f"/api/vega-backend/v1/resources/{rid}")
+            except Exception as exc:  # noqa: BLE001 — re-raise with id context
+                raise type(exc)(f"vega resource {rid} fetch failed: {exc}") from exc
+
+            detail = detail_raw
+            if isinstance(detail_raw, dict):
+                entries = detail_raw.get("entries") or detail_raw.get("data")
+                if isinstance(entries, list) and entries:
+                    detail = entries[0]
+            if not isinstance(detail, dict):
+                continue
+            columns_raw = (detail.get("source_metadata") or {}).get("columns") or []
             tables.append(
                 Table(
-                    name=table_name,
+                    name=detail.get("name", s.get("name", "")),
                     columns=[
                         Column(
                             name=c.get("name", c.get("field_name", "")),
                             type=c.get("type", c.get("field_type", "varchar")),
-                            comment=c.get("comment"),
+                            comment=c.get("description") or c.get("comment"),
                         )
                         for c in columns_raw
                     ],

--- a/packages/python/src/kweaver/resources/datasources.py
+++ b/packages/python/src/kweaver/resources/datasources.py
@@ -154,7 +154,7 @@ class DataSourcesResource:
         ``id`` is a vega catalog id, not a legacy data-connection datasource UUID.
         """
 
-        def _list_summaries() -> list[dict[str, Any]]:
+        def _list_summaries_raw() -> list[dict[str, Any]]:
             params: dict[str, Any] = {"category": "table"}
             if limit is not None:
                 params["limit"] = limit
@@ -164,20 +164,20 @@ class DataSourcesResource:
                 f"/api/vega-backend/v1/catalogs/{id}/resources",
                 params=params,
             )
-            items = (
+            return (
                 data
                 if isinstance(data, list)
                 else (data.get("entries") or data.get("data") or [])
             )
-            if keyword:
-                k = keyword.lower()
-                items = [it for it in items if k in str(it.get("name", "")).lower()]
-            return items
 
-        summaries = _list_summaries()
+        summaries = _list_summaries_raw()
         if not summaries and auto_scan:
             self.scan_metadata(id)
-            summaries = _list_summaries()
+            summaries = _list_summaries_raw()
+
+        if keyword:
+            k = keyword.lower()
+            summaries = [it for it in summaries if k in str(it.get("name", "")).lower()]
 
         tables: list[Table] = []
         for s in summaries:
@@ -186,8 +186,10 @@ class DataSourcesResource:
                 continue
             try:
                 detail_raw = self._http.get(f"/api/vega-backend/v1/resources/{rid}")
-            except Exception as exc:  # noqa: BLE001 — re-raise with id context
-                raise type(exc)(f"vega resource {rid} fetch failed: {exc}") from exc
+            except Exception as exc:
+                raise RuntimeError(
+                    f"vega resource {rid} fetch failed: {exc}"
+                ) from exc
 
             detail = detail_raw
             if isinstance(detail_raw, dict):

--- a/packages/python/src/kweaver/resources/vega/catalogs.py
+++ b/packages/python/src/kweaver/resources/vega/catalogs.py
@@ -1,7 +1,7 @@
 """VegaCatalogsResource — catalog CRUD + discover/health operations."""
 from __future__ import annotations
 from typing import Any, TYPE_CHECKING
-from kweaver.types import VegaCatalog, VegaResource
+from kweaver.types import Column, Table, VegaCatalog, VegaResource
 
 if TYPE_CHECKING:
     from kweaver._http import HttpClient
@@ -65,3 +65,90 @@ class VegaCatalogsResource:
         data = self._http.get(f"{self._BASE}/{id}/resources", params=params)
         entries = data.get("entries", data.get("data", [])) if isinstance(data, dict) else data
         return [VegaResource(**e) for e in entries]
+
+    # ── Scan & table listing ──────────────────────────────────────────────
+
+    def scan_metadata(self, id: str) -> dict:
+        """Trigger a metadata scan (discover) for a vega catalog, wait for it.
+
+        ``id`` is a vega catalog id (e.g. ``d7nicrcjto2s73d9g67g``).
+        Returns the discover endpoint's response as a dict.
+        """
+        return self.discover(id, wait=True)
+
+    def list_tables(
+        self,
+        id: str,
+        *,
+        keyword: str | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        auto_scan: bool = True,
+    ) -> list[Table]:
+        """List tables with columns from a vega catalog.
+
+        Two-stage fetch:
+          1. ``GET /catalogs/{id}/resources?category=table`` — list summaries
+          2. For each resource: ``GET /resources/{rid}`` — pull
+             ``source_metadata.columns``
+
+        If no table resources exist and ``auto_scan=True``, triggers a
+        discover and retries once. ``keyword`` filters summaries client-side
+        before the per-resource detail fetches, narrowing N+1 to k+1.
+        """
+        def _list_summaries_raw() -> list[dict[str, Any]]:
+            params: dict[str, Any] = {"category": "table"}
+            if limit is not None:
+                params["limit"] = limit
+            if offset is not None:
+                params["offset"] = offset
+            data = self._http.get(f"{self._BASE}/{id}/resources", params=params)
+            return (
+                data
+                if isinstance(data, list)
+                else (data.get("entries") or data.get("data") or [])
+            )
+
+        summaries = _list_summaries_raw()
+        if not summaries and auto_scan:
+            self.scan_metadata(id)
+            summaries = _list_summaries_raw()
+
+        if keyword:
+            k = keyword.lower()
+            summaries = [it for it in summaries if k in str(it.get("name", "")).lower()]
+
+        tables: list[Table] = []
+        for s in summaries:
+            rid = s.get("id", "")
+            if not rid:
+                continue
+            try:
+                detail_raw = self._http.get(f"/api/vega-backend/v1/resources/{rid}")
+            except Exception as exc:
+                raise RuntimeError(
+                    f"vega resource {rid} fetch failed: {exc}"
+                ) from exc
+
+            detail = detail_raw
+            if isinstance(detail_raw, dict):
+                entries = detail_raw.get("entries") or detail_raw.get("data")
+                if isinstance(entries, list) and entries:
+                    detail = entries[0]
+            if not isinstance(detail, dict):
+                continue
+            columns_raw = (detail.get("source_metadata") or {}).get("columns") or []
+            tables.append(
+                Table(
+                    name=detail.get("name", s.get("name", "")),
+                    columns=[
+                        Column(
+                            name=c.get("name", c.get("field_name", "")),
+                            type=c.get("type", c.get("field_type", "varchar")),
+                            comment=c.get("description") or c.get("comment"),
+                        )
+                        for c in columns_raw
+                    ],
+                )
+            )
+        return tables

--- a/packages/python/tests/unit/test_datasources.py
+++ b/packages/python/tests/unit/test_datasources.py
@@ -176,13 +176,14 @@ def test_list_tables_keyword_filters_before_detail_fetch(capture: RequestCapture
         if "/vega-backend/v1/resources/" in url:
             rid = url.split("/resources/")[1].split("?")[0]
             detail_calls.append(rid)
+            name_for = {"r1": "skills", "r2": "orders", "r3": "skill_logs"}
             return httpx.Response(
                 200,
                 json={
                     "entries": [
                         {
                             "id": rid,
-                            "name": rid,
+                            "name": name_for[rid],
                             "source_metadata": {"columns": []},
                         }
                     ]
@@ -193,10 +194,59 @@ def test_list_tables_keyword_filters_before_detail_fetch(capture: RequestCapture
     client = make_client(handler, capture)
     tables = client.datasources.list_tables("cat-1", keyword="skill", auto_scan=False)
     # Only "skills" and "skill_logs" match — orders filtered out before detail fetch
-    assert sorted(t.name for t in tables) == ["r1", "r3"]
+    assert sorted(t.name for t in tables) == ["skill_logs", "skills"]
     assert sorted(detail_calls) == ["r1", "r3"], (
         f"detail fetch should skip non-matching summaries; got {detail_calls}"
     )
+
+
+def test_list_tables_keyword_no_match_does_not_trigger_scan(capture: RequestCapture):
+    discover_called = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        url = str(req.url)
+        if "/vega-backend/v1/catalogs/cat-1/resources" in url and req.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {"id": "r1", "catalog_id": "cat-1", "name": "users", "category": "table"},
+                    ],
+                    "total_count": 1,
+                },
+            )
+        if "/vega-backend/v1/catalogs/cat-1/discover" in url and req.method == "POST":
+            discover_called["n"] += 1
+            return httpx.Response(200, json={"task_id": "t1"})
+        raise AssertionError(f"unexpected {req.method} {req.url}")
+
+    client = make_client(handler, capture)
+    tables = client.datasources.list_tables("cat-1", keyword="zzz_no_match", auto_scan=True)
+    assert tables == []
+    assert discover_called["n"] == 0, "scan should NOT trigger when keyword filters out all results"
+
+
+def test_list_tables_per_resource_failure_includes_rid(capture: RequestCapture):
+    def handler(req: httpx.Request) -> httpx.Response:
+        url = str(req.url)
+        if "/vega-backend/v1/catalogs/cat-1/resources" in url and req.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {"id": "r_bad", "catalog_id": "cat-1", "name": "boom", "category": "table"},
+                    ],
+                    "total_count": 1,
+                },
+            )
+        if "/vega-backend/v1/resources/r_bad" in url:
+            return httpx.Response(500, text="boom")
+        raise AssertionError(f"unexpected {req.method} {req.url}")
+
+    client = make_client(handler, capture)
+    import pytest as _pytest
+    with _pytest.raises(RuntimeError, match=r"r_bad"):
+        client.datasources.list_tables("cat-1", auto_scan=False)
 
 
 def test_list_datasources():

--- a/packages/python/tests/unit/test_datasources.py
+++ b/packages/python/tests/unit/test_datasources.py
@@ -91,3 +91,36 @@ def test_delete_datasource(capture: RequestCapture):
     client = make_client(handler, capture)
     client.datasources.delete("ds_01")
     assert "ds_01" in capture.last_url()
+
+
+def test_scan_metadata_calls_vega_discover(capture: RequestCapture):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and "/vega-backend/v1/catalogs/cat-1/discover" in str(req.url):
+            return httpx.Response(200, json={"task_id": "vega-task-1"})
+        raise AssertionError(f"unexpected {req.method} {req.url}")
+
+    client = make_client(handler, capture)
+    result = client.datasources.scan_metadata("cat-1")
+    assert "vega-task-1" in result, f"discover response should contain task_id; got {result!r}"
+    last_url = capture.last_url()
+    assert "wait=true" in last_url, f"expected wait=true in {last_url}"
+    all_urls = [str(r.url) for r in capture.requests]
+    for u in all_urls:
+        assert "/data-connection/" not in u, f"unexpected data-connection call: {u}"
+
+
+def test_scan_metadata_does_not_lookup_legacy_ds_type(capture: RequestCapture):
+    def handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and "/vega-backend/v1/catalogs/cat-1/discover" in str(req.url):
+            return httpx.Response(200, json={"task_id": "t1"})
+        raise AssertionError(f"unexpected {req.method} {req.url}")
+
+    client = make_client(handler, capture)
+    client.datasources.scan_metadata("cat-1")
+
+    methods_and_paths = [(r.method, str(r.url)) for r in capture.requests]
+    # No GET on /datasource/{id} (the old ds_type lookup)
+    for method, url in methods_and_paths:
+        assert not (
+            method == "GET" and "/datasource/cat-1" in url
+        ), f"unexpected legacy ds_type lookup: {method} {url}"

--- a/packages/python/tests/unit/test_datasources.py
+++ b/packages/python/tests/unit/test_datasources.py
@@ -53,23 +53,150 @@ def test_test_connectivity(capture: RequestCapture):
     assert "/datasource/test" in capture.last_url()
 
 
-def test_list_tables(capture: RequestCapture):
+def test_list_tables_via_vega_resources(capture: RequestCapture):
     def handler(req: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={
-            "data": [
-                {"name": "products", "columns": [
-                    {"name": "id", "type": "integer"},
-                    {"name": "name", "type": "varchar"},
-                ]},
-                {"name": "orders", "columns": []},
-            ]
-        })
+        url = str(req.url)
+        if "/vega-backend/v1/catalogs/cat-1/resources" in url and req.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {"id": "r1", "catalog_id": "cat-1", "name": "skills", "category": "table"},
+                        {"id": "r2", "catalog_id": "cat-1", "name": "orders", "category": "table"},
+                    ],
+                    "total_count": 2,
+                },
+            )
+        if "/vega-backend/v1/resources/r1" in url:
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "id": "r1",
+                            "name": "skills",
+                            "category": "table",
+                            "source_metadata": {
+                                "columns": [
+                                    {"name": "skill_id", "type": "varchar"},
+                                    {"name": "label", "type": "varchar"},
+                                ]
+                            },
+                        }
+                    ]
+                },
+            )
+        if "/vega-backend/v1/resources/r2" in url:
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "id": "r2",
+                            "name": "orders",
+                            "category": "table",
+                            "source_metadata": {"columns": []},
+                        }
+                    ]
+                },
+            )
+        raise AssertionError(f"unexpected {req.method} {req.url}")
 
     client = make_client(handler, capture)
-    tables = client.datasources.list_tables("ds_01")
-    assert len(tables) == 2
-    assert tables[0].name == "products"
-    assert tables[0].columns[0].name == "id"
+    tables = client.datasources.list_tables("cat-1", auto_scan=False)
+    names = sorted(t.name for t in tables)
+    assert names == ["orders", "skills"]
+    skills = next(t for t in tables if t.name == "skills")
+    assert [c.name for c in skills.columns] == ["skill_id", "label"]
+    for url in [str(r.url) for r in capture.requests]:
+        assert "/data-connection/" not in url, f"leak: {url}"
+
+
+def test_list_tables_empty_with_auto_scan_triggers_discover(capture: RequestCapture):
+    list_calls = {"n": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        url = str(req.url)
+        if "/vega-backend/v1/catalogs/cat-1/resources" in url and req.method == "GET":
+            list_calls["n"] += 1
+            if list_calls["n"] == 1:
+                return httpx.Response(200, json={"entries": [], "total_count": 0})
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {"id": "r1", "catalog_id": "cat-1", "name": "skills", "category": "table"}
+                    ],
+                    "total_count": 1,
+                },
+            )
+        if "/vega-backend/v1/catalogs/cat-1/discover" in url and req.method == "POST":
+            return httpx.Response(200, json={"task_id": "t1"})
+        if "/vega-backend/v1/resources/r1" in url:
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "id": "r1",
+                            "name": "skills",
+                            "source_metadata": {
+                                "columns": [{"name": "id", "type": "integer"}]
+                            },
+                        }
+                    ]
+                },
+            )
+        raise AssertionError(f"unexpected {req.method} {req.url}")
+
+    client = make_client(handler, capture)
+    tables = client.datasources.list_tables("cat-1", auto_scan=True)
+    assert len(tables) == 1
+    assert tables[0].name == "skills"
+    assert list_calls["n"] == 2
+
+
+def test_list_tables_keyword_filters_before_detail_fetch(capture: RequestCapture):
+    detail_calls: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        url = str(req.url)
+        if "/vega-backend/v1/catalogs/cat-1/resources" in url and req.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {"id": "r1", "catalog_id": "cat-1", "name": "skills", "category": "table"},
+                        {"id": "r2", "catalog_id": "cat-1", "name": "orders", "category": "table"},
+                        {"id": "r3", "catalog_id": "cat-1", "name": "skill_logs", "category": "table"},
+                    ],
+                    "total_count": 3,
+                },
+            )
+        if "/vega-backend/v1/resources/" in url:
+            rid = url.split("/resources/")[1].split("?")[0]
+            detail_calls.append(rid)
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "id": rid,
+                            "name": rid,
+                            "source_metadata": {"columns": []},
+                        }
+                    ]
+                },
+            )
+        raise AssertionError(f"unexpected {req.method} {req.url}")
+
+    client = make_client(handler, capture)
+    tables = client.datasources.list_tables("cat-1", keyword="skill", auto_scan=False)
+    # Only "skills" and "skill_logs" match — orders filtered out before detail fetch
+    assert sorted(t.name for t in tables) == ["r1", "r3"]
+    assert sorted(detail_calls) == ["r1", "r3"], (
+        f"detail fetch should skip non-matching summaries; got {detail_calls}"
+    )
 
 
 def test_list_datasources():

--- a/packages/typescript/src/api/datasources.ts
+++ b/packages/typescript/src/api/datasources.ts
@@ -1,7 +1,6 @@
 import { HttpError } from "../utils/http.js";
 import { encryptPassword } from "../utils/crypto.js";
 import { buildHeaders } from "./headers.js";
-import { discoverVegaCatalog, getVegaResource, listVegaCatalogResources } from "./vega.js";
 
 const HTTPS_PROTOCOLS = new Set(["maxcompute", "anyshare7", "opensearch"]);
 
@@ -273,219 +272,20 @@ export async function listTables(options: ListTablesOptions): Promise<string> {
   return body;
 }
 
-export interface ListTablesWithColumnsOptions {
-  baseUrl: string;
-  accessToken: string;
-  /** A vega catalog id, not a legacy data-connection datasource UUID. */
-  id: string;
-  keyword?: string;
-  limit?: number;
-  offset?: number;
-  businessDomain?: string;
-  autoScan?: boolean;
-}
+// ── Vega catalog re-exports (backward compatibility) ─────────────────────────
+//
+// listTablesWithColumns, scanMetadata, and scanDatasourceMetadata now live in
+// vega.ts (they talk exclusively to vega-backend, not data-connection).
+// Re-exported here so existing callers don't break — new code should import
+// from "../api/vega.js" directly.
+export {
+  listTablesWithColumns,
+  scanMetadata,
+  scanDatasourceMetadata,
+} from "./vega.js";
 
-interface VegaResourceListEntry {
-  id: string;
-  name: string;
-  category?: string;
-}
-
-interface VegaResourceDetail {
-  id: string;
-  name: string;
-  source_metadata?: { columns?: Array<Record<string, unknown>> };
-  primary_keys?: string[];
-  [key: string]: unknown;
-}
-
-/**
- * List tables with column details from a vega catalog.
- *
- * Two-stage fetch:
- *   1. GET /api/vega-backend/v1/catalogs/{id}/resources?category=table — list summaries
- *   2. For each resource: GET /api/vega-backend/v1/resources/{rid} — pull source_metadata.columns
- *
- * If the catalog has no resources and `autoScan=true`, triggers a discover and
- * retries the list once. The optional `keyword` filters summaries client-side
- * before the per-resource detail fetches — useful to keep N+1 down to k+1.
- *
- * `id` is a vega catalog id.
- */
-export async function listTablesWithColumns(
-  options: ListTablesWithColumnsOptions,
-): Promise<string> {
-  const {
-    baseUrl,
-    accessToken,
-    id,
-    keyword,
-    limit,
-    offset,
-    businessDomain = "bd_public",
-    autoScan = true,
-  } = options;
-
-  async function listResourceSummaries(): Promise<VegaResourceListEntry[]> {
-    const body = await listVegaCatalogResources({
-      baseUrl,
-      accessToken,
-      id,
-      category: "table",
-      limit,
-      offset,
-      businessDomain,
-    });
-    const parsed = JSON.parse(body) as
-      | Array<VegaResourceListEntry>
-      | { entries?: VegaResourceListEntry[]; data?: VegaResourceListEntry[] };
-    let items = Array.isArray(parsed) ? parsed : (parsed.entries ?? parsed.data ?? []);
-    if (keyword) {
-      const k = keyword.toLowerCase();
-      items = items.filter((it) => it.name.toLowerCase().includes(k));
-    }
-    return items;
-  }
-
-  let summaries = await listResourceSummaries();
-  if (summaries.length === 0 && autoScan) {
-    await scanMetadata({ baseUrl, accessToken, id, businessDomain });
-    summaries = await listResourceSummaries();
-  }
-
-  const details = await Promise.all(
-    summaries.map(async (s) => {
-      let body: string;
-      try {
-        body = await getVegaResource({
-          baseUrl,
-          accessToken,
-          id: s.id,
-          businessDomain,
-        });
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        throw new Error(`vega resource ${s.id} fetch failed: ${reason}`);
-      }
-      const parsed = JSON.parse(body) as
-        | VegaResourceDetail
-        | { entries?: VegaResourceDetail[]; data?: VegaResourceDetail[] };
-      if (Array.isArray((parsed as { entries?: unknown }).entries)) {
-        const arr = (parsed as { entries: VegaResourceDetail[] }).entries;
-        if (arr.length === 0) {
-          throw new Error(`vega resource ${s.id} returned empty entries`);
-        }
-        return arr[0]!;
-      }
-      if (Array.isArray((parsed as { data?: unknown }).data)) {
-        const arr = (parsed as { data: VegaResourceDetail[] }).data;
-        if (arr.length === 0) {
-          throw new Error(`vega resource ${s.id} returned empty data`);
-        }
-        return arr[0]!;
-      }
-      return parsed as VegaResourceDetail;
-    }),
-  );
-
-  const tables: Array<{
-    name: string;
-    columns: Array<{ name: string; type: string; comment?: string; isPrimaryKey?: boolean }>;
-    primaryKeys?: string[];
-  }> = [];
-
-  for (const d of details) {
-    const columnsRaw = (d.source_metadata?.columns ?? []) as Array<Record<string, unknown>>;
-    const tablePkArray = extractPrimaryKeys(d as unknown as Record<string, unknown>);
-    const columns = columnsRaw.map((c) => {
-      const name = String(c.name ?? c.field_name ?? "");
-      const flagged = isColumnPrimaryKey(c) || tablePkArray.includes(name);
-      return {
-        name,
-        type: String(c.type ?? c.field_type ?? "varchar"),
-        comment: typeof c.description === "string"
-          ? c.description
-          : (typeof c.comment === "string" ? c.comment : undefined),
-        ...(flagged ? { isPrimaryKey: true } : {}),
-      };
-    });
-    const synthesizedPks = tablePkArray.length > 0
-      ? tablePkArray
-      : columns.filter((c) => c.isPrimaryKey).map((c) => c.name);
-
-    tables.push({
-      name: d.name,
-      columns,
-      ...(synthesizedPks.length > 0 ? { primaryKeys: synthesizedPks } : {}),
-    });
-  }
-
-  return JSON.stringify(tables);
-}
-
-// Two PK metadata shapes are recognized — both confirmed conventions:
-//   - per-column `is_primary_key: true` (data-connection metadata standard)
-//   - per-column `column_key === "PRI"` (MySQL INFORMATION_SCHEMA pass-through)
-//   - table-level `primary_keys: string[]` (composite-PK carrier)
-// Other plausible spellings (camelCase, singular keys, SQLite `pk` integer) are
-// intentionally NOT recognized here — adding them speculatively risks false
-// matches and creates code paths the test suite can't pin down. Extend only when
-// a real backend response demonstrates the need.
-function isColumnPrimaryKey(col: Record<string, unknown>): boolean {
-  if (col.is_primary_key === true) return true;
-  if (typeof col.column_key === "string" && col.column_key.toUpperCase() === "PRI") return true;
-  return false;
-}
-
-function extractPrimaryKeys(table: Record<string, unknown>): string[] {
-  const arr = table.primary_keys;
-  if (Array.isArray(arr)) {
-    return arr.filter((x): x is string => typeof x === "string");
-  }
-  return [];
-}
-
-export interface ScanMetadataOptions {
-  baseUrl: string;
-  accessToken: string;
-  id: string;
-  /** Retained for signature compatibility; ignored — vega catalog already knows its connector_type. */
-  dsType?: string;
-  businessDomain?: string;
-}
-
-/**
- * Trigger a metadata scan for a vega catalog and wait for completion.
- * `id` is a vega catalog id (e.g. `d7nicrcjto2s73d9g67g`), not a legacy
- * data-connection datasource UUID.
- */
-export async function scanMetadata(options: ScanMetadataOptions): Promise<string> {
-  const { baseUrl, accessToken, id, businessDomain = "bd_public" } = options;
-  return discoverVegaCatalog({
-    baseUrl,
-    accessToken,
-    id,
-    wait: true,
-    businessDomain,
-  });
-}
-
-export interface ScanDatasourceMetadataOptions {
-  baseUrl: string;
-  accessToken: string;
-  id: string;
-  businessDomain?: string;
-}
-
-/**
- * Trigger a metadata scan and wait for completion. `id` is a vega catalog id.
- *
- * Historically this looked up the legacy `ds_type` to build a data-connection
- * scan body; vega catalogs already carry their own `connector_type`, so the
- * lookup is gone.
- */
-export async function scanDatasourceMetadata(
-  options: ScanDatasourceMetadataOptions,
-): Promise<string> {
-  return scanMetadata(options);
-}
+export type {
+  ListTablesWithColumnsOptions,
+  ScanMetadataOptions,
+  ScanDatasourceMetadataOptions,
+} from "./vega.js";

--- a/packages/typescript/src/api/datasources.ts
+++ b/packages/typescript/src/api/datasources.ts
@@ -1,6 +1,7 @@
 import { HttpError } from "../utils/http.js";
 import { encryptPassword } from "../utils/crypto.js";
 import { buildHeaders } from "./headers.js";
+import { discoverVegaCatalog } from "./vega.js";
 
 const HTTPS_PROTOCOLS = new Set(["maxcompute", "anyshare7", "opensearch"]);
 
@@ -379,58 +380,25 @@ export interface ScanMetadataOptions {
   baseUrl: string;
   accessToken: string;
   id: string;
+  /** Retained for signature compatibility; ignored — vega catalog already knows its connector_type. */
   dsType?: string;
   businessDomain?: string;
 }
 
+/**
+ * Trigger a metadata scan for a vega catalog and wait for completion.
+ * `id` is a vega catalog id (e.g. `d7nicrcjto2s73d9g67g`), not a legacy
+ * data-connection datasource UUID.
+ */
 export async function scanMetadata(options: ScanMetadataOptions): Promise<string> {
-  const {
+  const { baseUrl, accessToken, id, businessDomain = "bd_public" } = options;
+  return discoverVegaCatalog({
     baseUrl,
     accessToken,
     id,
-    dsType = "mysql",
-    businessDomain = "bd_public",
-  } = options;
-
-  const base = baseUrl.replace(/\/+$/, "");
-  const scanUrl = `${base}/api/data-connection/v1/metadata/scan`;
-  const statusUrl = (taskId: string) => `${base}/api/data-connection/v1/metadata/scan/${taskId}`;
-
-  const scanBody = JSON.stringify({
-    scan_name: `sdk_scan_${id.slice(0, 8)}`,
-    type: 0,
-    ds_info: { ds_id: id, ds_type: dsType },
-    use_default_template: true,
-    use_multi_threads: true,
-    status: "open",
+    wait: true,
+    businessDomain,
   });
-
-  const scanResponse = await fetch(scanUrl, {
-    method: "POST",
-    headers: {
-      ...buildHeaders(accessToken, businessDomain),
-      "content-type": "application/json",
-    },
-    body: scanBody,
-  });
-
-  const scanResult = await scanResponse.json() as { id?: string };
-  const taskId = scanResult.id ?? "";
-
-  for (let i = 0; i < 30; i += 1) {
-    const delay = Math.min(2000 * Math.pow(1.5, i), 15000);
-    await new Promise((r) => setTimeout(r, delay));
-    const statusResponse = await fetch(statusUrl(taskId), {
-      method: "GET",
-      headers: buildHeaders(accessToken, businessDomain),
-    });
-    const statusData = (await statusResponse.json()) as { status?: string };
-    if (statusData.status === "success" || statusData.status === "fail") {
-      break;
-    }
-  }
-
-  return taskId;
 }
 
 export interface ScanDatasourceMetadataOptions {
@@ -440,13 +408,15 @@ export interface ScanDatasourceMetadataOptions {
   businessDomain?: string;
 }
 
-// Looks up a datasource's type then triggers a metadata scan, so callers
-// don't have to repeat the GET-then-scan dance whenever a flow needs the
-// platform catalog refreshed (after import-csv, before discovering tables).
+/**
+ * Trigger a metadata scan and wait for completion. `id` is a vega catalog id.
+ *
+ * Historically this looked up the legacy `ds_type` to build a data-connection
+ * scan body; vega catalogs already carry their own `connector_type`, so the
+ * lookup is gone.
+ */
 export async function scanDatasourceMetadata(
   options: ScanDatasourceMetadataOptions,
 ): Promise<string> {
-  const dsBody = await getDatasource(options);
-  const dsType = (JSON.parse(dsBody) as { type?: string }).type ?? "mysql";
-  return scanMetadata({ ...options, dsType });
+  return scanMetadata(options);
 }

--- a/packages/typescript/src/api/datasources.ts
+++ b/packages/typescript/src/api/datasources.ts
@@ -1,7 +1,7 @@
 import { HttpError } from "../utils/http.js";
 import { encryptPassword } from "../utils/crypto.js";
 import { buildHeaders } from "./headers.js";
-import { discoverVegaCatalog } from "./vega.js";
+import { discoverVegaCatalog, getVegaResource, listVegaCatalogResources } from "./vega.js";
 
 const HTTPS_PROTOCOLS = new Set(["maxcompute", "anyshare7", "opensearch"]);
 
@@ -273,79 +273,142 @@ export async function listTables(options: ListTablesOptions): Promise<string> {
   return body;
 }
 
-export interface ListTablesWithColumnsOptions extends ListTablesOptions {
+export interface ListTablesWithColumnsOptions {
+  baseUrl: string;
+  accessToken: string;
+  /** A vega catalog id, not a legacy data-connection datasource UUID. */
+  id: string;
+  keyword?: string;
+  limit?: number;
+  offset?: number;
+  businessDomain?: string;
   autoScan?: boolean;
 }
 
-/** List tables with column details. Optionally triggers metadata scan if no tables found. */
-export async function listTablesWithColumns(options: ListTablesWithColumnsOptions): Promise<string> {
-  const { id, autoScan = true, ...rest } = options;
-  let body = await listTables({ ...rest, id });
+interface VegaResourceListEntry {
+  id: string;
+  name: string;
+  category?: string;
+}
 
-  const parsed = JSON.parse(body) as
-    | Array<Record<string, unknown>>
-    | { entries?: Array<Record<string, unknown>>; data?: Array<Record<string, unknown>> };
-  let items = Array.isArray(parsed) ? parsed : (parsed.entries ?? parsed.data ?? []);
+interface VegaResourceDetail {
+  id: string;
+  name: string;
+  source_metadata?: { columns?: Array<Record<string, unknown>> };
+  primary_keys?: string[];
+  [key: string]: unknown;
+}
 
-  if (items.length === 0 && autoScan) {
-    await scanMetadata({
-      baseUrl: rest.baseUrl,
-      accessToken: rest.accessToken,
+/**
+ * List tables with column details from a vega catalog.
+ *
+ * Two-stage fetch:
+ *   1. GET /api/vega-backend/v1/catalogs/{id}/resources?category=table — list summaries
+ *   2. For each resource: GET /api/vega-backend/v1/resources/{rid} — pull source_metadata.columns
+ *
+ * If the catalog has no resources and `autoScan=true`, triggers a discover and
+ * retries the list once. The optional `keyword` filters summaries client-side
+ * before the per-resource detail fetches — useful to keep N+1 down to k+1.
+ *
+ * `id` is a vega catalog id.
+ */
+export async function listTablesWithColumns(
+  options: ListTablesWithColumnsOptions,
+): Promise<string> {
+  const {
+    baseUrl,
+    accessToken,
+    id,
+    keyword,
+    limit,
+    offset,
+    businessDomain = "bd_public",
+    autoScan = true,
+  } = options;
+
+  async function listResourceSummaries(): Promise<VegaResourceListEntry[]> {
+    const body = await listVegaCatalogResources({
+      baseUrl,
+      accessToken,
       id,
-      businessDomain: rest.businessDomain,
+      category: "table",
+      limit,
+      offset,
+      businessDomain,
     });
-    body = await listTables({ ...rest, id });
-    const parsed2 = JSON.parse(body) as
-      | Array<Record<string, unknown>>
-      | { entries?: Array<Record<string, unknown>>; data?: Array<Record<string, unknown>> };
-    items = Array.isArray(parsed2) ? parsed2 : (parsed2.entries ?? parsed2.data ?? []);
+    const parsed = JSON.parse(body) as
+      | Array<VegaResourceListEntry>
+      | { entries?: VegaResourceListEntry[]; data?: VegaResourceListEntry[] };
+    let items = Array.isArray(parsed) ? parsed : (parsed.entries ?? parsed.data ?? []);
+    if (keyword) {
+      const k = keyword.toLowerCase();
+      items = items.filter((it) => it.name.toLowerCase().includes(k));
+    }
+    return items;
   }
 
-  const base = rest.baseUrl.replace(/\/+$/, "");
+  let summaries = await listResourceSummaries();
+  if (summaries.length === 0 && autoScan) {
+    await scanMetadata({ baseUrl, accessToken, id, businessDomain });
+    summaries = await listResourceSummaries();
+  }
+
+  const details = await Promise.all(
+    summaries.map(async (s) => {
+      const body = await getVegaResource({
+        baseUrl,
+        accessToken,
+        id: s.id,
+        businessDomain,
+      });
+      const parsed = JSON.parse(body) as
+        | VegaResourceDetail
+        | { entries?: VegaResourceDetail[]; data?: VegaResourceDetail[] };
+      if (Array.isArray((parsed as { entries?: unknown }).entries)) {
+        const arr = (parsed as { entries: VegaResourceDetail[] }).entries;
+        if (arr.length === 0) {
+          throw new Error(`vega resource ${s.id} returned empty entries`);
+        }
+        return arr[0]!;
+      }
+      if (Array.isArray((parsed as { data?: unknown }).data)) {
+        const arr = (parsed as { data: VegaResourceDetail[] }).data;
+        if (arr.length === 0) {
+          throw new Error(`vega resource ${s.id} returned empty data`);
+        }
+        return arr[0]!;
+      }
+      return parsed as VegaResourceDetail;
+    }),
+  );
+
   const tables: Array<{
     name: string;
     columns: Array<{ name: string; type: string; comment?: string; isPrimaryKey?: boolean }>;
     primaryKeys?: string[];
   }> = [];
 
-  for (const t of items) {
-    const tableId = String(t.id ?? "");
-    const tableName = String(t.name ?? "");
-    let columnsRaw = (t.columns ?? t.fields ?? []) as Array<Record<string, unknown>>;
-
-    if (columnsRaw.length === 0 && tableId) {
-      const tableUrl = `${base}/api/data-connection/v1/metadata/table/${encodeURIComponent(tableId)}?limit=-1`;
-      const colResponse = await fetch(tableUrl, {
-        method: "GET",
-        headers: buildHeaders(rest.accessToken, rest.businessDomain ?? "bd_public"),
-      });
-      const colData = (await colResponse.json()) as
-        | Array<Record<string, unknown>>
-        | { entries?: Array<Record<string, unknown>>; data?: Array<Record<string, unknown>> };
-      columnsRaw = Array.isArray(colData) ? colData : (colData.entries ?? colData.data ?? []);
-    }
-
-    const tablePkArray = extractPrimaryKeys(t);
-
+  for (const d of details) {
+    const columnsRaw = (d.source_metadata?.columns ?? []) as Array<Record<string, unknown>>;
+    const tablePkArray = extractPrimaryKeys(d as unknown as Record<string, unknown>);
     const columns = columnsRaw.map((c) => {
       const name = String(c.name ?? c.field_name ?? "");
       const flagged = isColumnPrimaryKey(c) || tablePkArray.includes(name);
       return {
         name,
         type: String(c.type ?? c.field_type ?? "varchar"),
-        comment: typeof c.comment === "string" ? c.comment : undefined,
+        comment: typeof c.description === "string"
+          ? c.description
+          : (typeof c.comment === "string" ? c.comment : undefined),
         ...(flagged ? { isPrimaryKey: true } : {}),
       };
     });
-
-    // Reconcile: if backend gave per-column flags but no table-level array,
-    // synthesize one so downstream callers have a single PK source of truth.
     const synthesizedPks = tablePkArray.length > 0
       ? tablePkArray
       : columns.filter((c) => c.isPrimaryKey).map((c) => c.name);
 
     tables.push({
-      name: tableName,
+      name: d.name,
       columns,
       ...(synthesizedPks.length > 0 ? { primaryKeys: synthesizedPks } : {}),
     });

--- a/packages/typescript/src/api/datasources.ts
+++ b/packages/typescript/src/api/datasources.ts
@@ -355,12 +355,18 @@ export async function listTablesWithColumns(
 
   const details = await Promise.all(
     summaries.map(async (s) => {
-      const body = await getVegaResource({
-        baseUrl,
-        accessToken,
-        id: s.id,
-        businessDomain,
-      });
+      let body: string;
+      try {
+        body = await getVegaResource({
+          baseUrl,
+          accessToken,
+          id: s.id,
+          businessDomain,
+        });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(`vega resource ${s.id} fetch failed: ${reason}`);
+      }
       const parsed = JSON.parse(body) as
         | VegaResourceDetail
         | { entries?: VegaResourceDetail[]; data?: VegaResourceDetail[] };

--- a/packages/typescript/src/api/vega.ts
+++ b/packages/typescript/src/api/vega.ts
@@ -890,3 +890,229 @@ export async function listAllVegaResources(options: ListAllVegaResourcesOptions)
   });
 }
 
+// ── Catalog Table Listing & Scan ─────────────────────────────────────────────
+//
+// These functions operate on vega catalog ids (short slugs like
+// `d7nicrcjto2s73d9g67g`), never legacy data-connection datasource UUIDs.
+// They were originally in datasources.ts but belong here because they talk
+// exclusively to vega-backend.
+
+export interface ListTablesWithColumnsOptions {
+  baseUrl: string;
+  accessToken: string;
+  /** A vega catalog id, not a legacy data-connection datasource UUID. */
+  id: string;
+  keyword?: string;
+  limit?: number;
+  offset?: number;
+  businessDomain?: string;
+  autoScan?: boolean;
+}
+
+interface VegaResourceListEntry {
+  id: string;
+  name: string;
+  category?: string;
+}
+
+interface VegaResourceDetail {
+  id: string;
+  name: string;
+  source_metadata?: { columns?: Array<Record<string, unknown>> };
+  primary_keys?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * List tables with column details from a vega catalog.
+ *
+ * Two-stage fetch:
+ *   1. GET /api/vega-backend/v1/catalogs/{id}/resources?category=table — list summaries
+ *   2. For each resource: GET /api/vega-backend/v1/resources/{rid} — pull source_metadata.columns
+ *
+ * If the catalog has no resources and `autoScan=true`, triggers a discover and
+ * retries the list once. The optional `keyword` filters summaries client-side
+ * before the per-resource detail fetches — useful to keep N+1 down to k+1.
+ *
+ * `id` is a vega catalog id.
+ */
+export async function listTablesWithColumns(
+  options: ListTablesWithColumnsOptions,
+): Promise<string> {
+  const {
+    baseUrl,
+    accessToken,
+    id,
+    keyword,
+    limit,
+    offset,
+    businessDomain = "bd_public",
+    autoScan = true,
+  } = options;
+
+  async function listResourceSummaries(): Promise<VegaResourceListEntry[]> {
+    const body = await listVegaCatalogResources({
+      baseUrl,
+      accessToken,
+      id,
+      category: "table",
+      limit,
+      offset,
+      businessDomain,
+    });
+    const parsed = JSON.parse(body) as
+      | Array<VegaResourceListEntry>
+      | { entries?: VegaResourceListEntry[]; data?: VegaResourceListEntry[] };
+    return Array.isArray(parsed) ? parsed : (parsed.entries ?? parsed.data ?? []);
+  }
+
+  let summaries = await listResourceSummaries();
+  if (summaries.length === 0 && autoScan) {
+    await scanMetadata({ baseUrl, accessToken, id, businessDomain });
+    summaries = await listResourceSummaries();
+  }
+
+  // Keyword filter applied after autoScan guard: if the catalog has tables but
+  // keyword matches none, we must NOT trigger a redundant discover.
+  if (keyword) {
+    const k = keyword.toLowerCase();
+    summaries = summaries.filter((it) => it.name.toLowerCase().includes(k));
+  }
+
+  const details = await Promise.all(
+    summaries.map(async (s) => {
+      let body: string;
+      try {
+        body = await getVegaResource({
+          baseUrl,
+          accessToken,
+          id: s.id,
+          businessDomain,
+        });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(`vega resource ${s.id} fetch failed: ${reason}`);
+      }
+      const parsed = JSON.parse(body) as
+        | VegaResourceDetail
+        | { entries?: VegaResourceDetail[]; data?: VegaResourceDetail[] };
+      if (Array.isArray((parsed as { entries?: unknown }).entries)) {
+        const arr = (parsed as { entries: VegaResourceDetail[] }).entries;
+        if (arr.length === 0) {
+          throw new Error(`vega resource ${s.id} returned empty entries`);
+        }
+        return arr[0]!;
+      }
+      if (Array.isArray((parsed as { data?: unknown }).data)) {
+        const arr = (parsed as { data: VegaResourceDetail[] }).data;
+        if (arr.length === 0) {
+          throw new Error(`vega resource ${s.id} returned empty data`);
+        }
+        return arr[0]!;
+      }
+      return parsed as VegaResourceDetail;
+    }),
+  );
+
+  const tables: Array<{
+    name: string;
+    columns: Array<{ name: string; type: string; comment?: string; isPrimaryKey?: boolean }>;
+    primaryKeys?: string[];
+  }> = [];
+
+  for (const d of details) {
+    const columnsRaw = (d.source_metadata?.columns ?? []) as Array<Record<string, unknown>>;
+    const tablePkArray = extractPrimaryKeys(d as unknown as Record<string, unknown>);
+    const columns = columnsRaw.map((c) => {
+      const name = String(c.name ?? c.field_name ?? "");
+      const flagged = isColumnPrimaryKey(c) || tablePkArray.includes(name);
+      return {
+        name,
+        type: String(c.type ?? c.field_type ?? "varchar"),
+        comment: typeof c.description === "string"
+          ? c.description
+          : (typeof c.comment === "string" ? c.comment : undefined),
+        ...(flagged ? { isPrimaryKey: true } : {}),
+      };
+    });
+    const synthesizedPks = tablePkArray.length > 0
+      ? tablePkArray
+      : columns.filter((c) => c.isPrimaryKey).map((c) => c.name);
+
+    tables.push({
+      name: d.name,
+      columns,
+      ...(synthesizedPks.length > 0 ? { primaryKeys: synthesizedPks } : {}),
+    });
+  }
+
+  return JSON.stringify(tables);
+}
+
+// Two PK metadata shapes are recognized — both confirmed conventions:
+//   - per-column `is_primary_key: true` (data-connection metadata standard)
+//   - per-column `column_key === "PRI"` (MySQL INFORMATION_SCHEMA pass-through)
+//   - table-level `primary_keys: string[]` (composite-PK carrier)
+// Other plausible spellings (camelCase, singular keys, SQLite `pk` integer) are
+// intentionally NOT recognized here — adding them speculatively risks false
+// matches and creates code paths the test suite can't pin down. Extend only when
+// a real backend response demonstrates the need.
+function isColumnPrimaryKey(col: Record<string, unknown>): boolean {
+  if (col.is_primary_key === true) return true;
+  if (typeof col.column_key === "string" && col.column_key.toUpperCase() === "PRI") return true;
+  return false;
+}
+
+function extractPrimaryKeys(table: Record<string, unknown>): string[] {
+  const arr = table.primary_keys;
+  if (Array.isArray(arr)) {
+    return arr.filter((x): x is string => typeof x === "string");
+  }
+  return [];
+}
+
+export interface ScanMetadataOptions {
+  baseUrl: string;
+  accessToken: string;
+  id: string;
+  /** Retained for signature compatibility; ignored — vega catalog already knows its connector_type. */
+  dsType?: string;
+  businessDomain?: string;
+}
+
+/**
+ * Trigger a metadata scan for a vega catalog and wait for completion.
+ * `id` is a vega catalog id (e.g. `d7nicrcjto2s73d9g67g`), not a legacy
+ * data-connection datasource UUID.
+ */
+export async function scanMetadata(options: ScanMetadataOptions): Promise<string> {
+  const { baseUrl, accessToken, id, businessDomain = "bd_public" } = options;
+  return discoverVegaCatalog({
+    baseUrl,
+    accessToken,
+    id,
+    wait: true,
+    businessDomain,
+  });
+}
+
+export interface ScanDatasourceMetadataOptions {
+  baseUrl: string;
+  accessToken: string;
+  id: string;
+  businessDomain?: string;
+}
+
+/**
+ * Trigger a metadata scan and wait for completion. `id` is a vega catalog id.
+ *
+ * @deprecated Use {@link scanMetadata} directly. This wrapper exists only for
+ * backward compatibility with callers that used the old data-connection-based
+ * `scanDatasourceMetadata` signature.
+ */
+export async function scanDatasourceMetadata(
+  options: ScanDatasourceMetadataOptions,
+): Promise<string> {
+  return scanMetadata(options);
+}
+

--- a/packages/typescript/src/commands/bkn-ops.ts
+++ b/packages/typescript/src/commands/bkn-ops.ts
@@ -47,6 +47,20 @@ import {
   confirmYes,
 } from "./bkn-utils.js";
 
+// ── Vega catalog id guard ────────────────────────────────────────────────────
+
+const UUID_V4_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+function assertVegaCatalogId(id: string): void {
+  if (UUID_V4_RE.test(id)) {
+    throw new Error(
+      `bkn create-from-ds expects a vega catalog id, got UUID '${id}'. ` +
+      `This looks like a legacy data-connection datasource UUID. ` +
+      `Run \`kweaver vega catalog list --keyword <name>\` to find the corresponding catalog id.`,
+    );
+  }
+}
+
 // ── BKN object name validation ──────────────────────────────────────────────
 // Mirrors bkn-backend OBJECT_NAME_MAX_LENGTH (interfaces/common.go:28) and
 // validateObjectName (driveradapters/validate.go:85). 40 utf-8 codepoints,
@@ -568,9 +582,11 @@ export async function runKnPullCommand(args: string[]): Promise<number> {
 
 // ── Create from datasource ──────────────────────────────────────────────────
 
-const KN_CREATE_FROM_DS_HELP = `kweaver bkn create-from-ds <ds-id> --name X [options]
+const KN_CREATE_FROM_DS_HELP = `kweaver bkn create-from-ds <vega-catalog-id> --name X [options]
 
-Create a knowledge network from a datasource (dataviews + object types + optional build).
+Create a knowledge network from a vega catalog datasource (dataviews + object types + optional build).
+<vega-catalog-id> is a vega catalog id (use \`kweaver vega catalog list\` to find one;
+legacy data-connection datasource UUIDs are no longer accepted).
 
 Options:
   --name <s>       Knowledge network name (required)
@@ -654,6 +670,7 @@ export function parseKnCreateFromDsArgs(args: string[]): {
   if (!dsId || !name) {
     throw new Error("Usage: kweaver bkn create-from-ds <ds-id> --name X [options]");
   }
+  assertVegaCatalogId(dsId);
   const pkMap = pkMapStr ? parsePkMap(pkMapStr) : {};
   if (!businessDomain) businessDomain = resolveBusinessDomain();
   return { dsId, name, tables, pkMap, build, timeout, businessDomain, pretty, noRollback };
@@ -964,9 +981,11 @@ export async function runKnCreateFromDsCommand(
 
 // ── Create from CSV ─────────────────────────────────────────────────────────
 
-const KN_CREATE_FROM_CSV_HELP = `kweaver bkn create-from-csv <ds-id> --files <glob> --name X [options]
+const KN_CREATE_FROM_CSV_HELP = `kweaver bkn create-from-csv <vega-catalog-id> --files <glob> --name X [options]
 
-Import CSV files into datasource, then create a knowledge network.
+Import CSV files into a vega catalog datasource, then create a knowledge network.
+<vega-catalog-id> is a vega catalog id (use \`kweaver vega catalog list\` to find one;
+legacy data-connection datasource UUIDs are no longer accepted).
 
 Options:
   --files <s>          CSV file paths (comma-separated or glob, required)
@@ -1064,6 +1083,7 @@ export function parseKnCreateFromCsvArgs(args: string[]): {
   if (!dsId || !files || !name) {
     throw new Error("Usage: kweaver bkn create-from-csv <ds-id> --files <glob> --name X [options]");
   }
+  assertVegaCatalogId(dsId);
   const pkMap = pkMapStr ? parsePkMap(pkMapStr) : {};
   if (!businessDomain) businessDomain = resolveBusinessDomain();
   return { dsId, files, name, tablePrefix, batchSize, tables, pkMap, build, timeout, businessDomain, noRollback };

--- a/packages/typescript/src/commands/bkn-ops.ts
+++ b/packages/typescript/src/commands/bkn-ops.ts
@@ -17,7 +17,7 @@ import {
   buildKnowledgeNetwork,
   getBuildStatus,
 } from "../api/knowledge-networks.js";
-import { listTablesWithColumns, scanDatasourceMetadata } from "../api/datasources.js";
+import { listTablesWithColumns, scanDatasourceMetadata } from "../api/vega.js";
 import { createDataView, findDataView } from "../api/dataviews.js";
 import { resolveFiles } from "./ds.js";
 import { buildTableName } from "./import-csv.js";

--- a/packages/typescript/src/commands/bkn-ops.ts
+++ b/packages/typescript/src/commands/bkn-ops.ts
@@ -45,21 +45,8 @@ import {
   parsePkMap,
   resolvePrimaryKey,
   confirmYes,
+  assertVegaCatalogId,
 } from "./bkn-utils.js";
-
-// ── Vega catalog id guard ────────────────────────────────────────────────────
-
-const UUID_V4_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
-
-function assertVegaCatalogId(id: string): void {
-  if (UUID_V4_RE.test(id)) {
-    throw new Error(
-      `bkn create-from-ds expects a vega catalog id, got UUID '${id}'. ` +
-      `This looks like a legacy data-connection datasource UUID. ` +
-      `Run \`kweaver vega catalog list --keyword <name>\` to find the corresponding catalog id.`,
-    );
-  }
-}
 
 // ── BKN object name validation ──────────────────────────────────────────────
 // Mirrors bkn-backend OBJECT_NAME_MAX_LENGTH (interfaces/common.go:28) and

--- a/packages/typescript/src/commands/bkn-utils.ts
+++ b/packages/typescript/src/commands/bkn-utils.ts
@@ -270,6 +270,28 @@ export function detectDisplayKey(
   return primaryKey;
 }
 
+// ── Vega catalog id guard ────────────────────────────────────────────────────
+
+const UUID_V4_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * Reject legacy data-connection datasource UUIDs.
+ *
+ * Since the SDK migration to vega-backend (#114), commands that call
+ * `listTablesWithColumns` / `scanMetadata` expect a vega catalog id (a short
+ * slug like `d7nicrcjto2s73d9g67g`), not the UUID-shaped id stored in
+ * data-connection.
+ */
+export function assertVegaCatalogId(id: string): void {
+  if (UUID_V4_RE.test(id)) {
+    throw new Error(
+      `expected a vega catalog id, got UUID '${id}'. ` +
+      `This looks like a legacy data-connection datasource UUID. ` +
+      `Run \`kweaver vega catalog list --keyword <name>\` to find the corresponding catalog id.`,
+    );
+  }
+}
+
 // ── Interactive confirmation ─────────────────────────────────────────────────
 
 export function confirmYes(prompt: string): Promise<boolean> {

--- a/packages/typescript/src/commands/ds.ts
+++ b/packages/typescript/src/commands/ds.ts
@@ -15,6 +15,7 @@ import {
 } from "../api/datasources.js";
 import { formatCallOutput } from "./call.js";
 import { resolveBusinessDomain } from "../config/store.js";
+import { assertVegaCatalogId } from "./bkn-utils.js";
 import {
   parseCsvFile,
   buildTableName,
@@ -218,9 +219,14 @@ async function runDsTablesCommand(args: string[]): Promise<number> {
     if (!arg.startsWith("-")) id = arg;
   }
   if (!id) {
-    console.error("Usage: kweaver ds tables <id> [--keyword X]");
+    console.error(
+      "Usage: kweaver ds tables <vega-catalog-id> [--keyword X]\n" +
+      "  <vega-catalog-id> is a vega catalog id (use `kweaver vega catalog list` to find one;\n" +
+      "  legacy data-connection datasource UUIDs are no longer accepted)."
+    );
     return 1;
   }
+  assertVegaCatalogId(id);
 
   const token = await ensureValidToken();
   const body = await listTablesWithColumns({

--- a/packages/typescript/src/commands/ds.ts
+++ b/packages/typescript/src/commands/ds.ts
@@ -9,10 +9,8 @@ import {
   listDatasources,
   getDatasource,
   deleteDatasource,
-  listTables,
-  listTablesWithColumns,
-  scanMetadata,
 } from "../api/datasources.js";
+import { listTablesWithColumns, scanMetadata } from "../api/vega.js";
 import { formatCallOutput } from "./call.js";
 import { resolveBusinessDomain } from "../config/store.js";
 import { assertVegaCatalogId } from "./bkn-utils.js";

--- a/packages/typescript/src/resources/datasources.ts
+++ b/packages/typescript/src/resources/datasources.ts
@@ -5,9 +5,8 @@ import {
   getDatasource,
   deleteDatasource,
   listTables,
-  listTablesWithColumns,
-  scanMetadata,
 } from "../api/datasources.js";
+import { listTablesWithColumns, scanMetadata } from "../api/vega.js";
 import type { ClientContext } from "../client.js";
 
 export class DataSourcesResource {

--- a/packages/typescript/test/bkn-create-from-ds.test.ts
+++ b/packages/typescript/test/bkn-create-from-ds.test.ts
@@ -277,3 +277,14 @@ test("parseKnCreateFromCsvArgs: rejects legacy datasource UUID", () => {
     /vega catalog id/i,
   );
 });
+
+test("parseKnCreateFromCsvArgs: accepts short vega catalog id", () => {
+  const opts = parseKnCreateFromCsvArgs([
+    "d7nicrcjto2s73d9g67g",
+    "--files",
+    "/tmp/a.csv",
+    "--name",
+    "kn1",
+  ]);
+  assert.equal(opts.dsId, "d7nicrcjto2s73d9g67g");
+});

--- a/packages/typescript/test/bkn-create-from-ds.test.ts
+++ b/packages/typescript/test/bkn-create-from-ds.test.ts
@@ -240,3 +240,40 @@ test("parseKnCreateFromCsvArgs: --pk-map populates pkMap", () => {
   ]);
   assert.deepEqual(opts.pkMap, { t1: "f1" });
 });
+
+test("parseKnCreateFromDsArgs: rejects legacy datasource UUID", () => {
+  const uuid = "dfaf719c-4c41-4661-9ec9-25c263ff8c46";
+  assert.throws(
+    () =>
+      parseKnCreateFromDsArgs([
+        uuid,
+        "--name",
+        "kn1",
+      ]),
+    /vega catalog id/i,
+  );
+});
+
+test("parseKnCreateFromDsArgs: accepts short vega catalog id", () => {
+  const opts = parseKnCreateFromDsArgs([
+    "d7nicrcjto2s73d9g67g",
+    "--name",
+    "kn1",
+  ]);
+  assert.equal(opts.dsId, "d7nicrcjto2s73d9g67g");
+});
+
+test("parseKnCreateFromCsvArgs: rejects legacy datasource UUID", () => {
+  const uuid = "dfaf719c-4c41-4661-9ec9-25c263ff8c46";
+  assert.throws(
+    () =>
+      parseKnCreateFromCsvArgs([
+        uuid,
+        "--name",
+        "kn1",
+        "--files",
+        "/tmp/a.csv",
+      ]),
+    /vega catalog id/i,
+  );
+});

--- a/packages/typescript/test/bkn-create-from-ds.test.ts
+++ b/packages/typescript/test/bkn-create-from-ds.test.ts
@@ -14,6 +14,7 @@ import {
   detectPrimaryKey,
   formatPkDetectionError,
   parsePkMap,
+  assertVegaCatalogId,
 } from "../src/commands/bkn-utils.js";
 
 let savedConfigDir: string | undefined;
@@ -287,4 +288,17 @@ test("parseKnCreateFromCsvArgs: accepts short vega catalog id", () => {
     "kn1",
   ]);
   assert.equal(opts.dsId, "d7nicrcjto2s73d9g67g");
+});
+
+// ── assertVegaCatalogId (shared utility, now also used by ds tables) ──────────
+
+test("assertVegaCatalogId: rejects UUID v4 with helpful hint", () => {
+  assert.throws(
+    () => assertVegaCatalogId("dfaf719c-4c41-4661-9ec9-25c263ff8c46"),
+    /vega catalog list/,
+  );
+});
+
+test("assertVegaCatalogId: accepts short slug", () => {
+  assert.doesNotThrow(() => assertVegaCatalogId("d7nicrcjto2s73d9g67g"));
 });

--- a/packages/typescript/test/datasources-pk-propagation.test.ts
+++ b/packages/typescript/test/datasources-pk-propagation.test.ts
@@ -12,27 +12,58 @@ function stubFetch(handler: (url: string, init?: RequestInit) => Response | Prom
   }) as typeof fetch;
 }
 
-// ── Per-column PK propagation ─────────────────────────────────────────────────
-// The bug: `listTablesWithColumns` reduces every column to {name, type, comment},
-// silently dropping any PK indicator the backend exposes. The contract this test
-// fixes: when the raw column carries a PK indicator under any of the well-known
-// names, the SDK surfaces it as `isPrimaryKey: true`.
+// Vega resource detail shape — confirmed against admin platform 2026-05-08:
+// GET /api/vega-backend/v1/resources/{id} returns
+//   { id, name, category, source_metadata: { columns: [...] }, ... }
+// where each column has { name, type, orig_type, column_key, ... }.
 
-test("listTablesWithColumns: propagates is_primary_key from backend column", async () => {
+function resourceListResponse(catalogId: string, items: Array<{ id: string; name: string }>) {
+  return new Response(
+    JSON.stringify({
+      entries: items.map((it) => ({
+        id: it.id,
+        catalog_id: catalogId,
+        name: it.name,
+        category: "table",
+      })),
+      total_count: items.length,
+    }),
+    { status: 200 },
+  );
+}
+
+function resourceDetailResponse(
+  rid: string,
+  name: string,
+  columns: Array<Record<string, unknown>>,
+  extra: Record<string, unknown> = {},
+) {
+  return new Response(
+    JSON.stringify({
+      entries: [
+        {
+          id: rid,
+          name,
+          category: "table",
+          source_metadata: { columns },
+          ...extra,
+        },
+      ],
+    }),
+    { status: 200 },
+  );
+}
+
+test("listTablesWithColumns: vega resources list + per-resource detail → table shape", async () => {
   stubFetch((url) => {
-    if (url.includes("/data-connection/v1/metadata/data-source/ds-1")) {
-      return new Response(
-        JSON.stringify([
-          {
-            name: "skills",
-            columns: [
-              { name: "skill_id", type: "varchar", is_primary_key: true },
-              { name: "label", type: "varchar" },
-            ],
-          },
-        ]),
-        { status: 200 },
-      );
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources")) {
+      return resourceListResponse("cat-1", [{ id: "r1", name: "skills" }]);
+    }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse("r1", "skills", [
+        { name: "skill_id", type: "varchar", is_primary_key: true },
+        { name: "label", type: "varchar" },
+      ]);
     }
     throw new Error(`unexpected url ${url}`);
   });
@@ -41,13 +72,15 @@ test("listTablesWithColumns: propagates is_primary_key from backend column", asy
     const body = await listTablesWithColumns({
       baseUrl: "https://h.example",
       accessToken: "tok",
-      id: "ds-1",
+      id: "cat-1",
     });
     const tables = JSON.parse(body) as Array<{
       name: string;
       columns: Array<{ name: string; type: string; isPrimaryKey?: boolean }>;
+      primaryKeys?: string[];
     }>;
     assert.equal(tables.length, 1);
+    assert.equal(tables[0]!.name, "skills");
     const cols = tables[0]!.columns;
     assert.equal(cols.find((c) => c.name === "skill_id")!.isPrimaryKey, true);
     assert.notEqual(cols.find((c) => c.name === "label")!.isPrimaryKey, true);
@@ -56,21 +89,16 @@ test("listTablesWithColumns: propagates is_primary_key from backend column", asy
   }
 });
 
-test("listTablesWithColumns: propagates MySQL INFORMATION_SCHEMA column_key='PRI'", async () => {
+test("listTablesWithColumns: column_key='PRI' propagates as isPrimaryKey", async () => {
   stubFetch((url) => {
-    if (url.includes("/data-connection/v1/metadata/data-source/ds-1")) {
-      return new Response(
-        JSON.stringify([
-          {
-            name: "skills",
-            columns: [
-              { name: "skill_id", type: "varchar", column_key: "PRI" },
-              { name: "label", type: "varchar", column_key: "" },
-            ],
-          },
-        ]),
-        { status: 200 },
-      );
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources")) {
+      return resourceListResponse("cat-1", [{ id: "r1", name: "skills" }]);
+    }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse("r1", "skills", [
+        { name: "skill_id", type: "varchar", column_key: "PRI" },
+        { name: "label", type: "varchar", column_key: "" },
+      ]);
     }
     throw new Error(`unexpected url ${url}`);
   });
@@ -79,35 +107,30 @@ test("listTablesWithColumns: propagates MySQL INFORMATION_SCHEMA column_key='PRI
     const body = await listTablesWithColumns({
       baseUrl: "https://h.example",
       accessToken: "tok",
-      id: "ds-1",
+      id: "cat-1",
     });
-    const tables = JSON.parse(body) as Array<{
-      name: string;
-      columns: Array<{ name: string; isPrimaryKey?: boolean }>;
-    }>;
-    assert.equal(tables[0]!.columns.find((c) => c.name === "skill_id")!.isPrimaryKey, true);
+    const tables = JSON.parse(body);
+    const cols = tables[0].columns;
+    assert.equal(cols.find((c: { name: string }) => c.name === "skill_id").isPrimaryKey, true);
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test("listTablesWithColumns: propagates table-level primary_keys array", async () => {
-  // Composite-PK case: backend emits primary_keys at table level, not per column.
+test("listTablesWithColumns: table-level primary_keys[] surfaces as primaryKeys", async () => {
   stubFetch((url) => {
-    if (url.includes("/data-connection/v1/metadata/data-source/ds-1")) {
-      return new Response(
-        JSON.stringify([
-          {
-            name: "mat_skill",
-            primary_keys: ["sku", "skill_id"],
-            columns: [
-              { name: "sku", type: "varchar" },
-              { name: "skill_id", type: "varchar" },
-              { name: "rank", type: "int" },
-            ],
-          },
-        ]),
-        { status: 200 },
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources")) {
+      return resourceListResponse("cat-1", [{ id: "r1", name: "orders" }]);
+    }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse(
+        "r1",
+        "orders",
+        [
+          { name: "order_id", type: "integer" },
+          { name: "tenant_id", type: "varchar" },
+        ],
+        { primary_keys: ["order_id", "tenant_id"] },
       );
     }
     throw new Error(`unexpected url ${url}`);
@@ -117,42 +140,32 @@ test("listTablesWithColumns: propagates table-level primary_keys array", async (
     const body = await listTablesWithColumns({
       baseUrl: "https://h.example",
       accessToken: "tok",
-      id: "ds-1",
+      id: "cat-1",
     });
-    const tables = JSON.parse(body) as Array<{
-      name: string;
-      primaryKeys?: string[];
-      columns: Array<{ name: string; isPrimaryKey?: boolean }>;
-    }>;
-    // Table-level array wins for composite PKs.
-    assert.deepEqual(tables[0]!.primaryKeys, ["sku", "skill_id"]);
-    // And the per-column flag is materialized so downstream callers can use either.
-    const byName = Object.fromEntries(tables[0]!.columns.map((c) => [c.name, c]));
-    assert.equal(byName.sku!.isPrimaryKey, true);
-    assert.equal(byName.skill_id!.isPrimaryKey, true);
-    assert.notEqual(byName.rank!.isPrimaryKey, true);
+    const tables = JSON.parse(body);
+    assert.deepEqual(tables[0].primaryKeys, ["order_id", "tenant_id"]);
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test("listTablesWithColumns: leaves columns unflagged when backend returns no PK info", async () => {
-  // Regression guard: today's behavior must keep working — sample-based detection
-  // remains the fallback when backend doesn't expose PK metadata.
-  stubFetch((url) => {
-    if (url.includes("/data-connection/v1/metadata/data-source/ds-1")) {
-      return new Response(
-        JSON.stringify([
-          {
-            name: "skills",
-            columns: [
-              { name: "skill_id", type: "varchar" },
-              { name: "label", type: "varchar" },
-            ],
-          },
-        ]),
-        { status: 200 },
-      );
+test("listTablesWithColumns: empty resources + autoScan triggers discover then re-lists", async () => {
+  let listCalls = 0;
+  let discoverCalls = 0;
+  stubFetch((url, init) => {
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources") && (init?.method ?? "GET") === "GET") {
+      listCalls += 1;
+      if (listCalls === 1) {
+        return resourceListResponse("cat-1", []);
+      }
+      return resourceListResponse("cat-1", [{ id: "r1", name: "skills" }]);
+    }
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/discover")) {
+      discoverCalls += 1;
+      return new Response(JSON.stringify({ task_id: "task-1" }), { status: 200 });
+    }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse("r1", "skills", [{ name: "skill_id", type: "varchar" }]);
     }
     throw new Error(`unexpected url ${url}`);
   });
@@ -161,17 +174,45 @@ test("listTablesWithColumns: leaves columns unflagged when backend returns no PK
     const body = await listTablesWithColumns({
       baseUrl: "https://h.example",
       accessToken: "tok",
-      id: "ds-1",
+      id: "cat-1",
+      autoScan: true,
     });
-    const tables = JSON.parse(body) as Array<{
-      name: string;
-      primaryKeys?: string[];
-      columns: Array<{ name: string; isPrimaryKey?: boolean }>;
-    }>;
-    assert.equal(tables[0]!.primaryKeys, undefined);
-    for (const c of tables[0]!.columns) {
-      assert.notEqual(c.isPrimaryKey, true);
+    const tables = JSON.parse(body);
+    assert.equal(tables.length, 1);
+    assert.equal(discoverCalls, 1, "discover called exactly once");
+    assert.equal(listCalls, 2, "resources list called twice (initial + post-scan)");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("listTablesWithColumns: per-resource fetch failure surfaces (not silently dropped)", async () => {
+  stubFetch((url) => {
+    if (url.includes("/vega-backend/v1/catalogs/cat-1/resources")) {
+      return resourceListResponse("cat-1", [
+        { id: "r1", name: "skills" },
+        { id: "r2", name: "orders" },
+      ]);
     }
+    if (url.includes("/vega-backend/v1/resources/r1")) {
+      return resourceDetailResponse("r1", "skills", [{ name: "id", type: "integer" }]);
+    }
+    if (url.includes("/vega-backend/v1/resources/r2")) {
+      return new Response("boom", { status: 500, statusText: "Internal Server Error" });
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+
+  try {
+    await assert.rejects(
+      () =>
+        listTablesWithColumns({
+          baseUrl: "https://h.example",
+          accessToken: "tok",
+          id: "cat-1",
+        }),
+      /500|r2/,
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/typescript/test/datasources-pk-propagation.test.ts
+++ b/packages/typescript/test/datasources-pk-propagation.test.ts
@@ -211,7 +211,7 @@ test("listTablesWithColumns: per-resource fetch failure surfaces (not silently d
           accessToken: "tok",
           id: "cat-1",
         }),
-      /500|r2/,
+      /r2/,
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/packages/typescript/test/datasources-pk-propagation.test.ts
+++ b/packages/typescript/test/datasources-pk-propagation.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { listTablesWithColumns } from "../src/api/datasources.js";
+import { listTablesWithColumns } from "../src/api/vega.js";
 
 const originalFetch = globalThis.fetch;
 

--- a/packages/typescript/test/datasources-scan.test.ts
+++ b/packages/typescript/test/datasources-scan.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { scanDatasourceMetadata } from "../src/api/datasources.js";
+import { scanDatasourceMetadata, scanMetadata } from "../src/api/datasources.js";
 
 const originalFetch = globalThis.fetch;
 
@@ -25,70 +25,84 @@ function stubFetch(handler: (call: CallRecord) => Response | Promise<Response>) 
   return calls;
 }
 
-test("scanDatasourceMetadata: fetches ds type then triggers scan and polls", async () => {
+test("scanMetadata: POSTs vega discover with wait=true", async () => {
   const calls = stubFetch((c) => {
-    if (c.method === "GET" && c.url.includes("/data-connection/v1/datasource/")) {
-      return new Response(JSON.stringify({ type: "postgres" }), { status: 200 });
-    }
-    if (c.method === "POST" && c.url.endsWith("/data-connection/v1/metadata/scan")) {
-      return new Response(JSON.stringify({ id: "task-xyz" }), { status: 200 });
-    }
-    if (c.method === "GET" && c.url.includes("/data-connection/v1/metadata/scan/")) {
-      return new Response(JSON.stringify({ status: "success" }), { status: 200 });
+    if (
+      c.method === "POST" &&
+      c.url.includes("/vega-backend/v1/catalogs/cat-1/discover")
+    ) {
+      return new Response(JSON.stringify({ task_id: "vega-task-9" }), { status: 200 });
     }
     throw new Error(`unexpected ${c.method} ${c.url}`);
   });
 
   try {
-    const taskId = await scanDatasourceMetadata({
+    const body = await scanMetadata({
       baseUrl: "https://h.example",
       accessToken: "tok",
-      id: "ds-1",
+      id: "cat-1",
       businessDomain: "bd_public",
     });
-
-    assert.equal(taskId, "task-xyz");
-
-    const lookup = calls.find((c) => c.method === "GET" && c.url.includes("/datasource/ds-1"));
-    assert.ok(lookup, "expected datasource lookup call");
-
-    const scanPost = calls.find((c) => c.method === "POST" && c.url.endsWith("/metadata/scan"));
-    assert.ok(scanPost, "expected scan POST call");
-    assert.ok(scanPost!.body, "scan body should be present");
-    const scanBody = JSON.parse(scanPost!.body!);
-    assert.equal(scanBody.ds_info.ds_id, "ds-1");
-    assert.equal(scanBody.ds_info.ds_type, "postgres", "ds_type should come from datasource lookup");
-
-    const status = calls.find((c) => c.method === "GET" && c.url.includes("/metadata/scan/task-xyz"));
-    assert.ok(status, "expected status poll call");
+    assert.ok(body.includes("vega-task-9"), "should return discover response body");
+    const discoverCall = calls.find((c) => c.url.includes("/discover"));
+    assert.ok(discoverCall, "must call vega discover");
+    const u = new URL(discoverCall!.url);
+    assert.equal(u.searchParams.get("wait"), "true", "wait must be true");
+    assert.equal(
+      calls.filter((c) => c.url.includes("/data-connection/")).length,
+      0,
+      "must not touch data-connection",
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test("scanDatasourceMetadata: defaults ds_type to mysql when datasource has no type", async () => {
-  stubFetch((c) => {
-    if (c.method === "GET" && c.url.includes("/data-connection/v1/datasource/")) {
-      return new Response(JSON.stringify({}), { status: 200 });
-    }
-    if (c.method === "POST" && c.url.endsWith("/data-connection/v1/metadata/scan")) {
-      const body = JSON.parse(c.body ?? "{}");
-      assert.equal(body.ds_info.ds_type, "mysql");
-      return new Response(JSON.stringify({ id: "task-default" }), { status: 200 });
-    }
-    if (c.method === "GET" && c.url.includes("/data-connection/v1/metadata/scan/")) {
-      return new Response(JSON.stringify({ status: "success" }), { status: 200 });
+test("scanDatasourceMetadata: delegates to vega discover (no GET-then-scan dance)", async () => {
+  const calls = stubFetch((c) => {
+    if (c.method === "POST" && c.url.includes("/vega-backend/v1/catalogs/cat-1/discover")) {
+      return new Response(JSON.stringify({ task_id: "vega-task-1" }), { status: 200 });
     }
     throw new Error(`unexpected ${c.method} ${c.url}`);
   });
 
   try {
-    const taskId = await scanDatasourceMetadata({
+    const body = await scanDatasourceMetadata({
       baseUrl: "https://h.example",
       accessToken: "tok",
-      id: "ds-2",
+      id: "cat-1",
+      businessDomain: "bd_public",
     });
-    assert.equal(taskId, "task-default");
+    assert.ok(body.includes("vega-task-1"));
+    assert.equal(
+      calls.filter((c) => c.url.includes("/data-connection/")).length,
+      0,
+      "must not touch data-connection",
+    );
+    assert.equal(
+      calls.filter((c) => c.method === "GET" && c.url.includes("/datasource/")).length,
+      0,
+      "must not look up legacy ds_type",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("scanMetadata: surfaces vega 404 with HttpError", async () => {
+  stubFetch(() => new Response("not found", { status: 404, statusText: "Not Found" }));
+
+  try {
+    await assert.rejects(
+      () =>
+        scanMetadata({
+          baseUrl: "https://h.example",
+          accessToken: "tok",
+          id: "missing",
+          businessDomain: "bd_public",
+        }),
+      /404/,
+    );
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/typescript/test/datasources-scan.test.ts
+++ b/packages/typescript/test/datasources-scan.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { scanDatasourceMetadata, scanMetadata } from "../src/api/datasources.js";
+import { scanDatasourceMetadata, scanMetadata } from "../src/api/vega.js";
 
 const originalFetch = globalThis.fetch;
 


### PR DESCRIPTION
Closes #114.

## Summary
- Migrate `listTablesWithColumns` / `scanMetadata` (TS) and `list_tables` / `scan_metadata` (Py) off `/api/data-connection/v1/...` onto `/api/vega-backend/v1/catalogs/*` (`resources` + `discover`), preserving `source_metadata` so PK auto-detect works without `--pk-map`.
- `bkn create-from-ds` / `create-from-csv` now require a vega catalog id; `kweaver ds` table commands also routed through vega. CLI guard + help updated.
- TS API surface consolidated: vega catalog table/scan helpers live in `src/api/vega.ts`; `src/api/datasources.ts` thin-wraps them. Python `VegaCatalogsResource` is the canonical entrypoint.
- Spec + plan docs in `docs/specs` and `docs/plans` updated to match the final layout.

## Test plan
- [x] `pnpm -C packages/typescript test` — unit + bkn-ops + datasources-pk/scan suites updated and green
- [x] `pytest packages/python/tests/unit/test_datasources.py`
- [ ] e2e: `KWEAVER_TOKEN=__NO_AUTH__ kweaver ds list` against dip-poc
- [ ] e2e: `kweaver bkn create-from-ds <vega-catalog-id> --name verify --no-build --tables suppliers,materials,skills,mat_skill` — exit 0 without `--pk-map`

🤖 Generated with [Claude Code](https://claude.com/claude-code)